### PR TITLE
fix: update artifact packaging structure to include subfolders for CL…

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -39,11 +39,14 @@
         OR restore from the local tool manifest:
             dotnet tool restore
 
-    Artefact outputs (placed under ./output/, one zip per RID + component):
-      - MigrationTools-{rid}-CLI-{SemVer}.zip         — devopsMigration CLI (win-x64 includes tfsmigration/)
-      - MigrationTools-win-x64-TfsCLI-{SemVer}.zip   — TFS CLI standalone (Windows x64 only)
-      - MigrationTools-{rid}-ControlPlane-{SemVer}.zip — Control Plane host
-      - MigrationTools-{rid}-Agent-{SemVer}.zip        — Migration Agent worker
+    Artefact outputs (placed under ./output/, one zip per RID):
+      - MigrationTools-{rid}-{SemVer}.zip
+
+    Each zip contains:
+      /                  — devopsMigration CLI (root)
+      /ControlPlane/     — Control Plane host
+      /MigrationAgent/   — Migration Agent worker
+      /TfsMigration/     — TFS CLI subprocess (win-x64 only)
 
     RIDs produced: win-x64, win-arm64, linux-x64, osx-x64, osx-arm64
 
@@ -281,42 +284,38 @@ function Invoke-Package {
     param($SemVer, $StagingDir)
 
     foreach ($rid in $Rids) {
-        # ── CLI Package ──────────────────────────────────────────────────────
-        Write-Host "`n==> Packaging CLI [$rid]..." -ForegroundColor Cyan
-        $cliStaging = Join-Path $StagingDir "cli-zip-staging-$rid"
-        New-Item -ItemType Directory -Path $cliStaging -Force | Out-Null
-        Copy-Item -Path (Join-Path $script:CliMigrationOutByRid[$rid] '*') -Destination $cliStaging -Recurse -Force
-        # Only win-x64 includes tfsmigration/ — the net481 subprocess; other RIDs
-        # cannot run it and TfsExportRunner.RunAsync() will reject non-Windows early.
+        Write-Host "`n==> Packaging MigrationTools [$rid]..." -ForegroundColor Cyan
+        $zipStaging = Join-Path $StagingDir "zip-staging-$rid"
+        New-Item -ItemType Directory -Path $zipStaging -Force | Out-Null
+
+        # ── CLI in root ──────────────────────────────────────────────────────
+        Copy-Item -Path (Join-Path $script:CliMigrationOutByRid[$rid] '*') -Destination $zipStaging -Recurse -Force
+
+        # ── ControlPlane subfolder ───────────────────────────────────────────
+        $cpSubDir = Join-Path $zipStaging 'ControlPlane'
+        New-Item -ItemType Directory -Path $cpSubDir -Force | Out-Null
+        Copy-Item -Path (Join-Path $script:ControlPlaneOutByRid[$rid] '*') -Destination $cpSubDir -Recurse -Force
+
+        # ── MigrationAgent subfolder ─────────────────────────────────────────
+        $agentSubDir = Join-Path $zipStaging 'MigrationAgent'
+        New-Item -ItemType Directory -Path $agentSubDir -Force | Out-Null
+        Copy-Item -Path (Join-Path $script:AgentOutByRid[$rid] '*') -Destination $agentSubDir -Recurse -Force
+
+        # ── TfsMigration subfolder (win-x64 only) ───────────────────────────
+        # net481 subprocess; other RIDs cannot run it and TfsExportRunner.RunAsync()
+        # will reject non-Windows early.
         if ($rid -eq 'win-x64') {
-            $tfsSubDir = Join-Path $cliStaging 'tfsmigration'
+            $tfsSubDir = Join-Path $zipStaging 'TfsMigration'
             New-Item -ItemType Directory -Path $tfsSubDir -Force | Out-Null
             Copy-Item -Path (Join-Path $script:CliTfsOut '*') -Destination $tfsSubDir -Recurse -Force
         }
-        $cliZip = Join-Path $ArtifactsDir "MigrationTools-$rid-CLI-$SemVer.zip"
-        Push-Location $cliStaging
-        Compress-Archive -Path '*' -DestinationPath $cliZip -Force
+
+        $zip = Join-Path $ArtifactsDir "MigrationTools-$rid-$SemVer.zip"
+        Push-Location $zipStaging
+        Compress-Archive -Path '*' -DestinationPath $zip -Force
         Pop-Location
-        Write-Host "  Created: $cliZip"
-
-        # ── Control Plane Package ────────────────────────────────────────────
-        Write-Host "`n==> Packaging Control Plane [$rid]..." -ForegroundColor Cyan
-        $cpZip = Join-Path $ArtifactsDir "MigrationTools-$rid-ControlPlane-$SemVer.zip"
-        Compress-Archive -Path (Join-Path $script:ControlPlaneOutByRid[$rid] '*') -DestinationPath $cpZip -Force
-        Write-Host "  Created: $cpZip"
-
-        # ── Agent Package ────────────────────────────────────────────────────
-        Write-Host "`n==> Packaging Agent [$rid]..." -ForegroundColor Cyan
-        $agentZip = Join-Path $ArtifactsDir "MigrationTools-$rid-Agent-$SemVer.zip"
-        Compress-Archive -Path (Join-Path $script:AgentOutByRid[$rid] '*') -DestinationPath $agentZip -Force
-        Write-Host "  Created: $agentZip"
+        Write-Host "  Created: $zip"
     }
-
-    # ── TfsCLI standalone package (win-x64 only) ─────────────────────────────
-    Write-Host "`n==> Packaging TfsCLI [win-x64]..." -ForegroundColor Cyan
-    $tfsCliZip = Join-Path $ArtifactsDir "MigrationTools-win-x64-TfsCLI-$SemVer.zip"
-    Compress-Archive -Path (Join-Path $script:CliTfsOut '*') -DestinationPath $tfsCliZip -Force
-    Write-Host "  Created: $tfsCliZip"
 }
 
 function Start-AppHost {


### PR DESCRIPTION
This pull request simplifies and unifies the packaging process for MigrationTools in the `build.ps1` script. Instead of producing multiple separate zip artifacts per runtime identifier (RID), it now generates a single consolidated zip per RID containing all relevant components organized into subfolders. This change streamlines artifact management and makes it easier to distribute and consume the toolset.

**Packaging process simplification:**

* Produces a single zip artifact per RID named `MigrationTools-{rid}-{SemVer}.zip` instead of multiple separate zips for each component (CLI, ControlPlane, Agent, TfsCLI). [[1]](diffhunk://#diff-3258bc4162690adead72c70b672093e68c92e86a4628148f0015d61738f21b5aL42-R49) [[2]](diffhunk://#diff-3258bc4162690adead72c70b672093e68c92e86a4628148f0015d61738f21b5aL284-R318)
* Each zip now contains the CLI at the root, with `ControlPlane`, `MigrationAgent`, and (for `win-x64`) `TfsMigration` as subfolders, consolidating all components into one package. [[1]](diffhunk://#diff-3258bc4162690adead72c70b672093e68c92e86a4628148f0015d61738f21b5aL42-R49) [[2]](diffhunk://#diff-3258bc4162690adead72c70b672093e68c92e86a4628148f0015d61738f21b5aL284-R318)

**Code and documentation updates:**

* Updated the documentation in `build.ps1` to reflect the new artifact structure and output locations.
* Removed redundant packaging steps and artifact creation for individual components, cleaning up the build script logic.…I, Control Plane, and Agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured package distribution to deliver a single zip file per platform instead of multiple separate packages, with all components organised in subdirectories for a streamlined download and installation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->