### PR TITLE
Fix for build 2

### DIFF
--- a/.build/GitVersion.yml
+++ b/.build/GitVersion.yml
@@ -16,4 +16,8 @@ branches:
     track-merge-target: false
     source-branches:
     - main
-    is-release-branch: true
+    is-release-branch: true  
+  unknown:
+    mode: ContinuousDelivery
+    label: '{BranchName}'
+    increment: Inherit

--- a/.build/GitVersion.yml
+++ b/.build/GitVersion.yml
@@ -1,12 +1,12 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: ContinuousDelivery
-label: 'Canary'
+label: 'canary'
 next-version: 20.0.0
 branches:
   main:
     regex: ^master$|^main$
     mode: ContinuousDelivery
-    label: 'Preview'
+    label: 'preview'
     increment: Patch
   release:
     regex: ^release(s)?[\/-]


### PR DESCRIPTION
This pull request makes minor adjustments to the `.build/GitVersion.yml` configuration file to standardize label casing and add support for unknown branches.

Versioning and branch configuration updates:

* Changed the `label` values for the main and default branches from `'Canary'` and `'Preview'` to lowercase `'canary'` and `'preview'` for consistency.
* Added an `unknown` branch configuration to handle branches not explicitly listed, setting its mode to `ContinuousDelivery`, using the branch name as the label, and inheriting the increment strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build versioning configuration to standardise label formatting and extend branch configuration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->