### PR TITLE
fix: update CLI package structure and path resolution for tfsmigration

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -250,16 +250,23 @@ function Invoke-Package {
     param($SemVer, $StagingDir)
 
     # --- CLI Package: MigrationTools-{SemVer}.zip ---
-    # Structure inside zip: tools/  (both CLIs merged flat)
+    # Structure inside zip:
+    #   (root)          — devopsmigration CLI (net10.0) at the top level
+    #   tfsmigration/   — tfsmigration CLI    (net481) in a subdirectory
+    # TfsExportRunner.ResolveExePath() in CLI.Migration discovers tfsmigration.exe
+    # via the tfsmigration/ subdirectory relative to the assembly location.
+    # Keeping them separate prevents the net481 Abstractions.dll from the TFS CLI
+    # overwriting the net10.0 build used by the migration CLI.
     Write-Host "`n==> Packaging CLI artefact..." -ForegroundColor Cyan
-    $CliZipStaging = Join-Path $StagingDir 'cli-zip-staging'
-    $ToolsDir      = Join-Path $CliZipStaging 'tools'
-    New-Item -ItemType Directory -Path $ToolsDir -Force | Out-Null
-    Copy-Item -Path (Join-Path $script:CliMigrationOut '*') -Destination $ToolsDir -Recurse -Force
-    Copy-Item -Path (Join-Path $script:CliTfsOut '*') -Destination $ToolsDir -Recurse -Force
+    $CliZipStaging  = Join-Path $StagingDir 'cli-zip-staging'
+    $TfsDir         = Join-Path $CliZipStaging 'tfsmigration'
+    New-Item -ItemType Directory -Path $CliZipStaging -Force | Out-Null
+    New-Item -ItemType Directory -Path $TfsDir        -Force | Out-Null
+    Copy-Item -Path (Join-Path $script:CliMigrationOut '*') -Destination $CliZipStaging -Recurse -Force
+    Copy-Item -Path (Join-Path $script:CliTfsOut '*')       -Destination $TfsDir        -Recurse -Force
     $CliZip = Join-Path $ArtifactsDir "MigrationTools-$SemVer.zip"
     Push-Location $CliZipStaging
-    Compress-Archive -Path 'tools' -DestinationPath $CliZip -Force
+    Compress-Archive -Path '*' -DestinationPath $CliZip -Force
     Pop-Location
     Write-Host "  Created: $CliZip"
 

--- a/src/DevOpsMigrationPlatform.CLI.Migration/Commands/TfsExportCommand.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Commands/TfsExportCommand.cs
@@ -93,9 +93,9 @@ internal static class TfsExportRunner
     {
         var assemblyDir = Path.GetDirectoryName(typeof(TfsExportRunner).Assembly.Location) ?? ".";
 
-        // Side-by-side (published layout)
-        var sideBySide = Path.Combine(assemblyDir, "tfsmigration.exe");
-        if (File.Exists(sideBySide)) return sideBySide;
+        // Published layout: tfsmigration/ subdirectory beside devopsmigration.exe
+        var subDir = Path.Combine(assemblyDir, "tfsmigration", "tfsmigration.exe");
+        if (File.Exists(subDir)) return subDir;
 
         // Debug layout: navigate from CLI.Migration bin up to CLI.TfsMigration bin
         return Path.GetFullPath(


### PR DESCRIPTION
This pull request updates the packaging structure for the CLI artifacts to prevent assembly conflicts and aligns the executable discovery logic accordingly. The main focus is to separate the `devopsmigration` and `tfsmigration` CLIs into distinct directories within the packaged ZIP, ensuring that their dependencies do not overwrite each other.

**Packaging structure changes:**

* The CLI ZIP package now places the `devopsmigration` CLI at the root and the `tfsmigration` CLI inside a `tfsmigration/` subdirectory, rather than merging both into a single `tools/` directory. This avoids conflicts between different versions of shared assemblies.

**Executable discovery logic:**

* The `TfsExportRunner.ResolveExePath()` method in `TfsExportCommand.cs` is updated to look for `tfsmigration.exe` inside the new `tfsmigration/` subdirectory, matching the revised packaging layout.