### PR TITLE
Feature gap and Central file locations

### DIFF
--- a/.agents/context/artefact-store.md
+++ b/.agents/context/artefact-store.md
@@ -101,9 +101,9 @@ The orchestrator resolves the implementation at startup: URLs whose host contain
 
 ## StateStore and Checkpoints
 
-`IStateStore` manages cursor files and the `idmap.db` (or `idmap.json`). Its Phase 1 implementation is `PackageCheckpointStateStore`, which writes checkpoint files into the `Checkpoints/` folder via `IArtefactStore` (i.e. the same blob container or filesystem path as the rest of the package).
+`IStateStore` manages cursor files and the `idmap.db` (or `idmap.json`). Its Phase 1 implementation is `PackageCheckpointStateStore`, which writes checkpoint files into the `.migration/Checkpoints/` folder via `IArtefactStore` (i.e. the same blob container or filesystem path as the rest of the package).
 
-The Migration Agent may optionally mirror the latest cursor value to the control plane via the progress reporting API for display purposes, but the package's `Checkpoints/` folder remains the authoritative resume state. See [.agents/context/checkpointing.md](checkpointing.md).
+The Migration Agent may optionally mirror the latest cursor value to the control plane via the progress reporting API for display purposes, but the package's `.migration/Checkpoints/` folder remains the authoritative resume state. See [.agents/context/checkpointing.md](checkpointing.md).
 
 ---
 

--- a/.agents/context/checkpointing.md
+++ b/.agents/context/checkpointing.md
@@ -7,7 +7,7 @@ Instead of per-work-item watermark tables, the system uses a forward-only cursor
 ### Cursor File Location
 
 ```
-Checkpoints/workitems.cursor.json
+.migration/Checkpoints/workitems.cursor.json
 ```
 
 ### Schema
@@ -61,10 +61,10 @@ The cursor is written after each stage completes. A crash between stages leaves 
 
 ### Per-Module Cursors
 
-Each module maintains its own cursor file under `Checkpoints/`:
+Each module maintains its own cursor file under `.migration/Checkpoints/`:
 
 ```
-Checkpoints/
+.migration/Checkpoints/
   workitems.cursor.json
   teams.cursor.json
   permissions.cursor.json
@@ -78,7 +78,7 @@ The convention is `<moduleName-lowercase>.cursor.json`. Modules must not share c
 
 ### ID Map
 
-The `Checkpoints/idmap.db` (or `idmap.json`) file tracks source-to-target work item ID mappings and uploaded attachment records. It is written during Stage `CreatedOrUpdated` (work item ID) and Stage `UploadedAttachments` (attachment ID per revision). It is the sole mechanism for idempotency checks during resume. See [.agents/context/identity-and-mapping.md](identity-and-mapping.md) for the identity mapping counterpart.
+The `Checkpoints/idmap.db` (or `idmap.json`) file (under `.migration/`) tracks source-to-target work item ID mappings and uploaded attachment records. It is written during Stage `CreatedOrUpdated` (work item ID) and Stage `UploadedAttachments` (attachment ID per revision). It is the sole mechanism for idempotency checks during resume. See [.agents/context/identity-and-mapping.md](identity-and-mapping.md) for the identity mapping counterpart.
 
 ---
 
@@ -100,7 +100,7 @@ When a job runs in `Both` mode (export then import), a top-level phase record tr
 ### Phase Record Location
 
 ```
-Checkpoints/job.phase.json
+.migration/Checkpoints/job.phase.json
 ```
 
 ### Schema
@@ -115,7 +115,7 @@ Checkpoints/job.phase.json
 
 ### Resume Logic (Both Mode)
 
-1. Read `Checkpoints/job.phase.json` before running any module.
+1. Read `.migration/Checkpoints/job.phase.json` before running any module.
 2. If `exportCompleted: true` → skip all export-phase modules; jump directly to import phase.
 3. If `importCompleted: true` → skip import-phase modules too; job is already complete.
 4. Otherwise run from the first incomplete phase, with each module resuming from its own cursor.

--- a/.agents/context/cli-commands.md
+++ b/.agents/context/cli-commands.md
@@ -33,7 +33,7 @@ Query and control existing jobs. Registered as a Spectre.Console branch named `m
 | `manage list` | `ManageListCommandSettings` | List all jobs visible to the authenticated user with status and progress. |
 | `manage status` | `ManageStatusCommandSettings` | Display job state and per-module progress for a specific job. Requires `--job <id>`. |
 | `manage progress` | `ManageProgressCommandSettings` | Fetch a snapshot of `ProgressEvent` records from the job ring buffer as NDJSON. Requires `--job <id>`. |
-| `manage diagnostics` | `ManageDiagnosticsCommandSettings` | Download package diagnostic log files (`Logs/agent.jsonl`) for a completed job. Accepts `--level` filter. Requires `--job <id>`. |
+| `manage diagnostics` | `ManageDiagnosticsCommandSettings` | Download package diagnostic log files (`.migration/Logs/agent.jsonl`) for a completed job. Accepts `--level` filter. Requires `--job <id>`. |
 | `manage pause` | `ManagePauseCommandSettings` | Signal the agent to checkpoint and pause. Requires `--job <id>`. |
 | `manage resume` | `ManageResumeCommandSettings` | Re-queue a paused job for agent pickup. Requires `--job <id>`. |
 | `manage cancel` | `ManageCancelCommandSettings` | Cancel a queued or running job. Requires `--job <id>`. |
@@ -119,7 +119,7 @@ The interactive prompt runs inside the command's `ExecuteInternalAsync` (before 
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--force-fresh` | `false` | Delete module cursor file(s) (and the job phase record for `Both` mode) before job execution. Enumeration restarts from the beginning. The identity map (`Checkpoints/idmap.json`) is **not** deleted so no duplicate items are created in the target. |
+| `--force-fresh` | `false` | Delete module cursor file(s) (and the job phase record for `Both` mode) before job execution. Enumeration restarts from the beginning. The identity map (`.migration/Checkpoints/idmap.json`) is **not** deleted so no duplicate items are created in the target. |
 
 ## Control Plane Endpoint Resolution (control-plane commands only)
 

--- a/.agents/context/import-streaming.md
+++ b/.agents/context/import-streaming.md
@@ -34,10 +34,10 @@ Stage label values are canonical and shared with the cursor schema. See [.agents
 
 ### Idempotency Notes
 
-- **Stage A (`CreatedOrUpdated`):** Check `Checkpoints/idmap.db` for an existing `sourceId → targetId` mapping. If found, use the existing target ID and skip creation.
+- **Stage A (`CreatedOrUpdated`):** Check `.migration/Checkpoints/idmap.db` for an existing `sourceId → targetId` mapping. If found, use the existing target ID and skip creation.
 - **Stage B (`AppliedFields`):** Applying the same fields again must be a no-op or result in the same state.
 - **Stage C (`AppliedLinks`):** Query the target for existing links before creation. Do not add a link that already exists.
-- **Stage D (`UploadedAttachments`):** The Azure DevOps REST API does not expose SHA256 in attachment list responses. Idempotency is therefore tracked locally: after a successful upload, record `(workItemId, revisionIndex, relativePath) → targetAttachmentId` in `Checkpoints/idmap.db`. On resume, if an entry exists for the attachment, skip re-upload. The SHA256 stored in `revision.json` is used for local file integrity verification only (export-time guarantee), not for target-side deduplication.
+- **Stage D (`UploadedAttachments`):** The Azure DevOps REST API does not expose SHA256 in attachment list responses. Idempotency is therefore tracked locally: after a successful upload, record `(workItemId, revisionIndex, relativePath) → targetAttachmentId` in `.migration/Checkpoints/idmap.db`. On resume, if an entry exists for the attachment, skip re-upload. The SHA256 stored in `revision.json` is used for local file integrity verification only (export-time guarantee), not for target-side deduplication.
 
 ### Non-Negotiables
 

--- a/.agents/context/job-contract.md
+++ b/.agents/context/job-contract.md
@@ -86,7 +86,7 @@ See [docs/validation.md](validation.md) for the full four-tier validation model.
 | `artefacts.createPackage` | No | If `true`, pack after export or unpack before import. Default `false`. |
 | `guardrails.streamingRequired` | Yes | Must be `true`. The Job Engine will reject any execution plan that would load all revisions into memory. |
 | `guardrails.canonicalWorkItemsLayoutRequired` | Yes | Must be `true`. Any module that would alter the canonical folder structure is rejected at plan time. |
-| `resume.mode` | No | `Auto` (default) — detect existing cursor and resume from last position; `ForceFresh` — delete all module cursor files and `Checkpoints/job.phase.json` before running. Absent or `null` is treated as `Auto`. |
+| `resume.mode` | No | `Auto` (default) — detect existing cursor and resume from last position; `ForceFresh` — delete all module cursor files and `.migration/Checkpoints/job.phase.json` before running. Absent or `null` is treated as `Auto`. |
 | `configHash` | Yes | SHA-256 of the normalised config JSON at job construction time. Written into `manifest.json` for auditability. |
 
 ---

--- a/.agents/context/package-format.md
+++ b/.agents/context/package-format.md
@@ -30,12 +30,15 @@ PackageRoot/
   Builds/
   Git/
   Identities/
-  Checkpoints/
-  Logs/
-    <ticks>-<jobId>/
-      progress.jsonl
-      agent.jsonl
+  .migration/
+    Checkpoints/
+    Logs/
+      <ticks>-<jobId>/
+        progress.jsonl
+        agent.jsonl
 ```
+
+> **Legacy fallback:** Packages created before the `.migration/` dotfolder change may store `Checkpoints/` and `Logs/` directly under `PackageRoot/`. All code that reads these paths tries the `.migration/` location first, then falls back to the legacy root-level location. The `PackagePaths` static class in `DevOpsMigrationPlatform.Abstractions` defines both current and legacy path constants.
 
 The WorkItems layout is canonical and must not be altered:
 
@@ -62,9 +65,9 @@ Key characteristics:
 - Resume is trivial
 - Human-auditable
 
-### Logs/
+### .migration/Logs/
 
-The `Logs/` folder contains structured observability records written by the Migration Agent during job execution. Each job writes to its own subfolder to prevent logs from different runs overwriting each other:
+The `.migration/Logs/` folder contains structured observability records written by the Migration Agent during job execution. Each job writes to its own subfolder to prevent logs from different runs overwriting each other:
 
 ```
 Logs/
@@ -84,7 +87,7 @@ The subfolder name uses `<ticks>-<jobId>` (e.g. `638807123456789012-a1b2c3d4`) s
 
 Both files are append-only and survive resume. They are the durable record of job execution — the control plane's in-memory ring buffer is ephemeral.
 
-**Backward compatibility:** Packages created before job-scoped logging may have log files directly under `Logs/` (e.g. `Logs/agent.jsonl`). The `LogDownloadController` falls back to this flat layout when no job-scoped subfolder is found.
+**Backward compatibility:** Packages created before job-scoped logging may have log files directly under `.migration/Logs/` (e.g. `.migration/Logs/agent.jsonl`). The `LogDownloadController` falls back to this flat layout when no job-scoped subfolder is found.
 
 ### Naming Conventions
 

--- a/.agents/guardrails/coding-standards.md
+++ b/.agents/guardrails/coding-standards.md
@@ -404,7 +404,7 @@ public class WorkItemsImportModule
 
 - All persistent writes MUST go through `IArtefactStore` or `IStateStore` — no direct file or database access from module code.
 - Schema evolution MUST be safe and additive by default; destructive changes require a versioned migration.
-- Import idempotency MUST be enforced via `Checkpoints/idmap.db` and cursor state — never by re-querying the target.
+- Import idempotency MUST be enforced via `.migration/Checkpoints/idmap.db` and cursor state — never by re-querying the target.
 - No partial writes: write to a temporary path and atomically rename to the final path where the store supports it.
 - Transactional boundaries MUST match the semantic unit of work; one revision folder = one atomic boundary.
 
@@ -501,7 +501,7 @@ public class WorkItemsImportModule
 - Direct Source → Target migration logic.
 - Global attachment stores.
 - Loading entire revision sets into memory.
-- Hidden resume state outside Checkpoints/.
+- Hidden resume state outside `.migration/Checkpoints/`.
 - Cross-module direct calls.
 - .NET Framework usage outside the explicit TFS exporter boundary.
 - `.Result` or `.Wait()` calls on `Task` or `ValueTask` anywhere in production code.

--- a/.agents/guardrails/migration-rules.md
+++ b/.agents/guardrails/migration-rules.md
@@ -61,7 +61,7 @@ revision.json <attachment files>
 ## 5) Resume is cursor-based
 
 - Resume MUST be forward-only via a cursor.
-- Cursor MUST be stored under `Checkpoints/`.
+- Cursor MUST be stored under `.migration/Checkpoints/`.
 - Hidden state elsewhere is prohibited.
 
 ## 6) Determinism is mandatory
@@ -77,8 +77,8 @@ Package root MUST contain:
 
 - `manifest.json`
 - `WorkItems/`
-- `Checkpoints/`
-- `Logs/`
+- `.migration/Checkpoints/`
+- `.migration/Logs/`
 - Optional module folders:
   - `Teams/`
   - `Permissions/`
@@ -113,7 +113,7 @@ Manifest MUST NOT be required for streaming import, but MUST be present for vali
 
 Each module MUST store its cursor in:
 
-- `Checkpoints/<module>.cursor.json`
+- `.migration/Checkpoints/<module>.cursor.json`
 
 WorkItems cursor example:
 
@@ -167,7 +167,7 @@ Modules MUST:
 Modules MUST NOT:
 
 * Access another module’s folder directly
-* Persist state outside Checkpoints/
+* Persist state outside `.migration/Checkpoints/`
 * Perform ad-hoc file IO
 * Perform live migrations
 
@@ -193,7 +193,7 @@ Rules:
 
 ID mappings MUST be stored under:
 
-Checkpoints/
+.migration/Checkpoints/
 
 * idmap.db OR idmap.json
 
@@ -380,7 +380,7 @@ Reject any design or implementation that:
 * Implements comment export or embedded-image export as a separate top-level `IModule` (these are sub-services of `WorkItemsModule`).
 * Loads all WorkItems or all revisions into memory.
 * Requires building a full graph before processing.
-* Introduces hidden progress state outside Checkpoints/.
+* Introduces hidden progress state outside `.migration/Checkpoints/`.
 * Performs direct source-to-target migration.
 * Breaks deterministic folder naming.
 * Bypasses identity mapping or id mapping services.

--- a/.agents/guardrails/module-template.md
+++ b/.agents/guardrails/module-template.md
@@ -20,7 +20,7 @@ See [docs/modules.md](../../docs/modules.md) for the full `IModule` contract and
 
 ## 3. Cursor Format
 
-- [ ] Define the cursor file at `Checkpoints/<modulename>.cursor.json`.
+- [ ] Define the cursor file at `.migration/Checkpoints/<modulename>.cursor.json`.
 - [ ] Document the `lastProcessed` field semantics (what path or key it holds).
 - [ ] Document all valid `stage` values for this module.
 - [ ] Implement resume logic that reads the cursor and skips already-processed items.
@@ -37,7 +37,7 @@ See [docs/modules.md](../../docs/modules.md) for the full `IModule` contract and
 
 - [ ] `ValidateAsync` checks that all required fields are present in every artefact file.
 - [ ] `ValidateAsync` checks schema version compatibility.
-- [ ] `ValidateAsync` reports anomalies to `Logs/` rather than failing silently.
+- [ ] `ValidateAsync` reports anomalies to `.migration/Logs/` rather than failing silently.
 - [ ] `ValidateAsync` fails fast on missing required fields.
 
 ## 6. Identity Mapping (if applicable)

--- a/.agents/guardrails/system-architecture.md
+++ b/.agents/guardrails/system-architecture.md
@@ -27,7 +27,7 @@ Silently working around a rule = violation. Blindly following a harmful rule = n
    Enumeration order is determined by lexicographic folder traversal. Sorting in memory defeats the purpose of the layout and breaks memory safety for large datasets.
 
 4. **Cursor-based checkpoints are required.**
-   Every module must maintain a cursor file under `Checkpoints/`. Watermark tables, databases, or in-memory progress tracking are not acceptable substitutes.
+   Every module must maintain a cursor file under `.migration/Checkpoints/`. Watermark tables, databases, or in-memory progress tracking are not acceptable substitutes.
 
 5. **Attachments are stored beside revision.json.**
    Attachment files live in the same folder as their `revision.json`. There is no global `Attachments/` root and no mandatory blob store.
@@ -51,7 +51,7 @@ Silently working around a rule = violation. Blindly following a harmful rule = n
     The `ControlPlane` service library accepts, stores, and assigns jobs. It does not call source or target APIs, run orchestrator logic, read or write the migration package, or unwrap secrets. `ControlPlaneHost` extends the control plane with agent lifecycle management but must not contain job execution logic. Violations break the separation between coordination (`ControlPlane`/`ControlPlaneHost`) and execution (`Agent`).
 
 12. **Agents are stateless; all durable state is in the package.**
-    Agents hold no state beyond the current lease. All durable state lives in the package (`Checkpoints/`, `Logs/`, revision folders) via `IArtefactStore` and `IStateStore`. An Agent that crashes is replaced by a new Agent that resumes from the cursor.
+    Agents hold no state beyond the current lease. All durable state lives in the package (`.migration/Checkpoints/`, `.migration/Logs/`, revision folders) via `IArtefactStore` and `IStateStore`. An Agent that crashes is replaced by a new Agent that resumes from the cursor.
 
 13. **IArtefactStore is the only permitted file abstraction.**
     Both `FileSystemArtefactStore` and `AzureBlobArtefactStore` implement `IArtefactStore`. Module code must not reference either implementation directly. Switching from local to cloud mode must require zero module code changes.
@@ -71,7 +71,7 @@ Silently working around a rule = violation. Blindly following a harmful rule = n
     The Job Engine has no dependency on any console, UI framework, or interactive terminal. It receives a `MigrationJob` and an `IProgressSink`; it produces package output and cursor state. It must be runnable in-process (local), in a container (Migration Agent), or in a test harness without modification.
 
 18. **No UI coupling in the Job Engine or modules.**
-    The Job Engine and all modules must not write to `Console`, reference `System.Console`, or use any interactive input mechanism. All output goes through `IProgressSink` (progress events) or `IArtefactStore` (logs written to `Logs/`). Any violation makes the engine unrunnable as a Migration Agent.
+    The Job Engine and all modules must not write to `Console`, reference `System.Console`, or use any interactive input mechanism. All output goes through `IProgressSink` (progress events) or `IArtefactStore` (logs written to `.migration/Logs/`). Any violation makes the engine unrunnable as a Migration Agent.
 
 19. **TFS Object Model runs in an isolated subprocess spawned by the CLI only.**
     The .NET 4.x TFS exporter (`DevOpsMigrationPlatform.CLI.TfsMigration`) is a completely separate binary invoked **directly by the CLI** (`TfsExportCommand` in `CLI.Migration`). It is not routed through ControlPlane or MigrationAgent — TFS OM cannot run in Docker, so this is a CLI-only operation for all topologies. `TfsExportAgent` uses the same `IArtefactStore`, `IStateStore`, and `IProgressSink` abstractions as the .NET 10 `MigrationAgent` — these interfaces are defined in the multi-targeted `DevOpsMigrationPlatform.Abstractions` (`net481;net10.0`). The `StdoutProgressSink` (net481) writes NDJSON progress events to stdout; the CLI reads these via `TfsExporterProcessAdapter` and streams them to the terminal. The .NET 10 host must never hold a compiled reference to the .NET 4 project. The only permitted caller of the subprocess is `ExternalToolRunner` in `DevOpsMigrationPlatform.CLI.Migration` — a generic, TFS-agnostic process bridge. `TfsExporterProcessAdapter` in `CLI.Migration` is the only permitted TFS-aware .NET 10 class; it translates NDJSON stdout lines into progress events for the CLI. See [docs/tfs-exporter.md](../../docs/tfs-exporter.md) for the full protocol specification.

--- a/.agents/guardrails/workitems-rules.md
+++ b/.agents/guardrails/workitems-rules.md
@@ -72,10 +72,10 @@ Process each revision folder through stages in this exact order:
 
 | Stage | Label | Description |
 |---|---|---|
-| A | `CreatedOrUpdated` | Create or identify the target work item; record source→target ID in `Checkpoints/idmap.db` |
+| A | `CreatedOrUpdated` | Create or identify the target work item; record source→target ID in `.migration/Checkpoints/idmap.db` |
 | B | `AppliedFields` | Apply all field values from `revision.json` |
 | C | `AppliedLinks` | Apply `relatedLinks`, `externalLinks`, `hyperlinks` |
-| D | `UploadedAttachments` | Upload files and record `(workItemId, revisionIndex, relativePath) → targetAttachmentId` in `Checkpoints/idmap.db` |
+| D | `UploadedAttachments` | Upload files and record `(workItemId, revisionIndex, relativePath) → targetAttachmentId` in `.migration/Checkpoints/idmap.db` |
 
 Write the cursor after each stage. Never skip a stage. Never reorder stages.
 
@@ -83,9 +83,9 @@ Stage label values are canonical. Use the exact string values above in the curso
 
 ## Idempotency and Resume Behaviour
 
-- **Before Stage A (`CreatedOrUpdated`):** Check `Checkpoints/idmap.db` for a `sourceWorkItemId → targetWorkItemId` entry. If found, skip creation and use the existing target ID.
+- **Before Stage A (`CreatedOrUpdated`):** Check `.migration/Checkpoints/idmap.db` for a `sourceWorkItemId → targetWorkItemId` entry. If found, skip creation and use the existing target ID.
 - **Before Stage C (`AppliedLinks`):** Query the target for existing links before adding. Do not add a link that already exists.
-- **Before Stage D (`UploadedAttachments`):** Check `Checkpoints/idmap.db` for an entry keyed by `(workItemId, revisionIndex, relativePath)`. If found, skip re-upload. The target API does not expose SHA256; idempotency is local-record-based only. SHA256 in `revision.json` is for local file integrity verification only.
+- **Before Stage D (`UploadedAttachments`):** Check `.migration/Checkpoints/idmap.db` for an entry keyed by `(workItemId, revisionIndex, relativePath)`. If found, skip re-upload. If found, skip re-upload. The target API does not expose SHA256; idempotency is local-record-based only. SHA256 in `revision.json` is for local file integrity verification only.
 - **On resume:** The cursor's `stage` field identifies the last completed stage. Begin from the next stage, not from Stage A.
 
 ## What Must Not Change
@@ -93,6 +93,6 @@ Stage label values are canonical. Use the exact string values above in the curso
 - The revision folder naming format — it is the streaming import contract.
 - The comment folder naming format — `<ticks>-<workItemId>-c<commentId>/` is canonical and must not be altered or replaced with a per-work-item flat file.
 - The stage order — it reflects dependency order (item must exist before fields, fields before links, links before attachments).
-- The cursor file path — `Checkpoints/workitems.cursor.json`.
+- The cursor file path — `.migration/Checkpoints/workitems.cursor.json`.
 - The `lastProcessed` value format — it must be the relative path of the revision or comment folder, not an ID or timestamp.
 - The stage label strings — they must be one of: `CreatedOrUpdated`, `AppliedFields`, `AppliedLinks`, `UploadedAttachments`, `Completed`. No other values are valid.

--- a/agents.md
+++ b/agents.md
@@ -256,7 +256,7 @@ Reject any proposal that:
 - Breaks chronological folder ordering.
 - Introduces global attachment storage.
 - Requires loading all revisions into memory.
-- Adds hidden state outside `Checkpoints/`.
+- Adds hidden state outside `.migration/Checkpoints/`.
 - Couples modules directly.
 - Performs live streaming migration.
 - Violates coding standards.

--- a/analysis/feature-gap.md
+++ b/analysis/feature-gap.md
@@ -355,3 +355,180 @@ These are capabilities the new platform provides that **do not exist** in the ol
 | Outbound link checking/preservation | 2 | Low |
 | Changeset mapping | 1 | Low |
 | Debug pause-after-each-item | 1 | Low |
+
+---
+
+## Part B — Gap Analysis: `azure-devops-automation-tools`
+
+> **Source**: `azure-devops-automation-tools` (PowerShell utility scripts)
+> **New tool**: `azure-devops-migration-platform` (C# platform)
+>
+> Generated: 2026-04-22
+
+This section captures every capability in the PowerShell automation tools repository that either does not exist in the new platform, or exists only as a placeholder, stub, or partial implementation. These tools are complementary to the migration tools — they handle **pre-migration preparation**, **organisation-wide process administration**, and **supplementary migration utilities**.
+
+---
+
+## 12. Organisation Roster & Multi-Org Config Management
+
+The automation tools use an `organisations.json` file as a shared roster of orgs (with PATs, enabled flags, project lists, and process metadata). Scripts read and write this file to accumulate discovered data over time.
+
+| Automation Tool Feature | Script | New Platform Equivalent | Status |
+|---|---|---|---|
+| Multi-org roster (`organisations.json`) with enabled/disabled toggle | All scripts | `organisations` array in scenario config | 🔶 Partial — scenario config has org list but no persistent multi-org roster with per-org PATs and discovery metadata |
+| Auto-discover all projects in an org via REST API and write them back to the roster | `Add-ProjectsToConfig.ps1` | — | ❌ |
+| Per-project enabled/disabled flag in roster | `organisations.json` schema | — | ❌ |
+| Per-org process match metadata in roster (`processMatch[]` with ProcessID, WorkItemType, enabled) | `organisations.json` + `Search-ProcessesWeCareAbout.ps1` | — | ❌ |
+| Discover processes containing a target field and upsert them into the roster | `Search-ProcessesWeCareAbout.ps1` | — | ❌ |
+| Generate a migration scenario config per org/project from a template library | `Generate-ConfigurationsFromTemplates.ps1` | `config new` wizard (single config, interactive) | 🔶 Partial — `config new` creates one file interactively; no bulk template-driven generation across all orgs+projects |
+| Template library with per-scenario JSON templates (workItemsOnly, casesPlansWithShared, pipelines, sharedQueries) | `data/*/templates/*.json` | `scenarios/*.json` sample configs | 🔶 Partial — samples exist but no automated stamping of source/target into each per-project output file |
+| Output one scenario config per project under `output/<org>/projects/<project>/<template>.json` | `Generate-ConfigurationsFromTemplates.ps1` | — | ❌ |
+
+---
+
+## 13. Pre-Migration Inventory & Sizing
+
+The platform has a `discovery inventory` command that counts work items and revisions. The automation tools go further with a sizing spreadsheet covering multiple artefact types.
+
+| Automation Tool Feature | Script | New Platform Equivalent | Status |
+|---|---|---|---|
+| Count work items per project (with year-by-year pagination for large projects) | `Generate-ProjectStats.ps1` | `discovery inventory` | 🔶 Partial — platform counts work items and revisions but not other artefact types |
+| Count shared-steps work items separately | `Generate-ProjectStats.ps1` | — | ❌ |
+| Count build/release pipelines per project | `Generate-ProjectStats.ps1` | — | ❌ |
+| Count test plans per project | `Generate-ProjectStats.ps1` | — | ❌ |
+| Count test suites (tree view) per test plan | `Generate-ProjectStats.ps1` | — | ❌ |
+| Count Git repositories per project | `Generate-ProjectStats.ps1` | — | ❌ |
+| Show process base and process name per project | `Generate-ProjectStats.ps1` | — | ❌ |
+| Export stats to Excel (`.xlsx`) via ImportExcel module | `Generate-ProjectStats.ps1` | `inventory.csv` / `inventory.json` | 🔶 Partial — platform outputs CSV/JSON but no Excel and does not include pipelines/repos/plans |
+
+---
+
+## 14. Process Field Administration (Cross-Org)
+
+The automation tools provide idempotent, multi-org process field and form layout management. The new platform has no equivalent capability — process administration is out of scope for the migration runtime itself, but these are critical pre- and post-migration tasks.
+
+### 14.1 Process Output Inventory
+
+| Automation Tool Feature | Script | New Platform Equivalent | Status |
+|---|---|---|---|
+| Export all org-level WIT fields to `fields.json` | `Generate-ProcessOutput.ps1` | — | ❌ |
+| Export all picklists (summary + detail per list) | `Generate-ProcessOutput.ps1` | — | ❌ |
+| Export all processes (skipping system processes) | `Generate-ProcessOutput.ps1` | — | ❌ |
+| Export WIT layout JSON per custom WIT per process | `Generate-ProcessOutput.ps1` | — | ❌ |
+| Export WIT field list per custom WIT per process | `Generate-ProcessOutput.ps1` | — | ❌ |
+| Folder-per-org / folder-per-process output structure | `Generate-ProcessOutput.ps1` | — | ❌ |
+
+### 14.2 Custom Field Installation
+
+| Automation Tool Feature | Script | New Platform Equivalent | Status |
+|---|---|---|---|
+| Idempotent: create a picklist if it doesn't exist, update items if it does | `Install-CustomFields.ps1` | — | ❌ |
+| Idempotent: create a WIT field at org level if it doesn't exist | `Install-CustomFields.ps1` | — | ❌ |
+| Idempotent: add field to a process WIT if not already present | `Install-CustomFields.ps1` | — | ❌ |
+| Idempotent: add field control to a named group on the WIT form layout | `Install-CustomFields.ps1` | — | ❌ |
+| Field config validation (referenceName consistency across createFieldPOST / addFieldPOST / createControlPOST) | `Install-CustomFields.ps1` | — | ❌ |
+| Enabled/disabled flag per field in `fields.json` manifest | `fields.json` schema | — | ❌ |
+| Per-field JSON definition with all REST POST bodies (`createFieldPOST`, `addFieldPOST`, `createPicklistPOST`, `createControlPOST`) | `data/*/fields/*.json` | — | ❌ |
+| Configurable target group label (`defaultGroupLabel`) per field definition | field definition schema | — | ❌ |
+
+### 14.3 Custom Page & Group Installation
+
+| Automation Tool Feature | Script | New Platform Equivalent | Status |
+|---|---|---|---|
+| Add a custom page to a WIT form layout if it doesn't exist | `Install-CustomPages.ps1` | — | ❌ |
+| Add groups to named sections of an existing page | `Install-CustomPages.ps1` | — | ❌ |
+| Auto-create a custom WIT inheriting from a system WIT when the system WIT cannot be modified | `Install-CustomPages.ps1` | — | ❌ |
+| Page scoped to specific work item type names (`workItemTypes` filter in page definition) | page definition schema | — | ❌ |
+| Enabled/disabled flag per page | page definition schema | — | ❌ |
+
+### 14.4 ReflectedWorkItemID Field Installation
+
+| Automation Tool Feature | Script | New Platform Equivalent | Status |
+|---|---|---|---|
+| Install the `Custom.ReflectedWorkItemId` field across all orgs, all non-system processes, all WITs | `Install-ReflectedWorkItemID.ps1` | — | ❌ |
+| Auto-create a custom WIT if the system WIT cannot be modified | `Install-ReflectedWorkItemID.ps1` | — | ❌ |
+| Validate the field reference name contains "Custom" (rejects accidental system field matches) | `Install-ReflectedWorkItemID.ps1` | — | ❌ |
+| Standalone field definition file (`ReflectedWorkItemId.json`) separate from the field manifest | `data/*/ReflectedWorkItemId.json` | — | ❌ |
+
+### 14.5 Field Deletion
+
+| Automation Tool Feature | Script | New Platform Equivalent | Status |
+|---|---|---|---|
+| Delete a field by reference name from all enabled orgs | `Delete-CustomField.ps1` | — | ❌ |
+
+---
+
+## 15. Git Repository Migration (Practical Implementation)
+
+The platform has a git-repos module placeholder. The automation tools have a working mirror-push implementation.
+
+| Automation Tool Feature | Script | New Platform Equivalent | Status |
+|---|---|---|---|
+| Enumerate enabled orgs and projects from roster | `Migrate-GitRepos.ps1` | — (placeholder) | ❌ |
+| List all Git repos in each project via REST | `Migrate-GitRepos.ps1` | — (placeholder) | ❌ |
+| Create target repository if it doesn't exist (same name, same project) | `Migrate-GitRepos.ps1` | — (placeholder) | ❌ |
+| Bare clone source repo locally | `Migrate-GitRepos.ps1` | — (placeholder) | ❌ |
+| `git push --mirror` to target (all branches, tags, deletes) | `Migrate-GitRepos.ps1` | — (placeholder) | ❌ |
+| Summary statistics logged at end | `Migrate-GitRepos.ps1` | — | ❌ |
+| PAT never logged (safety guarantee) | `Migrate-GitRepos.ps1` | — | ❌ |
+
+> **Note**: Mirror push deletes refs in target that were deleted in source. Target projects must be pre-created. This is a one-way additive + destructive sync, not a package-based migration.
+
+---
+
+## 16. Process Template Migration
+
+| Automation Tool Feature | Script | New Platform Equivalent | Status |
+|---|---|---|---|
+| Invoke `microsoft/process-migrator` npm tool to migrate a process template | `process-migrator.ps1` | — | ❌ |
+| `configuration.json` schema for process-migrator | `src/processMigrator/configuration.json` | — | ❌ |
+
+> **Note**: `process-migrator` is a separate Microsoft open-source tool. This is a wrapper that invokes it. Full process template migration (Section 6 above) remains unimplemented in the new platform.
+
+---
+
+## 17. Migration Execution Wrapper
+
+| Automation Tool Feature | Script | New Platform Equivalent | Status |
+|---|---|---|---|
+| Resolve config from output folder and invoke `devopsmigration.exe execute` | `Execute-MigrationTools.ps1` | `devopsmigration queue --config <path>` | 🔶 Partial — the new CLI supports equivalent functionality, but no script exists to loop over all generated per-project configs and execute them in batch |
+| Batch-execute all generated project configs sequentially | — | — | ❌ |
+
+---
+
+## 18. Cross-Cutting: Shared Infrastructure (Automation Tools)
+
+| Feature | Automation Tools | New Platform | Status |
+|---|---|---|---|
+| Structured logging with named properties (`Write-InfoLog`, `Write-WarningLog`, `Write-ErrorLog`, `Write-DebugLog`) | `src/_includes/logging.ps1` | NDJSON structured logging via OpenTelemetry | ✅ (different implementation) |
+| `config.json` with `dataFolder`, `outputFolder`, `dataEnvironment`, `queryString` | `config.json` + `runmefirst.ps1` | Scenario config (`scenarios/*.json`) | 🔶 Partial — platform has richer config but no concept of a separate writable `dataFolder` vs read-only `outputFolder` |
+| Excel export via `ImportExcel` PowerShell module | `src/_includes/ImportExcel.ps1` | — | ❌ |
+| Environment-layered data resolution (`debug` → `sample` → current env) | `setup.ps1` | — | ❌ |
+
+---
+
+## Summary: Automation Tools Feature Gaps
+
+| Category | Feature Count | Platform Status | Priority |
+|---|---|---|---|
+| **Org roster management** (add projects, process discovery, roster upsert) | 8 | ❌ Not implemented | **High** — required for managing migrations at scale across dozens of orgs |
+| **Bulk config generation from templates** | 3 | 🔶 Partial (`config new` is single-file interactive only) | **High** — operator efficiency for large multi-project programmes |
+| **Extended inventory / sizing** (pipelines, repos, plans, suites, Excel) | 8 | 🔶 Partial (work items only, no Excel) | **Medium** |
+| **Process output inventory** (fields, picklists, layouts) | 6 | ❌ Not implemented | **Medium** — useful for pre-migration audit |
+| **Custom field installation** (create, add to WIT, add control, idempotent) | 8 | ❌ Not implemented | **High** — required to prepare target orgs before migration |
+| **Custom page/group installation** | 5 | ❌ Not implemented | **Medium** |
+| **ReflectedWorkItemID installation** | 4 | ❌ Not implemented | **High** — required if the old migration tools' reflected-ID approach is used as a deduplication strategy |
+| **Field deletion** | 1 | ❌ Not implemented | Low |
+| **Git repository mirror migration** | 7 | ❌ Not implemented (placeholder only) | **High** — many migrations require repo migration alongside work items |
+| **Process template migration wrapper** | 2 | ❌ Not implemented | Medium |
+| **Batch migration execution across projects** | 2 | 🔶 Partial (CLI supports single config; no batch loop) | Medium |
+
+### Highest Priority Gaps (Automation Tools → New Platform)
+
+1. **`discovery org-sync`** — enumerate projects from all orgs and upsert them into a persistent roster; populate process metadata. Equivalent to `Add-ProjectsToConfig.ps1` + `Search-ProcessesWeCareAbout.ps1`.
+2. **`config generate`** (or `config bulk-generate`) — stamp a library of scenario templates with org/project/PAT values and write one config per project. Equivalent to `Generate-ConfigurationsFromTemplates.ps1`.
+3. **`discovery stats`** (extended inventory) — add pipelines, repos, test plans, test suites, and Excel output to `discovery inventory`. Equivalent to `Generate-ProjectStats.ps1`.
+4. **`admin field install`** — idempotent installation of custom fields (with picklists and controls) across orgs/processes. Equivalent to `Install-CustomFields.ps1`.
+5. **`admin field install-reflected-id`** — install the `Custom.ReflectedWorkItemId` field across all orgs/processes/WITs. Equivalent to `Install-ReflectedWorkItemID.ps1`.
+6. **Git repository module** — implement the placeholder with `git --mirror` push semantics. Equivalent to `Migrate-GitRepos.ps1`.
+7. **`admin page install`** — idempotent page/group installation on WIT form layouts. Equivalent to `Install-CustomPages.ps1`.

--- a/analysis/proposed-features.md
+++ b/analysis/proposed-features.md
@@ -1,0 +1,849 @@
+# Proposed Features: Rationalised into Platform Terminology
+
+> **Source**: `feature-gap.md` — gaps from `azure-devops-migration-tools` (v16+) and `azure-devops-automation-tools` (PowerShell scripts)
+> **Target architecture**: `azure-devops-migration-platform` — Source → Package → Target, modules + extensions + tools
+>
+> Generated: 2026-04-22
+
+---
+
+## How to Read This Document
+
+| Term | Meaning |
+|------|---------|
+| **Module** | A domain-scoped unit that implements `IModule`. Runs inside the Migration Agent. Handles one concern (e.g. `WorkItems`, `Teams`). Has both export and import paths. |
+| **Extension** | A named sub-data collector declared inside a module config block (e.g. `Revisions`, `Links`, `Attachments`). Enabled/disabled independently per run. |
+| **Tool** | A shared, cross-cutting service injected into one or more modules (e.g. `FieldMappingTool`, `NodeStructureTool`). Declared at the module or config level. Not a CLI command. |
+| **Scope** | A mandatory selection criterion on a module (e.g. `wiql` query, project name). |
+| **Discovery command** | A `discovery *` CLI sub-command that runs locally without submitting a `MigrationJob`. Reads source systems directly via REST. |
+| **CLI feature** | A `queue`, `config`, `manage`, or `admin` command addition. |
+| **Config feature** | A new field or schema addition to the scenario JSON config. |
+
+Status legend:
+
+| Icon | Meaning |
+|------|---------|
+| ✅ | Implemented |
+| 🔶 | Partially implemented |
+| ❌ | Not implemented |
+| 🆕 | Net-new — did not exist in either old tool |
+
+---
+
+## Index — Ordered by Perceived Value
+
+### Modules
+
+| # | Module | Status | Summary |
+|---|--------|--------|---------|
+| M1 | [WorkItemsModule — FieldMapping extensions](#m1-workitemsmodule--fieldmapping) | 🔶 Missing field-map engine | 14 field-map types required for cross-process-template migrations |
+| M2 | [WorkItemsModule — NodeStructure tool](#m2-workitemsmodule--nodestructure-tool) | ❌ | Area/iteration path mapping, creation, and language override |
+| M3 | [WorkItemsModule — WorkItemTypeMapping tool](#m3-workitemsmodule--workitemtypemapping-tool) | ❌ | Agile↔Scrum type remapping |
+| M4 | [WorkItemsModule — missing options](#m4-workitemsmodule--missing-options) | ❌ | CollapseRevisions, MaxRevisions, GracefulFailures, etc. |
+| M5 | [TeamsModule](#m5-teamsmodule) | ❌ Placeholder | Team settings, members, capacity, iteration paths |
+| M6 | [TestManagementModule](#m6-testmanagementmodule) | ❌ Not started | Test plans, suites, cases, shared steps, configurations |
+| M7 | [GitModule](#m7-gitmodule) | ❌ Placeholder | Full git repository mirror migration |
+| M8 | [SharedQueriesModule](#m8-sharedqueriesmodule) | ❌ Not started | Shared query folders with project-name remapping |
+| M9 | [ProcessDefinitionsModule](#m9-processdefinitionsmodule) | ❌ Not started | Process templates, WIT definitions, fields, layouts |
+| M10 | [ProfilePicturesModule](#m10-profilepicturesmodule) | ❌ Not started | AD profile picture export/import |
+
+### Tools (shared cross-cutting services)
+
+| # | Tool | Status | Summary |
+|---|------|--------|---------|
+| T1 | [FieldMappingTool](#t1-fieldmappingtool) | ❌ | 14 field-map types injected into WorkItemsModule |
+| T2 | [NodeStructureTool](#t2-nodestructuretool) | ❌ | Area/iteration path regex mapping + auto-creation |
+| T3 | [WorkItemTypeMappingTool](#t3-workitemtypemappingtool) | ❌ | Work item type name remapping table |
+| T4 | [StringManipulatorTool](#t4-stringmanipulatortool) | ❌ | Regex-based field string cleanup |
+| T5 | [GitRepositoryMappingTool](#t5-gitrepositorymappingtool) | ❌ | Source→target repo name mapping for GitModule and link rewriting |
+| T6 | [ChangesetMappingTool](#t6-changesetmappingtool) | ❌ | TFS changeset → Git commit SHA mapping |
+| T7 | [WorkItemResolutionTool](#t7-workitemresolutiontool) | 🆕 ❌ | Per-work-item-type strategy for finding existing items in the target (field, hyperlink, or title match); handles types that cannot have custom fields (e.g. Shared Steps) |
+
+### Discovery Commands
+
+| # | Command | Status | Summary |
+|---|---------|--------|---------|
+| D1 | [`discovery org-sync`](#d1-discovery-org-sync) | ❌ | Enumerate all projects from configured orgs and upsert into the `organisations` roster |
+| D2 | [`discovery inventory` — missing artefact types](#d2-discovery-inventory--missing-artefact-types) | 🔶 | Add pipelines, repos, test plans, suites, process name, shared steps counts to existing command |
+| D3 | [`discovery process`](#d3-discovery-process) | 🆕 ❌ | Export process/WIT/field/layout metadata and produce a source↔target diff report |
+
+### CLI Features
+
+| # | Feature | Status | Summary |
+|---|---------|--------|---------|
+| C1 | [`config generate`](#c1-config-generate) | ❌ | Bulk stamp scenario-config templates per org+project from template library |
+| C2 | [`queue --batch`](#c2-queue---batch) | ❌ | Queue multiple jobs from a roster of generated configs |
+| C3 | [`admin field install`](#c3-admin-field-install) | ❌ | Idempotent custom field + picklist + control installation across orgs |
+| C4 | [`admin field install-reflected-id`](#c4-admin-field-install-reflected-id) | ❌ | Install `Custom.ReflectedWorkItemId` across all orgs/processes/WITs |
+| C5 | [`admin field delete`](#c5-admin-field-delete) | ❌ | Delete a field by reference name from all enabled orgs |
+| C6 | [`admin page install`](#c6-admin-page-install) | ❌ | Idempotent page/group installation on WIT form layouts across orgs |
+
+---
+
+## Modules — Detail
+
+### M1: WorkItemsModule — FieldMapping
+
+**Current state**: The module copies fields as opaque values. Identity fields are mapped by `IIdentityMappingService`. No general field transformation exists.
+
+**Why it matters**: Any migration between organisations with different process templates (e.g. Agile source → Scrum target) requires value translation on State, Priority, and custom fields before import. Without this, work items import with invalid or missing field values.
+
+**Proposed additions**:
+
+#### New Tool: `FieldMappingTool` (see [T1](#t1-fieldmappingtool))
+
+Declared in the module config's `tools` array. The module passes each revision's fields through the tool before writing `revision.json`.
+
+```json
+{
+  "name": "WorkItems",
+  "tools": [
+    {
+      "type": "FieldMapping",
+      "applyTo": ["User Story", "Bug"],
+      "maps": [
+        { "type": "FieldToField",    "sourceField": "Custom.OldField", "targetField": "Custom.NewField" },
+        { "type": "FieldValue",      "field": "System.State", "valueMap": { "Active": "In Progress", "Resolved": "Done" } },
+        { "type": "FieldLiteral",    "field": "Custom.MigratedBy", "value": "migration-platform" },
+        { "type": "FieldToTag",      "field": "System.AreaPath" },
+        { "type": "FieldValueToTag", "field": "System.State", "pattern": "^Resolved$" },
+        { "type": "RegexField",      "field": "System.Title", "pattern": "^\\[OLD\\]\\s*", "replacement": "" },
+        { "type": "FieldClear",      "field": "Custom.LegacyId" },
+        { "type": "FieldSkip",       "field": "Custom.InternalOnly" },
+        { "type": "FieldMerge",      "sourceFields": ["System.Title", "Custom.Subtitle"], "targetField": "System.Title", "format": "{0} — {1}" },
+        { "type": "FieldCalculation","targetField": "Custom.Score", "expression": "..." },
+        { "type": "FieldToTagField", "sourceFields": ["System.Tags", "Custom.Labels"], "targetField": "System.Tags" },
+        { "type": "TreeToTagField",  "field": "System.AreaPath", "targetField": "System.Tags" },
+        { "type": "MultiValueConditional", "conditions": [...], "targetField": "...", "value": "..." },
+        { "type": "FieldToFieldMulti", "maps": [ { "sourceField": "...", "targetField": "..." } ] }
+      ]
+    }
+  ]
+}
+```
+
+**Map types to implement** (14 total):
+
+| Map Type | Purpose |
+|---|---|
+| `FieldToField` | Copy field A → field B with optional default |
+| `FieldToFieldMulti` | Multiple source→target field copy pairs |
+| `FieldLiteral` | Set field to a literal value |
+| `FieldValue` | Dictionary-based value remapping (e.g. State) |
+| `FieldMerge` | Merge multiple source fields into one with format string |
+| `FieldCalculation` | Compute field from an expression |
+| `FieldClear` | Null-out a field |
+| `FieldSkip` | Exclude field from the written revision (not imported) |
+| `FieldValueToTag` | Append to `System.Tags` when field value matches a pattern |
+| `FieldToTag` | Append field value to `System.Tags` |
+| `FieldToTagField` | Merge multiple field values into a tag-style target field |
+| `MultiValueConditional` | Conditional multi-field → single field mapping |
+| `RegexField` | Regex find-and-replace within a field value |
+| `TreeToTagField` | Convert area/iteration tree path into a tag |
+
+**Per-map `applyTo` filter** — each map entry (or the tool itself) accepts an optional `applyTo` array of work item type names to restrict application.
+
+---
+
+### M2: WorkItemsModule — NodeStructure Tool
+
+**Current state**: `System.AreaPath` and `System.IterationPath` are written verbatim into `revision.json`. On import, if those paths don't exist in the target, the import fails or the revision lands in the root.
+
+**Why it matters**: Almost every migration involves renaming or restructuring area/iteration trees. Without this, imports to a different project hierarchy fail silently or require manual remediation.
+
+**Proposed additions**:
+
+#### New Tool: `NodeStructureTool` (see [T2](#t2-nodestructuretool))
+
+```json
+{
+  "name": "WorkItems",
+  "tools": [
+    {
+      "type": "NodeStructure",
+      "areaMap":      { "OldOrg\\OldProject\\Team A": "NewOrg\\NewProject\\Team A - Migrated" },
+      "iterationMap": { "OldOrg\\OldProject\\Sprint 1": "NewOrg\\NewProject\\Sprint 1" },
+      "areaLanguageOverride":      "Area",
+      "iterationLanguageOverride": "Iteration",
+      "createMissingNodes": true,
+      "skipRevisionWithInvalidAreaPath": false,
+      "skipRevisionWithInvalidIterationPath": false,
+      "replicateAllExistingNodes": false
+    }
+  ]
+}
+```
+
+**Features within the tool**:
+
+| Feature | Description |
+|---|---|
+| Regex-based area path mapping | Source path → target path via regex replace |
+| Regex-based iteration path mapping | Source path → target path via regex replace |
+| Auto-create missing area/iteration nodes | Call ADO API to create missing paths before import |
+| Language override | Map localised node names (e.g. Spanish "Área" → "Area") |
+| Skip revision on invalid area path | Drop revision if path cannot be resolved/created |
+| Skip revision on invalid iteration path | Drop revision if path cannot be resolved/created |
+| Replicate all nodes from source | Enumerate and create all area/iteration nodes regardless of whether any work item uses them |
+| Convert area paths to tags | Optionally flatten the tree into `System.Tags` instead of mapping (see also `TreeToTagField` in FieldMappingTool) |
+
+---
+
+### M3: WorkItemsModule — WorkItemTypeMapping Tool
+
+**Current state**: Work item types are written verbatim from source into `revision.json`. On import, if the type name differs, the import fails.
+
+**Proposed additions**:
+
+#### New Tool: `WorkItemTypeMappingTool` (see [T3](#t3-workitemtypemappingtool))
+
+```json
+{
+  "name": "WorkItems",
+  "tools": [
+    {
+      "type": "WorkItemTypeMapping",
+      "map": {
+        "User Story":    "Product Backlog Item",
+        "Issue":         "Impediment"
+      }
+    }
+  ]
+}
+```
+
+Applied during both export (stored in `revision.json` as `_mappedType`) and import (used as the target `workItemType` on creation).
+
+---
+
+### M4: WorkItemsModule — Missing Options
+
+Options that belong directly on the `WorkItems` module config rather than as separate tools.
+
+| Option | Config Key | Default | Description |
+|---|---|---|---|
+| Explicit work item ID list | `scopes[].type: "ids"` | — | New scope type: select work items by explicit ID list instead of WIQL |
+| Collapse revisions to single item | `collapseRevisions` | `false` | Write only the latest revision rather than the full history |
+| Maximum revision limit | `maxRevisions` | `0` (unlimited) | Cap the number of revisions written per work item |
+| Graceful failure tolerance | `maxGracefulFailures` | `0` (strict) | Continue past N item-level failures before aborting the module |
+| Generate migration comment | `generateMigrationComment` | `false` | Append a comment to each imported work item recording source ID, org, and timestamp |
+| Maximum attachment size | `extensions[Attachments].maxSizeBytes` | unlimited | Skip attachment download if file exceeds this size |
+| Link count filter | `extensions[Links].filterIfCountMatches` | — | Skip import of links if the work item already has a matching link count |
+| Outbound link checking | `extensions[Links].checkOutboundLinks` | `false` | Validate that outbound link targets exist before import |
+
+---
+
+### M5: TeamsModule
+
+**Current state**: Placeholder feature files exist. No implementation.
+
+**Why it matters**: Team settings, capacity, and iteration assignments are required to restore the full team operating model after migration.
+
+**Proposed Module**: `TeamsModule`
+
+**Scopes**:
+- `type: "teams"` with optional `filter` (team name pattern)
+- `type: "all"` — all teams in the project
+
+**Extensions**:
+
+| Extension | Description |
+|---|---|
+| `TeamIterations` | Export/import iteration path assignments per team |
+| `TeamMembers` | Export/import team member assignments |
+| `TeamCapacity` | Export/import sprint capacity planning data |
+| `TeamSettings` | Export/import team backlog, working days, and area config |
+
+**Dependency**: `TeamsModule` depends on `IdentitiesModule` (team members are identities).
+
+**Additional CLI feature**: Export the list of all teams to `teams.csv` as part of `discovery inventory`.
+
+---
+
+### M6: TestManagementModule
+
+**Current state**: No implementation. Not started.
+
+**Why it matters**: Test plans, suites, and cases represent significant engineering investment and are often a hard requirement for compliance-regulated migrations.
+
+**Proposed Module**: `TestManagementModule`
+
+**Scopes**:
+- `type: "plans"` with optional plan name filter
+- `type: "all"` — all test plans in the project
+
+**Extensions**:
+
+| Extension | Description |
+|---|---|
+| `TestPlans` | Export/import test plan definitions |
+| `TestSuites` | Export/import static and dynamic suite hierarchy |
+| `TestCases` | Export/import test case work items (delegates to `WorkItemsModule` for revision history) |
+| `SharedSteps` | Export/import shared step work items |
+| `SharedParameters` | Export/import shared parameter data sets |
+| `TestConfigurations` | Export/import test configurations |
+| `TestVariables` | Export/import test variables |
+
+**Dependency**: `TestManagementModule` depends on `WorkItemsModule` (test cases are work items).
+
+---
+
+### M7: GitModule
+
+**Current state**: Placeholder feature files exist. No implementation beyond name-mapping tool reference.
+
+**Proposed Module**: `GitModule`
+
+**Scopes**:
+- `type: "repositories"` with optional repo name filter
+- `type: "all"` — all repositories in the project
+
+**Extensions**:
+
+| Extension | Description |
+|---|---|
+| `Mirror` | Full `git --mirror` push: all branches, tags, and ref deletions |
+| `Additive` | Push branches/tags without deleting refs removed from source |
+| `RepositoryMapping` | Apply source→target repository name mapping (see `GitRepositoryMappingTool`) |
+
+**Behaviour**:
+- Enumerate repos from source via REST API.
+- Create the target repository if it does not exist (same name after mapping).
+- Perform a temporary bare clone, then push to target.
+- Safety: target projects must exist — they are not created automatically.
+- PAT values are never written to the package or logged.
+
+**Tool dependency**: `GitRepositoryMappingTool` (see [T5](#t5-gitrepositorymappingtool)).
+
+---
+
+### M8: SharedQueriesModule
+
+**Current state**: No implementation. Not started.
+
+**Proposed Module**: `SharedQueriesModule`
+
+**Scopes**:
+- `type: "folder"` with a root folder path
+- `type: "all"` — entire shared query tree
+
+**Extensions**:
+
+| Extension | Description |
+|---|---|
+| `FolderHierarchy` | Preserve the full folder structure on import |
+| `ProjectNameRewrite` | Rewrite project names embedded in WIQL query strings to match the target project |
+
+---
+
+### M9: ProcessDefinitionsModule
+
+**Current state**: No implementation. Not started.
+
+**Why this is high-effort**: The ADO Process API is complex; many operations (e.g. updating picklist IDs) are unsupported. This module is better served by the `admin field install` CLI commands for field-level work, and by the Microsoft `process-migrator` tool for full template migration.
+
+**Proposed Module**: `ProcessDefinitionsModule`
+
+**Scopes**:
+- `type: "processes"` with optional name filter
+
+**Extensions**:
+
+| Extension | Description |
+|---|---|
+| `WorkItemTypes` | Export/import custom work item type definitions |
+| `Fields` | Export/import field definitions and picklists |
+| `Layouts` | Export/import page/group/control layout definitions |
+| `States` | Export/import state workflow definitions |
+| `Rules` | Export/import field rules and behaviours |
+
+**Note**: Full process template migration (XML → Inherited process) may delegate to `microsoft/process-migrator` as an external tool invocation, similar to how TFS export delegates to a .NET 4.8 subprocess.
+
+---
+
+### M10: ProfilePicturesModule
+
+**Current state**: No implementation. Not started. Low priority.
+
+**Proposed Module**: `ProfilePicturesModule`
+
+**Extensions**:
+
+| Extension | Description |
+|---|---|
+| `ExportFromAD` | Export profile pictures from Azure Active Directory / Entra ID |
+| `Import` | Import profile pictures to target ADO organisation |
+
+---
+
+## Tools — Detail
+
+### T1: FieldMappingTool
+
+**Used by**: `WorkItemsModule`  
+**Purpose**: Apply a declared set of field transformation rules to each work item revision before it is written to the package (export) or applied to the target (import).
+
+**Invocation**: Declared in the `tools` array of the `WorkItems` module config. See [M1](#m1-workitemsmodule--fieldmapping) for the full map type list and JSON schema.
+
+**Key design rules**:
+- Maps are applied in declaration order.
+- `FieldSkip` maps remove the field from the revision before any write — they are not import-only.
+- All maps respect the `applyTo` work item type filter.
+- Map processing is a pure transformation (no I/O). The tool is injected as `IFieldMappingTool` and receives a `WorkItemRevision` value object; it returns a transformed copy.
+
+---
+
+### T2: NodeStructureTool
+
+**Used by**: `WorkItemsModule`, `TeamsModule`  
+**Purpose**: Remap `System.AreaPath` and `System.IterationPath` values before write/import; optionally create missing nodes in the target via the ADO Classification Nodes API.
+
+**Invocation**: Declared in the `tools` array of the relevant module config. See [M2](#m2-workitemsmodule--nodestructure-tool) for the JSON schema.
+
+**Key design rules**:
+- Node creation calls are idempotent (check before POST).
+- All path lookups are normalised (case-insensitive, trimmed).
+- Language map overrides apply before regex mapping (so localised node names resolve correctly).
+- The tool is injected as `INodeStructureTool`.
+
+---
+
+### T3: WorkItemTypeMappingTool
+
+**Used by**: `WorkItemsModule`  
+**Purpose**: Translate source work item type names to target names at both export time (stored in package) and import time (used for item creation).
+
+**Invocation**: Declared in the `tools` array of the `WorkItems` module config. See [M3](#m3-workitemsmodule--workitemtypemapping-tool) for the JSON schema.
+
+**Features**:
+- Bidirectional: a map entry translates both the type name in the revision and any type-name references in link targets.
+- Unmapped types pass through unchanged.
+- Export-time validation: warn if a mapped target type does not exist in the target process.
+
+---
+
+### T4: StringManipulatorTool
+
+**Used by**: `WorkItemsModule`  
+**Purpose**: Apply regex-based find-and-replace rules to string field values (e.g. stripping legacy prefixes, sanitising invalid characters).
+
+**Invocation**: Declared in the `tools` array of the `WorkItems` module config.
+
+```json
+{
+  "type": "StringManipulator",
+  "applyTo": ["System.Title", "System.Description"],
+  "rules": [
+    { "pattern": "^\\[LEGACY\\]\\s*",    "replacement": "" },
+    { "pattern": "[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F]", "replacement": "" }
+  ]
+}
+```
+
+**Features**:
+- `applyTo` field list (applies to all string fields if omitted).
+- Multiple ordered rules per invocation.
+- Invalid character cleanup as a named built-in rule: `{ "type": "StripControlCharacters" }`.
+- The tool is injected as `IStringManipulatorTool`.
+
+---
+
+### T5: GitRepositoryMappingTool
+
+**Used by**: `GitModule`, `WorkItemsModule` (link rewriting in `EmbeddedImages` and `Links` extensions)  
+**Purpose**: Map source repository names to target repository names; rewrite embedded git:// or PR URLs in work item HTML fields.
+
+**Invocation**: Declared in the `tools` array of `GitModule` and/or `WorkItems` module config.
+
+```json
+{
+  "type": "GitRepositoryMapping",
+  "map": {
+    "OldRepoName":    "NewRepoName",
+    "LegacyService":  "platform-service"
+  }
+}
+```
+
+---
+
+### T6: ChangesetMappingTool
+
+**Used by**: `WorkItemsModule` (link rewriting for TFVC changeset links)  
+**Purpose**: Map TFS changeset IDs to Git commit SHAs so that `Fixed In Changeset` links survive migration.
+
+**Invocation**: Declared in the `tools` array of `WorkItems` module config.
+
+```json
+{
+  "type": "ChangesetMapping",
+  "mappingFile": "changeset-to-commit.json"
+}
+```
+
+The mapping file is a flat `{ "12345": "abc123def456..." }` JSON dictionary produced either manually or by a future `discovery changeset-map` command.
+
+---
+
+### T7: WorkItemResolutionTool
+
+**Used by**: `WorkItemsModule` (import path)  
+**Status**: 🆕 ❌ Not implemented  
+**Priority**: High
+
+**Purpose**: Determine how the import path decides whether a work item already exists in the target before creating or updating it. Different work item types may require different resolution strategies — for example, standard types can use a `ReflectedWorkItemId` custom field, while types that cannot carry custom fields (e.g. `Shared Steps`, `Shared Parameter`) need a fallback such as a hyperlink, a title+type match, or a dedicated field on their inherited type.
+
+**The problem in detail**:
+
+The ADO process model allows customisation only of *inherited* work item types. System-locked types like `Shared Steps` and `Shared Parameter` cannot have custom fields added without first creating a custom WIT that inherits from them. In many target organisations this step has not been done, leaving those types with no way to carry a `ReflectedWorkItemId` field. Without a fallback, the import either fails, skips, or duplicates those items on every run.
+
+**Proposed config**:
+
+```json
+{
+  "name": "WorkItems",
+  "tools": [
+    {
+      "type": "WorkItemResolution",
+      "default": {
+        "strategy": "ReflectedWorkItemIdField",
+        "field": "Custom.ReflectedWorkItemId"
+      },
+      "overrides": [
+        {
+          "applyTo": ["Shared Steps", "Shared Parameter"],
+          "strategy": "ReflectedWorkItemIdHyperlink",
+          "hyperlinkComment": "ReflectedWorkItemId"
+        },
+        {
+          "applyTo": ["Test Case"],
+          "strategy": "ReflectedWorkItemIdField",
+          "field": "Custom.AltReflectedId"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Resolution strategies**:
+
+| Strategy | How it finds an existing item | Notes |
+|---|---|---|
+| `ReflectedWorkItemIdField` | Query target for `{field} = {sourceId}` | Default. Requires a custom field on the WIT. |
+| `ReflectedWorkItemIdHyperlink` | Query target for a hyperlink whose `comment` matches a configured key and whose URL contains the source work item ID | Works on any WIT including system-locked types. Hyperlinks are stored as links, not fields. |
+| `TitleAndTypeMatch` | Query target for work items with matching `System.Title` + `System.WorkItemType` | Fuzzy fallback only — may produce false positives if titles are not unique. |
+| `AlwaysCreate` | Never searches for an existing item — always creates a new one | Use when the target is known to be empty and deduplication is not required. |
+| `AlwaysSkip` | Never creates or updates — logs a warning and moves on | Use to suppress a specific type entirely during import. |
+
+**Key design rules**:
+- The `default` strategy applies to all work item types not matched by any `overrides` entry.
+- `overrides` entries are matched in declaration order; the first match wins.
+- The resolution result (`Found`, `NotFound`, `Skipped`) is recorded in the package checkpoint so reruns do not re-query items that were already resolved.
+- The tool is injected as `IWorkItemResolutionTool` and called by the import orchestrator **before** any write attempt.
+- Export is unaffected — this tool is import-only.
+
+**Interaction with `admin field install-reflected-id`** ([C4](#c4-admin-field-install-reflected-id)):  
+When using `ReflectedWorkItemIdHyperlink` as the fallback, no field installation is required for the affected types. The `admin field install-reflected-id` command should log a note when it detects that a WIT is system-locked and advise the operator to configure `WorkItemResolutionTool` with a `ReflectedWorkItemIdHyperlink` override for those types.
+
+---
+
+## Discovery Commands — Detail
+
+
+### D1: `discovery org-sync`
+
+**Status**: ❌ Not implemented  
+**Priority**: High
+
+**Purpose**: Enumerate all projects from every org in the `organisations` roster and upsert them (with IDs) back into the config. Equivalent to `Add-ProjectsToConfig.ps1` + `Search-ProcessesWeCareAbout.ps1`.
+
+**Behaviour**:
+1. Read `organisations` from the config file.
+2. For each enabled org, call `GET /_apis/projects` and `GET /_apis/work/processes`.
+3. Upsert any new projects (with `id`, `name`, `enabled: true`) into the org's `projects` array.
+4. Upsert any non-system processes (with `typeId`, `name`) into the org's `processes` array.
+5. Write the updated config back to the same file.
+
+**CLI syntax**:
+```
+devopsmigration discovery org-sync --config organisations.json
+devopsmigration discovery org-sync --config organisations.json --dry-run
+```
+
+**Config additions required**: `organisations[].projects[]` already exists. Add `organisations[].processes[]` with `typeId`, `name`, `enabled`.
+
+---
+
+### D2: `discovery inventory` — missing artefact types
+
+**Status**: 🔶 Partially implemented — work items and revisions are counted; all other artefact types are missing  
+**Priority**: Medium
+
+**Purpose**: Extend the existing `discovery inventory` command with additional per-project artefact counts. These are additions to the existing command, not a new command. Equivalent to the artefact coverage in `Generate-ProjectStats.ps1`.
+
+**Additional counts to add to `discovery inventory`**:
+
+| Artefact | API |
+|---|---|
+| Build/release pipelines | `GET /_apis/pipelines` |
+| Test plans | `GET /_apis/testplan/plans` |
+| Test suites (tree, per plan) | `GET /_apis/testplan/plans/{id}/suites?asTreeView=True` |
+| Git repositories | `GET /_apis/git/repositories` |
+| Shared steps | WIQL `WorkItemType = 'Shared Steps'` |
+| Process base template name | `GET /_apis/projects/{id}/properties` |
+| Process template name (custom) | `GET /_apis/work/processes/{typeId}` |
+
+**Output additions**:
+- New columns appended to the existing `inventory.csv` and `inventory.json` output.
+- Optional Excel export: `--format csv|json|xlsx` (default `csv`).
+
+**CLI syntax** (additions to existing flags, not a new command):
+```
+devopsmigration discovery inventory --config migration.json
+devopsmigration discovery inventory --config migration.json --output ./reports
+devopsmigration discovery inventory --config migration.json --output ./reports --format xlsx
+```
+
+---
+
+### D3: `discovery process`
+
+**Status**: 🆕 ❌ Not implemented  
+**Priority**: Medium
+
+**Purpose**: A new command that does two things in one pass:
+
+1. **Export** — dumps the full process metadata (fields, picklists, WIT definitions, layouts, states) for every configured org to an output folder. Equivalent to `Generate-ProcessOutput.ps1`.
+2. **Diff** — when both `source` and `target` are configured, compares the two process snapshots and produces a gap report: fields present in source but absent from target, value-map mismatches, layout differences, and WITs that cannot accept custom fields.
+
+This is specifically useful as a **pre-migration validation step** — run it before configuring `WorkItemsModule` field maps to understand what transformations are actually needed.
+
+**Behaviour**:
+1. For each enabled org (from `organisations`), enumerate non-system processes and their WITs.
+2. Fetch fields, picklists, layouts, and state definitions via the Process REST API.
+3. Write raw snapshots to `--output`.
+4. If both source and target are resolvable from config, produce a `process-diff.json` and `process-diff.md` report comparing:
+   - Fields in source WITs that are missing from the corresponding target WITs.
+   - Fields present in both but with mismatched types or picklist values.
+   - States present in source that have no counterpart in target (affects `FieldValue` maps).
+   - WITs that exist in source but are absent from target process (affects `WorkItemTypeMappingTool`).
+   - WITs that are system-locked in target (affects `WorkItemResolutionTool` strategy choice).
+
+**Output structure**:
+```
+output/
+  <org-name>/
+    fields.json                     ← all org-level WIT fields
+    lists.json                      ← picklist summary
+    lists/<id>.json                 ← picklist detail per list
+    processes.json                  ← all processes
+    processes/<process-name>/
+      <wit.referenceName>-LAYOUT.json
+      <wit.referenceName>-fields.json
+      <wit.referenceName>-states.json
+  process-diff.md                   ← human-readable gap report (source vs target)
+  process-diff.json                 ← machine-readable gap report
+```
+
+**CLI syntax**:
+```
+devopsmigration discovery process --config migration.json --output ./process-audit
+devopsmigration discovery process --config migration.json --output ./process-audit --diff-only
+devopsmigration discovery process --config migration.json --output ./process-audit --export-only
+```
+
+**Flags**:
+
+| Flag | Description |
+|---|---|
+| `--diff-only` | Skip raw export; only produce the diff report (requires both source and target in config) |
+| `--export-only` | Skip diff; only export raw process metadata |
+| `--output <dir>` | Override `Artefacts.WorkingDirectory` for output |
+
+**Relationship to other features**:
+- The diff report directly informs `WorkItemsModule` `FieldMappingTool` configuration ([T1](#t1-fieldmappingtool)) — it tells the operator exactly which `FieldValue` maps and `FieldToField` maps are needed.
+- WIT presence gaps inform `WorkItemTypeMappingTool` configuration ([T3](#t3-workitemtypemappingtool)).
+- System-locked WIT detection informs `WorkItemResolutionTool` override configuration ([T7](#t7-workitemresolutiontool)).
+- The raw export can be used as input to `admin field install` ([C3](#c3-admin-field-install)) to understand which fields need installing on the target before migration begins.
+
+---
+
+## CLI Features — Detail
+
+### C1: `config generate`
+
+**Status**: ❌ Not implemented  
+**Priority**: High
+
+**Purpose**: Stamp a library of scenario-config templates with per-org/per-project source values and write one populated config file per project. Equivalent to `Generate-ConfigurationsFromTemplates.ps1`.
+
+**Behaviour**:
+1. Read `organisations` from a roster config (multi-org, using the `organisations` array).
+2. For each enabled org, iterate each enabled project.
+3. For each template file in `--templates <dir>`, produce a populated copy under `--output <dir>/<org>/<project>/<template-name>.json`, substituting `source.orgOrCollection`, `source.project`, and `source.authentication.accessToken`.
+4. Target values (org, project, PAT) are left as template placeholders or taken from a separate `--target` config flag.
+
+**CLI syntax**:
+```
+devopsmigration config generate --config organisations.json --templates ./templates --output ./generated-configs
+devopsmigration config generate --config organisations.json --templates ./templates --output ./generated-configs --dry-run
+```
+
+**Config additions required**: None — uses existing `organisations[]` schema. Template files are standard scenario JSON configs with `{{source.orgOrCollection}}` / `{{source.project}}` substitution tokens.
+
+---
+
+### C2: `queue --batch`
+
+**Status**: ❌ Not implemented  
+**Priority**: Medium
+
+**Purpose**: Queue multiple migration jobs from a folder of generated scenario configs, submitting each to the control plane in sequence (or in parallel up to `--max-concurrent`). Equivalent to iterating over the output of `config generate` and calling `devopsmigration queue` for each.
+
+**CLI syntax**:
+```
+devopsmigration queue --batch ./generated-configs/myorg --follow
+devopsmigration queue --batch ./generated-configs/myorg --max-concurrent 3
+devopsmigration queue --batch ./generated-configs/myorg --filter "*.workItems.json"
+```
+
+**Notes**:
+- Each config in the batch is submitted as an independent `MigrationJob`.
+- `--follow` streams all job logs to a single multiplexed output.
+- `--max-concurrent` controls how many jobs run simultaneously (default: 1 — sequential).
+- The batch command itself has no migration logic; it is a loop over `QueueCommand`.
+
+---
+
+### C3: `admin field install`
+
+**Status**: ❌ Not implemented  
+**Priority**: High
+
+**Purpose**: Idempotently install custom fields (with picklists and form controls) across all configured orgs and processes. Equivalent to `Install-CustomFields.ps1`.
+
+**CLI syntax**:
+```
+devopsmigration admin field install --config migration.json --fields ./fields
+devopsmigration admin field install --config migration.json --fields ./fields --dry-run
+devopsmigration admin field install --config migration.json --fields ./fields --validate-only
+```
+
+**Field definition file** (`fields/<refname>.json`):
+```json
+{
+  "referenceName": "Custom.MyField",
+  "createFieldPOST":   { ... },
+  "addFieldPOST":      { ... },
+  "createPicklistPOST": { ... },
+  "createControlPOST": { ... },
+  "defaultGroupLabel": "Details"
+}
+```
+
+**Fields manifest** (`fields.json`):
+```json
+{
+  "fields": [
+    { "refname": "Custom.MyField", "enabled": true },
+    { "refname": "Custom.OtherField", "enabled": false }
+  ]
+}
+```
+
+**Idempotency rules**:
+1. Check if the field exists at org level — create if absent.
+2. Check if the picklist exists — create or update items if needed.
+3. Check if the field is on the WIT in the process — add if absent.
+4. Check if the control is in the target group on the layout — add if absent.
+5. Validate `referenceName` consistency across all POST bodies before any API call.
+
+---
+
+### C4: `admin field install-reflected-id`
+
+**Status**: ❌ Not implemented  
+**Priority**: High
+
+**Purpose**: Install `Custom.ReflectedWorkItemId` across all configured orgs, all non-system processes, and all WITs (creating custom WIT inheritors for system WITs as needed). Equivalent to `Install-ReflectedWorkItemID.ps1`.
+
+**CLI syntax**:
+```
+devopsmigration admin field install-reflected-id --config migration.json
+devopsmigration admin field install-reflected-id --config migration.json --dry-run
+```
+
+**Field definition** read from a standard field definition file (same format as `C3`), defaulting to the bundled `ReflectedWorkItemId.json` definition. Accepts `--field-file <path>` to override.
+
+---
+
+### C5: `admin field delete`
+
+**Status**: ❌ Not implemented  
+**Priority**: Low
+
+**Purpose**: Delete a field by reference name from all enabled orgs. Equivalent to `Delete-CustomField.ps1`.
+
+**CLI syntax**:
+```
+devopsmigration admin field delete --config migration.json --field Custom.MyField
+devopsmigration admin field delete --config migration.json --field Custom.MyField --dry-run
+```
+
+---
+
+### C6: `admin page install`
+
+**Status**: ❌ Not implemented  
+**Priority**: Medium
+
+**Purpose**: Idempotently add pages and groups to WIT form layouts across all configured orgs and processes. Equivalent to `Install-CustomPages.ps1`.
+
+**CLI syntax**:
+```
+devopsmigration admin page install --config migration.json --pages ./pages
+devopsmigration admin page install --config migration.json --pages ./pages --dry-run
+```
+
+**Page definition file** (`pages/<name>.json`):
+```json
+{
+  "name": "Portfolio",
+  "enabled": true,
+  "workItemTypes": ["Epic", "Feature"],
+  "PagePOST": {
+    "label": "Portfolio",
+    "sections": [
+      {
+        "id": "Section1",
+        "groups": [ { "label": "Strategic Context", "controls": [...] } ]
+      }
+    ]
+  }
+}
+```
+
+**Idempotency rules**:
+1. Enumerate all non-system processes and WITs.
+2. Auto-create a custom WIT inheritor if the system WIT cannot be modified directly.
+3. Add the page if it doesn't exist; otherwise proceed to group check.
+4. Add missing groups to the correct section; skip groups already present.
+
+---
+
+## Config Schema Additions Required
+
+The following additions to the scenario JSON schema are implied by the proposals above:
+
+| Field | Location | Purpose |
+|---|---|---|
+| `modules[].tools[]` | Module config | Array of tool declarations injected into the module |
+| `organisations[].processes[]` | Config root | Process metadata discovered by `discovery org-sync` |
+| `organisations[].projects[].enabled` | Config root | Already in schema; documented as relevant to `config generate` |
+| `scopes[].type: "ids"` | Module scopes | New scope type for explicit work item ID list |
+| `modules[].collapseRevisions` | WorkItems module | Boolean option |
+| `modules[].maxRevisions` | WorkItems module | Integer option |
+| `modules[].maxGracefulFailures` | WorkItems module | Integer option |
+| `modules[].generateMigrationComment` | WorkItems module | Boolean option |
+| `extensions[Attachments].maxSizeBytes` | WorkItems/Attachments extension | Integer option |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,7 +216,7 @@ Key properties:
 3. Migration Agent worker service (poll, execute, heartbeat, report) — spawned as child process by CLI
 4. Job Engine (orchestrator + modules contract + cursors)
 5. `IArtefactStore` + `FileSystemArtefactStore` (`file:///` URI)
-6. `IStateStore` / `PackageCheckpointStateStore` (`Checkpoints/` inside package)
+6. `IStateStore` / `PackageCheckpointStateStore` (`.migration/Checkpoints/` inside package)
 7. `IProgressSink` with `ConsoleProgressSink` + `PackageProgressSink` ✅
 8. `ControlPlaneClient` (CLI always uses this to talk to the in-process or remote control plane)
 9. WorkItems module (REST)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -192,7 +192,7 @@ All job management commands live under the `manage` sub-command.
 | `manage list` | List all jobs visible to the authenticated user, with current status and progress. |
 | `manage status` | Display job state and per-module progress for a specific job. |
 | `manage progress` | Fetch a snapshot of `ProgressEvent` records from the job ring buffer. Prints buffered events as NDJSON and exits. Requires `--job`. |
-| `manage diagnostics` | Download package diagnostic log files (`Logs/agent.jsonl`) for a completed job. Accepts `--level` to filter by minimum severity. Requires `--job`. |
+| `manage diagnostics` | Download package diagnostic log files (`.migration/Logs/agent.jsonl`) for a completed job. Accepts `--level` to filter by minimum severity. Requires `--job`. |
 | `manage pause` | Signal the running Migration Agent to checkpoint and pause. |
 | `manage resume` | Resume a paused job (re-queues it for Migration Agent pickup). |
 | `manage cancel` | Cancel a queued or running job. |
@@ -366,7 +366,7 @@ When `Environment.Type` is `Standalone` (the default), the CLI starts `LocalStac
 - Control plane starts on `http://localhost:{port}` as an in-process host (default: `5100`).
 - Agents run as in-process workers.
 - `IArtefactStore` is `FileSystemArtefactStore`.
-- `IStateStore` is `PackageCheckpointStateStore` (writes `Checkpoints/` inside the package).
+- `IStateStore` is `PackageCheckpointStateStore` (writes `.migration/Checkpoints/` inside the package).
 - Any machine with network access to the host can attach a TUI and monitor the migration.
 
 ### Hosted (Cloud)
@@ -418,6 +418,6 @@ The CLI recomputes `configHash` from the config file and queries the control pla
 ### Notes
 
 - `manage status` is a read-only poll — it never affects the running job.
-- `manage progress` returns a snapshot of buffered events — earlier events may be in `Logs/progress.jsonl` in the package.
-- `manage diagnostics` downloads diagnostic logs from the package's `Logs/agent.jsonl`.
+- `manage progress` returns a snapshot of buffered events — earlier events may be in `.migration/Logs/progress.jsonl` in the package.
+- `manage diagnostics` downloads diagnostic logs from the package's `.migration/Logs/agent.jsonl`.
 - `manage pause`, `manage resume`, `manage cancel` are the only commands that change job state.

--- a/docs/concurrent-write-detection.md
+++ b/docs/concurrent-write-detection.md
@@ -19,7 +19,7 @@ Agent A                          Agent B
 
 This leads to **silent data loss**. Example:
 - Package is at revision 100
-- Agent A processes revisions 101–150 and writes `Checkpoints/revision.cursor`
+- Agent A processes revisions 101–150 and writes `.migration/Checkpoints/revision.cursor`
 - Agent B processes revisions 101–120 (slower, late assignment) and overwrites the same cursor
 - Result: Revisions 121–150 are never re-attempted if Agent A crashes; cursor points to wrong location
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -55,7 +55,7 @@ The control plane does **not** run the Job Engine, call source or target APIs, o
 | `GET` | `/jobs/{jobId}/diagnostics` | Return buffered diagnostic log records as a JSON array (snapshot). Accepts `?level=` filter (`Trace`, `Debug`, `Information`, `Warning`, `Error`, `Critical`). Requires same auth as `GET /jobs/{jobId}`. |
 | `GET` | `/jobs/{jobId}/diagnostics?follow=true` | **SSE stream**: push diagnostic log records in real time. Accepts `?level=` filter. Heartbeat comment every 15 s. Requires same auth as `GET /jobs/{jobId}`. |
 | `GET` | `/jobs/{jobId}/telemetry` | Return the latest `MetricSnapshot` for the job. `204 No Content` when no snapshot has been pushed yet by the Migration Agent. `MetricSnapshot` is a versioned DTO whose fields correspond to registered OTel instruments — see `WellKnownMetricNames` for the canonical reference. Requires same auth as `GET /jobs/{jobId}`. |
-| `GET` | `/jobs/{jobId}/logs/download` | Download the package log files (`Logs/progress.jsonl` and `Logs/agent.jsonl`) for a completed job. Requires same auth as `GET /jobs/{jobId}`. |
+| `GET` | `/jobs/{jobId}/logs/download` | Download the package log files (`.migration/Logs/progress.jsonl` and `.migration/Logs/agent.jsonl`) for a completed job. Requires same auth as `GET /jobs/{jobId}`. |
 
 ### Migration Agent Protocol
 
@@ -125,7 +125,7 @@ The control plane stores each event in a bounded per-job **ring buffer** (`Bound
 
 - Powers `GET /jobs/{jobId}/progress` (snapshot of current buffer contents)
 - Powers `GET /jobs/{jobId}/progress?follow=true` (SSE broadcast from the buffer to all active subscribers)
-- Is in-memory only — it is cleared when the control plane restarts, but the package's `Logs/progress.jsonl` is the durable record
+- Is in-memory only — it is cleared when the control plane restarts, but the package's `.migration/Logs/progress.jsonl` is the durable record
 
 The ring buffer always reflects the most recent activity. For very long jobs, oldest events are evicted to stay within capacity. The cursor in the package remains the authoritative resume state.
 
@@ -228,7 +228,7 @@ The control plane persists:
 - Job states and state transitions
 - Latest progress per module (for display; not authoritative for resume)
 - Lease records
-- Log references (URIs into blob storage; logs themselves are stored in the package's `Logs/` folder by the Migration Agent)
+- Log references (URIs into blob storage; logs themselves are stored in the package's `.migration/Logs/` folder by the Migration Agent)
 
 ### Technology
 
@@ -332,7 +332,7 @@ A background service runs this query on a configurable interval (default: every 
 The control plane deliberately does **not** store:
 
 - The migration package contents (revision files, cursors, attachments) — those live in `IArtefactStore` (filesystem or Azure Blob).
-- Log file contents — logs are written into the package's `Logs/` folder by the Migration Agent; the control plane stores only the URI prefix for the TUI to tail.
+- Log file contents — logs are written into the package's `.migration/Logs/` folder by the Migration Agent; the control plane stores only the URI prefix for the TUI to tail.
 - Source or target credentials — only Key Vault references (opaque strings) are stored in `job_json`; the actual secret is never held in the database.
 
 ---

--- a/docs/migration-agent.md
+++ b/docs/migration-agent.md
@@ -19,11 +19,11 @@ The package contract, modules, and cursors are unchanged across all deployment t
 | Mount artefact store | Connect to the package URI from the job definition (filesystem or blob). See [.agents/context/artefact-store.md](../.agents/context/artefact-store.md). |
 | Resolve secrets | Fetch credentials from Key Vault references in the job definition before executing. |
 | Run orchestrator | Execute `ExportAsync`, `ImportAsync`, or both in sequence, exactly as in local mode. |
-| Write cursors | Write checkpoint cursors into the package's `Checkpoints/` folder after each stage, as always. |
+| Write cursors | Write checkpoint cursors into the package's `.migration/Checkpoints/` folder after each stage, as always. |
 | Heartbeat | Signal liveness to the control plane at regular intervals. |
-| Report progress | Emit `ProgressEvent` via `IProgressSink` after each stage. Three sinks run simultaneously: `ConsoleProgressSink` (terminal), `PackageProgressSink` (`Logs/progress.jsonl`), and `ControlPlaneProgressSink` (POST to control plane ring buffer for live TUI streaming). |
+| Report progress | Emit `ProgressEvent` via `IProgressSink` after each stage. Three sinks run simultaneously: `ConsoleProgressSink` (terminal), `PackageProgressSink` (`.migration/Logs/progress.jsonl`), and `ControlPlaneProgressSink` (POST to control plane ring buffer for live TUI streaming). |
 | Record metrics | Record OTel metrics via `IMigrationMetrics` during job execution (execution counters, payload histograms, duration). Metric aggregates are pushed to the control plane via `ControlPlaneTelemetryTimer`. |
-| Write package logs | Write structured logs to `Logs/` in the package via `IArtefactStore`. |
+| Write package logs | Write structured logs to `.migration/Logs/` in the package via `IArtefactStore`. |
 | Signal completion or failure | Call the control plane's complete or fail endpoint when the job finishes. |
 
 The Agent does **not** accept job submissions, manage other Agents, or store job state. All job coordination is `ControlPlaneHost`'s responsibility.
@@ -41,7 +41,7 @@ Poll /agents/lease
        ├─ Start heartbeat loop (background)
        ├─ Register IProgressSink composite:
        │    ├─ ConsoleProgressSink     (NDJSON to terminal)
-       │    ├─ PackageProgressSink     (Logs/progress.jsonl in package)
+       │    ├─ PackageProgressSink     (.migration/Logs/progress.jsonl in package)
        │    └─ ControlPlaneProgressSink (POST /agents/lease/{id}/progress)
        └─ Run Job Engine
             ├─ ExportAsync (if mode = Export or Both)
@@ -67,7 +67,7 @@ For network zone isolation — where source and target systems are in different 
 
 Agents are stateless. All durable state lives either:
 
-- In the migration package (`revision.json`, cursors, `idmap.db`, `Logs/`) via `IArtefactStore` and `IStateStore`.
+- In the migration package (`revision.json`, cursors, `idmap.db`, `.migration/Logs/`) via `IArtefactStore` and `IStateStore`.
 - In the control plane (job status, latest reported progress).
 
 An Agent may be stopped, rescheduled, or replaced at any point. The new Agent reads the cursor to determine where to resume. This makes Agents safe to run in auto-scaling container environments.
@@ -110,7 +110,7 @@ See [docs/architecture.md — Data Residency](architecture.md#data-residency--ag
 
 Migration Agents write structured logs to both:
 
-- `Logs/` in the package (durable, included in zip).
+- `.migration/Logs/` in the package (durable, included in zip).
 - The control plane (pushed in real time via the lease API for TUI tailing).
 
 Both outputs use the same structured format (OpenTelemetry-compatible). No `Console.WriteLine` in module code.

--- a/docs/packaging-zip.md
+++ b/docs/packaging-zip.md
@@ -22,7 +22,7 @@ migration-package.zip → PackageRoot/
 
 - Unpack extracts to a specified directory before import begins.
 - If `artefacts.zip` is `true` in configuration, unpack is handled automatically by the runner before import.
-- Partial extraction (e.g., extracting only `Checkpoints/` for cursor inspection) is a supported tooling use case.
+- Partial extraction (e.g., extracting only `.migration/Checkpoints/` for cursor inspection) is a supported tooling use case.
 
 ### Guarantees
 
@@ -30,12 +30,12 @@ Because the WorkItems layout is deterministic (lexicographic folder names derive
 
 - **Order preservation:** A zip file unpacked to any platform produces the same folder traversal order.
 - **Streaming import compatibility:** Streaming import works identically on a packed-then-unpacked package as on an in-place export.
-- **Determinism:** Given the same export input, two independent runs produce structurally identical packages (excluding `runId`, timestamps in `manifest.json`, and `Logs/`).
+- **Determinism:** Given the same export input, two independent runs produce structurally identical packages (excluding `runId`, timestamps in `manifest.json`, and `.migration/Logs/`).
 
 ### What Zip Does Not Affect
 
-- Cursor state (`Checkpoints/`) is included in the zip and resumes correctly after unpack.
-- ID maps (`Checkpoints/idmap.db` or `idmap.json`) are included.
+- Cursor state (`.migration/Checkpoints/`) is included in the zip and resumes correctly after unpack.
+- ID maps (`.migration/Checkpoints/idmap.db` or `idmap.json`) are included.
 - Identity descriptors and mappings (`Identities/`) are included.
 
 ### Large Package Considerations

--- a/docs/source-types.md
+++ b/docs/source-types.md
@@ -72,7 +72,7 @@ For TFC/Azure DevOps Server source types, the `devopsmigration discovery invento
 Regardless of source type, data written to the package must conform to the schema versions declared in `manifest.json`. The exporter or adapter layer is responsible for:
 
 1. Validating its own output before writing.
-2. Emitting a validation report to `Logs/` if any anomalies are found.
+2. Emitting a validation report to `.migration/Logs/` if any anomalies are found.
 3. Failing fast if required fields are absent.
 
 The control plane performs a secondary validation pass before beginning import when running in `Both` mode.

--- a/docs/tfs-exporter.md
+++ b/docs/tfs-exporter.md
@@ -280,7 +280,7 @@ The adapter MUST NOT kill the subprocess directly. Instead:
 
 1. When `CancellationToken` fires, the adapter writes a sentinel file at `CancellationSentinelPath`.
 2. The subprocess polls for this file at regular intervals (≤ 1 second).
-3. On detecting the file, the subprocess writes its current cursor to `Checkpoints/TfsExporter.cursor`, writes a `Failed` stdout line with `errorCode: "Cancelled"`, and exits with code `2`.
+3. On detecting the file, the subprocess writes its current cursor to `.migration/Checkpoints/TfsExporter.cursor`, writes a `Failed` stdout line with `errorCode: "Cancelled"`, and exits with code `2`.
 4. The adapter deletes the sentinel file after the subprocess exits.
 
 This gives the subprocess a chance to flush its current cursor before stopping, enabling clean resume.
@@ -289,7 +289,7 @@ This gives the subprocess a chance to flush its current cursor before stopping, 
 
 ## Resume and Cursor Handoff
 
-The subprocess writes a cursor file `Checkpoints/TfsExporter.cursor` inside the package after each revision folder is written. When the Job Engine resumes a TFS export job:
+The subprocess writes a cursor file `.migration/Checkpoints/TfsExporter.cursor` inside the package after each revision folder is written. When the Job Engine resumes a TFS export job:
 
 1. The adapter reads the cursor file and passes its value as `resumeFromCursor` in `TfsExportRequest`.
 2. The adapter passes this to the subprocess via a `--resume` CLI argument (the cursor value contains no credentials).
@@ -368,7 +368,7 @@ Activity sources registered: `WorkItemExport`, `AttachmentDownload`.
 
 ### Serilog Integration
 
-Logs are forwarded to the OTLP collector via `Serilog.Sinks.OpenTelemetry` when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. File sinks (`Logs/`) are always active.
+Logs are forwarded to the OTLP collector via `Serilog.Sinks.OpenTelemetry` when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. File sinks (`.migration/Logs/`) are always active.
 
 ### Package Dependencies
 
@@ -389,7 +389,7 @@ The `DevOpsMigrationPlatform.CLI.TfsMigration` project (net481) MUST:
 - Write NDJSON progress lines to stdout, flushed after each line.
 - Write error detail to stderr.
 - Write package files to `--output` following canonical layouts.
-- Write cursor to `Checkpoints/TfsExporter.cursor` after each revision folder.
+- Write cursor to `.migration/Checkpoints/TfsExporter.cursor` after each revision folder.
 - Poll the cancellation sentinel file and abort gracefully when it appears.
 - Exit with the appropriate exit code.
 
@@ -506,8 +506,8 @@ public sealed record TfsImportRequest
 
 | Executor | Direction | Package access | TFS OM direction | Checkpoint file |
 |---|---|---|---|---|
-| `TfsExportAgent` | TFS → Package | Write via `IArtefactStore` | Read (TFS OM queries) | `Checkpoints/TfsExporter.cursor` |
-| `TfsImportAgent` *(future)* | Package → TFS | Read via `IArtefactStore` | Write (TFS OM mutations) | `Checkpoints/TfsImporter.cursor` |
+| `TfsExportAgent` | TFS → Package | Write via `IArtefactStore` | Read (TFS OM queries) | `.migration/Checkpoints/TfsExporter.cursor` |
+| `TfsImportAgent` *(future)* | Package → TFS | Read via `IArtefactStore` | Write (TFS OM mutations) | `.migration/Checkpoints/TfsImporter.cursor` |
 
 Both executors use the same `IArtefactStore`, `IStateStore`, `IProgressSink`, and NDJSON stdout protocol. The only substantive difference is TFS OM read vs write.
 
@@ -520,7 +520,7 @@ The `TfsImportAgent` MUST:
 - Write NDJSON progress lines to stdout, flushed after each line.
 - Write error detail to stderr.
 - Read package files from `--input` following canonical layouts (streaming — never load all revisions into memory).
-- Write cursor to `Checkpoints/TfsImporter.cursor` after each revision applied.
+- Write cursor to `.migration/Checkpoints/TfsImporter.cursor` after each revision applied.
 - Poll the cancellation sentinel file and abort gracefully when it appears.
 - Exit with the same exit code scheme as the exporter.
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -66,7 +66,7 @@ interface IProgressSink
 | Sink | Description |
 |---|---|
 | `ConsoleProgressSink` | Renders a live progress log in the terminal (local CLI output). |
-| `PackageProgressSink` | Writes structured events to `Logs/progress.jsonl` in the package (always active). |
+| `PackageProgressSink` | Writes structured events to `.migration/Logs/progress.jsonl` in the package (always active). |
 | `ControlPlaneProgressSink` | POSTs each event to `POST /agents/lease/{leaseId}/progress` for real-time TUI streaming. |
 
 All three sinks run simultaneously when the Migration Agent holds a lease. The Job Engine sees only `IProgressSink`; it does not know which sinks are active.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -106,7 +106,7 @@ Pre-flight validation runs:
 ### Failure Behaviour
 
 - Any check failure causes immediate termination unless `policies.validation.continueOnError` is `true` in configuration.
-- All failures are written to `Logs/` with enough detail to identify the offending file and field.
+- All failures are written to `.migration/Logs/` with enough detail to identify the offending file and field.
 - The run does not begin import if any pre-flight check fails under the default policy.
 
 ---
@@ -155,7 +155,7 @@ Each module's `ValidateAsync` is called during the pre-flight pass. It must:
 
 - Check that all required fields are present in every artefact file it owns.
 - Check schema version compatibility against `manifest.json`.
-- Report anomalies to `Logs/` rather than silently skipping them.
+- Report anomalies to `.migration/Logs/` rather than silently skipping them.
 - Fail fast on missing required fields (unless `continueOnError` is set).
 - Have no side effects on the package or the target system.
 
@@ -165,7 +165,7 @@ See [docs/modules.md](modules.md) for the full `IModule` contract and [.agents/g
 
 ## Validation Report
 
-After validation completes, a machine-readable report is written to `Logs/validation-report.json`:
+After validation completes, a machine-readable report is written to `.migration/Logs/validation-report.json`:
 
 ```json
 {

--- a/docs/work-item-iteration-pattern.md
+++ b/docs/work-item-iteration-pattern.md
@@ -306,7 +306,7 @@ Each revision folder is processed through four sequential stages via `RevisionFo
 
 | Stage | Name | Description |
 |-------|------|-------------|
-| A | `CreatedOrUpdated` | Create or resolve target work item; record ID mapping in `Checkpoints/idmap.db` |
+| A | `CreatedOrUpdated` | Create or resolve target work item; record ID mapping in `.migration/Checkpoints/idmap.db` |
 | B | `AppliedFields` | Apply all fields (with identity resolution); rewrite embedded image URLs |
 | C | `AppliedLinks` | Add related links, external links, and hyperlinks (skip duplicates) |
 | D | `UploadedAttachments` | Stream attachment binaries to the target (skip already-uploaded) |
@@ -315,7 +315,7 @@ A cursor is written after each stage. On resume, completed stages are skipped.
 
 ### ID Mapping: idmap.db
 
-The `SqliteIdMapStore` maintains `Checkpoints/idmap.db` (SQLite, package-local):
+The `SqliteIdMapStore` maintains `.migration/Checkpoints/idmap.db` (SQLite, package-local):
 
 - `work_item_map (source_id PK, target_id)` — source-to-target work item ID mapping.
 - `attachment_map (source_work_item_id, revision_index, relative_path, target_attachment_id)` — idempotency for attachment uploads.

--- a/features/cli/export/export-follow-and-level.feature
+++ b/features/cli/export/export-follow-and-level.feature
@@ -6,12 +6,12 @@ Feature: Export follow and level options
   Scenario: Export with explicit log level writes records at that level to the package
     Given an operator runs "export --config migration.json --level Debug"
     When the job executes on the agent
-    Then "Logs/agent.jsonl" in the package contains records at Debug level and above
+    Then ".migration/Logs/agent.jsonl" in the package contains records at Debug level and above
 
   Scenario: Export with default log level writes Information and above
     Given an operator runs "export --config migration.json" without a --level option
     When the job executes on the agent
-    Then "Logs/agent.jsonl" in the package contains only Information level records and above
+    Then ".migration/Logs/agent.jsonl" in the package contains only Information level records and above
 
   Scenario: Export without follow in remote mode prints job ID and exits
     Given an operator runs "export --config migration.json --url https://cp.example.com"

--- a/features/export/work-items/revisions/export-work-item-revisions.feature
+++ b/features/export/work-items/revisions/export-work-item-revisions.feature
@@ -24,10 +24,10 @@ Feature: Export Work Item Revisions
   Scenario: Export records a cursor after each revision is written
     Given the export module begins writing revision folders
     When the export module successfully writes a revision folder
-    Then the cursor file at "Checkpoints/workitems.cursor.json" is updated with the last processed revision path
+    Then the cursor file at ".migration/Checkpoints/workitems.cursor.json" is updated with the last processed revision path
 
   Scenario: Export resumes from the cursor after an interruption
-    Given the cursor file at "Checkpoints/workitems.cursor.json" records the last processed folder as "WorkItems/2024-01-15/00638412345678-42-1/"
+    Given the cursor file at ".migration/Checkpoints/workitems.cursor.json" records the last processed folder as "WorkItems/2024-01-15/00638412345678-42-1/"
     When the export module is re-run
     Then the export skips all revision folders at or before "WorkItems/2024-01-15/00638412345678-42-1/"
     And the export continues from the next unprocessed revision

--- a/features/platform/checkpointing/cursor-resume.feature
+++ b/features/platform/checkpointing/cursor-resume.feature
@@ -5,27 +5,27 @@ Feature: Cursor-Based Resume and Checkpointing
 
   Background:
     Given the migration platform is configured to checkpoint progress after each unit of work
-    And the checkpoint location is "Checkpoints/<module>.cursor.json"
+    And the checkpoint location is ".migration/Checkpoints/<module>.cursor.json"
 
   Scenario: Cursor file is created on the first successful write
     Given no cursor file exists for the WorkItems module
     When the WorkItems module successfully processes its first revision folder
-    Then "Checkpoints/workitems.cursor.json" is created
+    Then the cursor file for the WorkItems module is created
     And the cursor records the path of the last successfully processed folder
 
   Scenario: Cursor file is updated after each successfully processed revision
     Given the WorkItems module has already processed 10 revision folders
     When the WorkItems module processes the 11th revision folder
-    Then "Checkpoints/workitems.cursor.json" is updated to record the 11th folder path
+    Then the cursor file for the WorkItems module is updated to record the 11th folder path
 
   Scenario: Resume skips all revision folders up to and including the cursor position
-    Given "Checkpoints/workitems.cursor.json" records "WorkItems/2024-03-10/00638500000000-100-4/"
+    Given the cursor file for the WorkItems module records "WorkItems/2024-03-10/00638500000000-100-4/"
     When the WorkItems module starts on a second run
     Then all folders lexicographically less than or equal to "WorkItems/2024-03-10/00638500000000-100-4/" are skipped
     And the module resumes processing from the next folder after the cursor position
 
   Scenario: A run with no cursor starts from the beginning of the package
-    Given "Checkpoints/workitems.cursor.json" does not exist
+    Given the cursor file for the WorkItems module does not exist
     When the WorkItems module starts
     Then the module processes all revision folders from the first lexicographic path
 
@@ -45,5 +45,5 @@ Feature: Cursor-Based Resume and Checkpointing
   Scenario: Multiple modules maintain independent cursors without interference
     Given both the WorkItems module and the AreaPaths module are running
     When each module processes its respective data
-    Then "Checkpoints/workitems.cursor.json" and "Checkpoints/areapaths.cursor.json" are independent files
+    Then the WorkItems module and the AreaPaths module have independent cursor files
     And updating one cursor does not affect the other

--- a/features/platform/checkpointing/import-cursor-resume.feature
+++ b/features/platform/checkpointing/import-cursor-resume.feature
@@ -10,7 +10,7 @@ Feature: Import Cursor Resume
   @cursor-resume
   Scenario: Interrupted import resumes from the last cursor position
     Given an import has previously processed some revision folders
-    And a cursor file exists at "Checkpoints/workitems.cursor.json" with stage "Completed"
+    And a cursor file exists at ".migration/Checkpoints/workitems.cursor.json" with stage "Completed"
     When the import is restarted
     Then all revision folders at or before the cursor "lastProcessed" value are skipped
     And import processing resumes from the first folder after the cursor position
@@ -25,8 +25,8 @@ Feature: Import Cursor Resume
 
   @cursor-resume
   Scenario: Force-fresh deletes the cursor but preserves the ID map
-    Given an existing cursor file at "Checkpoints/workitems.cursor.json"
-    And an existing ID map database at "Checkpoints/idmap.db"
+    Given an existing cursor file at ".migration/Checkpoints/workitems.cursor.json"
+    And an existing ID map database at ".migration/Checkpoints/idmap.db"
     When the import is run with the "--force-fresh" flag
     Then the cursor file is deleted before import begins
     And the ID map database is preserved

--- a/features/platform/observability/endpoint-rename.feature
+++ b/features/platform/observability/endpoint-rename.feature
@@ -22,7 +22,7 @@ Feature: Endpoint and CLI command rename
   Scenario: Manage diagnostics downloads diagnostic logs from the package
     Given a completed job with diagnostic logs in the package
     When an operator runs "manage diagnostics --job <id>"
-    Then diagnostic log records from "Logs/agent.jsonl" are downloaded and displayed
+    Then diagnostic log records from ".migration/Logs/agent.jsonl" are downloaded and displayed
 
   Scenario: Manage diagnostics filters by level
     Given a completed job with diagnostic logs at multiple levels

--- a/features/platform/observability/log-download.feature
+++ b/features/platform/observability/log-download.feature
@@ -4,15 +4,15 @@ Feature: Package log download
   So that I can access diagnostic and progress logs without direct filesystem access
 
   Scenario: Download progress log file from the package
-    Given a completed job with "Logs/progress.jsonl" in the package
+    Given a completed job with ".migration/Logs/progress.jsonl" in the package
     When a client calls the download endpoint with type "progress"
-    Then the response body contains the contents of "Logs/progress.jsonl"
+    Then the response body contains the contents of ".migration/Logs/progress.jsonl"
     And the content type is "application/x-ndjson"
 
   Scenario: Download diagnostics log file from the package
-    Given a completed job with "Logs/agent.jsonl" in the package
+    Given a completed job with ".migration/Logs/agent.jsonl" in the package
     When a client calls the download endpoint with type "diagnostics"
-    Then the response body contains the contents of "Logs/agent.jsonl"
+    Then the response body contains the contents of ".migration/Logs/agent.jsonl"
     And the content type is "application/x-ndjson"
 
   Scenario: Download works with filesystem package URI
@@ -21,6 +21,6 @@ Feature: Package log download
     Then the control plane reads from the filesystem artefact store and returns the file
 
   Scenario: Download returns 404 when log file does not exist
-    Given a completed job where "Logs/agent.jsonl" was not produced
+    Given a completed job where ".migration/Logs/agent.jsonl" was not produced
     When a client calls the download endpoint with type "diagnostics"
     Then the response status is 404

--- a/features/platform/observability/package-diagnostics-sink.feature
+++ b/features/platform/observability/package-diagnostics-sink.feature
@@ -8,23 +8,23 @@ Feature: Package diagnostics sink persistence
 
   Scenario: Warning and error log records are written to the package
     When a warning or error log record is emitted by the agent
-    Then a structured NDJSON log record is appended to "Logs/agent.jsonl" in the package
+    Then a structured NDJSON log record is appended to ".migration/Logs/agent.jsonl" in the package
 
   Scenario: Diagnostic log records contain required fields
     Given the agent has written diagnostic records to the package
-    When an operator opens "Logs/agent.jsonl"
+    When an operator opens ".migration/Logs/agent.jsonl"
     Then each line is a valid JSON object containing timestamp, level, category, and message
     And lines with exceptions also contain an exception field
 
   Scenario: Log records below configured minimum level are discarded
     Given the agent diagnostic log level is set to "Information"
     When a Trace or Debug log record is emitted
-    Then the record is not written to "Logs/agent.jsonl"
+    Then the record is not written to ".migration/Logs/agent.jsonl"
 
   Scenario: Log records at or above configured minimum level are written
     Given the agent diagnostic log level is set to "Information"
     When an Information, Warning, or Error log record is emitted
-    Then the record is written to "Logs/agent.jsonl"
+    Then the record is written to ".migration/Logs/agent.jsonl"
 
   Scenario: Log sink failures do not halt the export
     Given the package store is temporarily unavailable

--- a/features/platform/observability/package-progress-sink.feature
+++ b/features/platform/observability/package-progress-sink.feature
@@ -8,11 +8,11 @@ Feature: Package progress sink persistence
 
   Scenario: Progress events are appended to the package as NDJSON
     When a progress event is emitted via the progress sink
-    Then a JSON-serialised progress event line is appended to "Logs/progress.jsonl" in the package
+    Then a JSON-serialised progress event line is appended to ".migration/Logs/progress.jsonl" in the package
 
   Scenario: Package contains at least one record per module stage transition
     When the export completes successfully
-    Then "Logs/progress.jsonl" in the package contains at least one record per module stage transition
+    Then ".migration/Logs/progress.jsonl" in the package contains at least one record per module stage transition
 
   Scenario: Progress sink writes are non-blocking
     When a progress event is emitted via the progress sink

--- a/features/platform/observability/tiered-log-levels.feature
+++ b/features/platform/observability/tiered-log-levels.feature
@@ -7,7 +7,7 @@ Feature: Tiered log level architecture
     Given the agent diagnostic log level is set to "Debug"
     And the control plane deployment-level minimum is "Warning"
     When the agent emits log records at Debug, Information, Warning, and Error levels
-    Then "Logs/agent.jsonl" in the package contains records at Debug and above
+    Then ".migration/Logs/agent.jsonl" in the package contains records at Debug and above
 
   Scenario: Control plane discards records below its deployment-level minimum
     Given the agent diagnostic log level is set to "Debug"

--- a/features/platform/validation/package-validation.feature
+++ b/features/platform/validation/package-validation.feature
@@ -11,13 +11,13 @@ Feature: Pre-Import and Post-Import Validation
     And the package schema version matches a supported version
     When the validation pass runs
     Then the validation result is "Passed"
-    And no errors are written to "Logs/"
+    And no errors are written to ".migration/Logs/"
 
   Scenario: Validation fails when a revision.json is missing required fields
     Given a revision folder contains a "revision.json" missing the "workItemId" field
     When the validation pass runs
     Then the validation result is "Failed"
-    And an error is recorded in "Logs/" identifying the offending folder and missing field
+    And an error is recorded in ".migration/Logs/" identifying the offending folder and missing field
 
   Scenario: Validation fails when the package schema version is unsupported
     Given the package "manifest.json" declares schemaVersion "99.0" for the WorkItems module
@@ -35,7 +35,7 @@ Feature: Pre-Import and Post-Import Validation
     Given the import phase has completed successfully
     When the post-import validation runs
     Then each work item in the target is checked against its final revision.json
-    And any discrepancy is recorded in "Logs/post-import-validation.log"
+    And any discrepancy is recorded in ".migration/Logs/post-import-validation.log"
 
   Scenario: Validation has no side effects on the package
     Given a valid package

--- a/features/services/identity-mapping/identity-mapping.feature
+++ b/features/services/identity-mapping/identity-mapping.feature
@@ -18,7 +18,7 @@ Feature: Identity Mapping and Resolution
     And the configuration specifies a fallback identity of "migration-bot@target.example.com"
     When the WorkItems import module applies the revision
     Then the target work item is assigned to "migration-bot@target.example.com"
-    And a warning is recorded in "Logs/" for the unmapped identity
+    And a warning is recorded in ".migration/Logs/" for the unmapped identity
 
   Scenario: No module performs inline identity resolution
     Given any module that writes user references during import

--- a/src/DevOpsMigrationPlatform.Abstractions/ActivePackageState.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions/ActivePackageState.cs
@@ -39,8 +39,8 @@ public sealed class ActivePackageState
     }
 
     /// <summary>
-    /// Returns the log folder prefix for the current job, e.g. <c>Logs/638807123456789012-a1b2c3d4/</c>.
-    /// Falls back to <c>Logs/</c> when no job is active.
+    /// Returns the log folder prefix for the current job, e.g. <c>.migration/Logs/638807123456789012-a1b2c3d4</c>.
+    /// Falls back to <c>.migration/Logs</c> when no job is active.
     /// The folder name is cached for the lifetime of the job so all sinks write to the same folder.
     /// </summary>
     public string CurrentLogFolder
@@ -49,9 +49,9 @@ public sealed class ActivePackageState
         {
             var jobId = _currentJobId;
             if (string.IsNullOrEmpty(jobId))
-                return "Logs";
+                return PackagePaths.Logs;
 
-            return _cachedLogFolder ??= $"Logs/{DateTimeOffset.UtcNow.Ticks}-{jobId}";
+            return _cachedLogFolder ??= PackagePaths.JobLogFolder(DateTimeOffset.UtcNow.Ticks, jobId!);
         }
     }
 

--- a/src/DevOpsMigrationPlatform.Abstractions/PackagePaths.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions/PackagePaths.cs
@@ -1,0 +1,86 @@
+using System;
+
+namespace DevOpsMigrationPlatform.Abstractions;
+
+/// <summary>
+/// Centralised well-known paths for system files inside a migration package.
+/// All checkpoint, log, and identity-map paths are derived from this class
+/// so the prefix can be changed in a single place.
+/// </summary>
+/// <remarks>
+/// Paths use forward-slash separators — <see cref="IArtefactStore"/> and
+/// <see cref="IStateStore"/> normalise to the platform separator internally.
+/// </remarks>
+public static class PackagePaths
+{
+    /// <summary>
+    /// Root folder for all system/operational files inside a package.
+    /// Hidden by convention (dot-prefix) so user data folders remain uncluttered.
+    /// </summary>
+    public const string SystemRoot = ".migration";
+
+    /// <summary>Checkpoint cursor folder: <c>.migration/Checkpoints</c>.</summary>
+    public const string Checkpoints = $"{SystemRoot}/Checkpoints";
+
+    /// <summary>Log output folder: <c>.migration/Logs</c>.</summary>
+    public const string Logs = $"{SystemRoot}/Logs";
+
+    /// <summary>
+    /// Returns the artefact-store key for a module's cursor file,
+    /// e.g. <c>.migration/Checkpoints/workitems.cursor.json</c>.
+    /// </summary>
+    public static string CursorFile(string moduleName)
+        => $"{Checkpoints}/{moduleName.ToLowerInvariant()}.cursor.json";
+
+    /// <summary>
+    /// The phase-tracking file for Both-mode jobs:
+    /// <c>.migration/Checkpoints/job.phase.json</c>.
+    /// </summary>
+    public const string PhaseFile = $"{Checkpoints}/job.phase.json";
+
+    /// <summary>
+    /// Returns the OS-native filesystem path for the ID-map database,
+    /// e.g. <c>&lt;packageRoot&gt;\.migration\Checkpoints\idmap.db</c>.
+    /// Use this when constructing a SQLite connection string (which needs native separators).
+    /// </summary>
+    public static string IdMapDbNative(string packageLocalRoot)
+        => System.IO.Path.Combine(packageLocalRoot, SystemRoot, "Checkpoints", "idmap.db");
+
+    /// <summary>
+    /// Returns a job-scoped log folder path,
+    /// e.g. <c>.migration/Logs/638807123456789012-a1b2c3d4</c>.
+    /// </summary>
+    public static string JobLogFolder(long ticks, string jobId)
+        => $"{Logs}/{ticks}-{jobId}";
+
+    /// <summary>
+    /// Returns the artefact-store key for an identity-mapping warning file,
+    /// e.g. <c>.migration/Logs/identity-warnings/user%40example.com.log</c>.
+    /// </summary>
+    public static string IdentityWarning(string identity)
+        => $"{Logs}/identity-warnings/{Uri.EscapeDataString(identity)}.log";
+
+    // ── Legacy path helpers (pre-.migration packages) ────────────────────
+
+    /// <summary>Legacy checkpoint prefix before the <c>.migration</c> layout was introduced.</summary>
+    public const string LegacyCheckpoints = "Checkpoints";
+
+    /// <summary>Legacy log prefix before the <c>.migration</c> layout was introduced.</summary>
+    public const string LegacyLogs = "Logs";
+
+    /// <summary>
+    /// Returns the legacy cursor file path for backward-compatible reads,
+    /// e.g. <c>Checkpoints/workitems.cursor.json</c>.
+    /// </summary>
+    public static string LegacyCursorFile(string moduleName)
+        => $"{LegacyCheckpoints}/{moduleName.ToLowerInvariant()}.cursor.json";
+
+    /// <summary>Legacy phase file: <c>Checkpoints/job.phase.json</c>.</summary>
+    public const string LegacyPhaseFile = $"{LegacyCheckpoints}/job.phase.json";
+
+    /// <summary>
+    /// Returns the legacy OS-native path for the ID-map database.
+    /// </summary>
+    public static string LegacyIdMapDbNative(string packageLocalRoot)
+        => System.IO.Path.Combine(packageLocalRoot, "Checkpoints", "idmap.db");
+}

--- a/src/DevOpsMigrationPlatform.Abstractions/Storage/IStateStore.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions/Storage/IStateStore.cs
@@ -6,7 +6,7 @@ namespace DevOpsMigrationPlatform.Abstractions;
 public interface IStateStore
 {
     /// <summary>
-    /// Writes a state entry. Key is the cursor path, e.g. "Checkpoints/workitems.cursor.json".
+    /// Writes a state entry. Key is the cursor path, e.g. ".migration/Checkpoints/workitems.cursor.json".
     /// </summary>
     Task WriteAsync(string key, string value, CancellationToken cancellationToken);
 

--- a/src/DevOpsMigrationPlatform.ControlPlane/Controllers/LogDownloadController.cs
+++ b/src/DevOpsMigrationPlatform.ControlPlane/Controllers/LogDownloadController.cs
@@ -98,25 +98,34 @@ public sealed class LogDownloadController : ControllerBase
 
     /// <summary>
     /// Resolves the full artefact path for a log file by finding the job-scoped subfolder
-    /// under <c>Logs/</c> whose name ends with <c>-{jobId}</c>.
-    /// Falls back to the flat <c>Logs/{fileName}</c> for backward compatibility.
+    /// under the Logs folder whose name ends with <c>-{jobId}</c>.
+    /// Falls back to legacy <c>Logs/</c> for packages created before the <c>.migration</c> layout.
     /// </summary>
     private static async Task<string> ResolveLogPathAsync(
         IArtefactStore store, string jobId, string fileName, CancellationToken ct)
     {
-        // Look for job-scoped folder: Logs/<ticks>-<jobId>/
-        await foreach (var entry in store.EnumerateAsync("Logs/", ct))
+        // Try current layout first: .migration/Logs/<ticks>-<jobId>/
+        await foreach (var entry in store.EnumerateAsync(PackagePaths.Logs + "/", ct))
         {
-            // EnumerateAsync returns relative paths like "Logs/<ticks>-<jobId>/agent.jsonl"
-            // We look for a subfolder whose name ends with the jobId
             var segments = entry.Split('/');
-            if (segments.Length >= 2 && segments[1].EndsWith($"-{jobId}", StringComparison.OrdinalIgnoreCase))
+            // segments: [".migration", "Logs", "<ticks>-<jobId>", "agent.jsonl"]
+            if (segments.Length >= 3 && segments[2].EndsWith($"-{jobId}", StringComparison.OrdinalIgnoreCase))
             {
-                return $"Logs/{segments[1]}/{fileName}";
+                return $"{PackagePaths.Logs}/{segments[2]}/{fileName}";
             }
         }
 
-        // Backward compatibility: flat Logs/ folder
-        return $"Logs/{fileName}";
+        // Backward compatibility: legacy Logs/<ticks>-<jobId>/ layout
+        await foreach (var entry in store.EnumerateAsync(PackagePaths.LegacyLogs + "/", ct))
+        {
+            var segments = entry.Split('/');
+            if (segments.Length >= 2 && segments[1].EndsWith($"-{jobId}", StringComparison.OrdinalIgnoreCase))
+            {
+                return $"{PackagePaths.LegacyLogs}/{segments[1]}/{fileName}";
+            }
+        }
+
+        // Final fallback: flat legacy Logs/ folder
+        return $"{PackagePaths.LegacyLogs}/{fileName}";
     }
 }

--- a/src/DevOpsMigrationPlatform.Infrastructure/Checkpointing/CheckpointingService.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Checkpointing/CheckpointingService.cs
@@ -16,8 +16,16 @@ public class CheckpointingService : ICheckpointingService
 
     public async Task<CursorEntry?> ReadCursorAsync(string moduleName, CancellationToken cancellationToken)
     {
-        var key = $"Checkpoints/{moduleName.ToLowerInvariant()}.cursor.json";
+        var key = PackagePaths.CursorFile(moduleName);
         var json = await _stateStore.ReadAsync(key, cancellationToken).ConfigureAwait(false);
+
+        // Legacy fallback: try the pre-.migration path for existing packages.
+        if (json is null)
+        {
+            var legacyKey = PackagePaths.LegacyCursorFile(moduleName);
+            json = await _stateStore.ReadAsync(legacyKey, cancellationToken).ConfigureAwait(false);
+        }
+
         if (json is null)
             return null;
         return JsonSerializer.Deserialize<CursorEntry>(json);
@@ -25,14 +33,14 @@ public class CheckpointingService : ICheckpointingService
 
     public async Task WriteCursorAsync(string moduleName, CursorEntry cursor, CancellationToken cancellationToken)
     {
-        var key = $"Checkpoints/{moduleName.ToLowerInvariant()}.cursor.json";
+        var key = PackagePaths.CursorFile(moduleName);
         var json = JsonSerializer.Serialize(cursor);
         await _stateStore.WriteAsync(key, json, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DeleteCursorAsync(string moduleName, CancellationToken cancellationToken)
     {
-        var key = $"Checkpoints/{moduleName.ToLowerInvariant()}.cursor.json";
+        var key = PackagePaths.CursorFile(moduleName);
         await _stateStore.DeleteAsync(key, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/DevOpsMigrationPlatform.Infrastructure/JobEngine/PhaseTrackingService.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/JobEngine/PhaseTrackingService.cs
@@ -8,8 +8,6 @@ namespace DevOpsMigrationPlatform.Infrastructure.JobEngine;
 
 public class PhaseTrackingService : IPhaseTrackingService
 {
-    private const string PhaseKey = "Checkpoints/job.phase.json";
-
     private readonly IStateStore _stateStore;
 
     public PhaseTrackingService(IStateStore stateStore)
@@ -19,7 +17,12 @@ public class PhaseTrackingService : IPhaseTrackingService
 
     public async Task<JobPhaseRecord> ReadPhaseRecordAsync(CancellationToken cancellationToken)
     {
-        var json = await _stateStore.ReadAsync(PhaseKey, cancellationToken).ConfigureAwait(false);
+        var json = await _stateStore.ReadAsync(PackagePaths.PhaseFile, cancellationToken).ConfigureAwait(false);
+
+        // Legacy fallback: try the pre-.migration path for existing packages.
+        if (json is null)
+            json = await _stateStore.ReadAsync(PackagePaths.LegacyPhaseFile, cancellationToken).ConfigureAwait(false);
+
         if (json is null)
             return new JobPhaseRecord();
         return JsonSerializer.Deserialize<JobPhaseRecord>(json) ?? new JobPhaseRecord();
@@ -28,11 +31,11 @@ public class PhaseTrackingService : IPhaseTrackingService
     public async Task WritePhaseRecordAsync(JobPhaseRecord record, CancellationToken cancellationToken)
     {
         var json = JsonSerializer.Serialize(record);
-        await _stateStore.WriteAsync(PhaseKey, json, cancellationToken).ConfigureAwait(false);
+        await _stateStore.WriteAsync(PackagePaths.PhaseFile, json, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task DeletePhaseRecordAsync(CancellationToken cancellationToken)
     {
-        await _stateStore.DeleteAsync(PhaseKey, cancellationToken).ConfigureAwait(false);
+        await _stateStore.DeleteAsync(PackagePaths.PhaseFile, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/DevOpsMigrationPlatform.Infrastructure/Modules/DependencyDiscoveryModule.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Modules/DependencyDiscoveryModule.cs
@@ -23,7 +23,7 @@ namespace DevOpsMigrationPlatform.Infrastructure.Modules;
 /// </summary>
 public sealed class DependencyDiscoveryModule : IDiscoveryModule
 {
-    private const string CursorKey = "Checkpoints/Dependencies.cursor.json";
+    private const string CursorKey = PackagePaths.Checkpoints + "/Dependencies.cursor.json";
     private const string RootCsvPath = "dependencies.csv";
 
     private readonly IDependencyDiscoveryServiceFactory _dependencyFactory;
@@ -99,6 +99,11 @@ public sealed class DependencyDiscoveryModule : IDiscoveryModule
         var recordCount = 0;
 
         var cursorJson = await state.ReadAsync(CursorKey, ct).ConfigureAwait(false);
+
+        // Legacy fallback: try the pre-.migration path for existing packages.
+        if (cursorJson is null)
+            cursorJson = await state.ReadAsync("Checkpoints/Dependencies.cursor.json", ct).ConfigureAwait(false);
+
         if (cursorJson is not null)
         {
             _logger.LogInformation("Found existing dependencies cursor — attempting resume.");

--- a/src/DevOpsMigrationPlatform.Infrastructure/Modules/InventoryDiscoveryModule.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Modules/InventoryDiscoveryModule.cs
@@ -23,7 +23,7 @@ namespace DevOpsMigrationPlatform.Infrastructure.Modules;
 /// </summary>
 public sealed class InventoryDiscoveryModule : IDiscoveryModule
 {
-    private const string CursorKey = "Checkpoints/Inventory.cursor.json";
+    private const string CursorKey = PackagePaths.Checkpoints + "/Inventory.cursor.json";
     private const string CsvOutputPath = "inventory.csv";
     private const string JsonOutputPath = "inventory.json";
 
@@ -362,6 +362,11 @@ public sealed class InventoryDiscoveryModule : IDiscoveryModule
     private static async Task<string?> ReadCursorAsync(IStateStore state, CancellationToken ct)
     {
         var raw = await state.ReadAsync(CursorKey, ct).ConfigureAwait(false);
+
+        // Legacy fallback: try the pre-.migration path for existing packages.
+        if (raw is null)
+            raw = await state.ReadAsync("Checkpoints/Inventory.cursor.json", ct).ConfigureAwait(false);
+
         if (raw is null) return null;
         var doc = JsonDocument.Parse(raw);
         return doc.RootElement.TryGetProperty("lastCompleted", out var el) ? el.GetString() : null;

--- a/src/DevOpsMigrationPlatform.Infrastructure/Modules/WorkItemsModule.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Modules/WorkItemsModule.cs
@@ -203,7 +203,17 @@ public sealed class WorkItemsModule : IModule
         else
             localRoot = packageUri;
 
-        return Path.Combine(localRoot, "Checkpoints", "idmap.db");
+        var newPath = PackagePaths.IdMapDbNative(localRoot);
+
+        // Legacy fallback: if the .migration path doesn't exist yet, check the old location.
+        if (!File.Exists(newPath))
+        {
+            var legacyPath = PackagePaths.LegacyIdMapDbNative(localRoot);
+            if (File.Exists(legacyPath))
+                return legacyPath;
+        }
+
+        return newPath;
     }
 
     public async Task ValidateAsync(ValidationContext context, CancellationToken ct)

--- a/src/DevOpsMigrationPlatform.Infrastructure/Services/FileSystemIdentityMappingService.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Services/FileSystemIdentityMappingService.cs
@@ -55,7 +55,7 @@ public class FileSystemIdentityMappingService : IIdentityMappingService
         foreach (var identity in _unmapped)
         {
             var msg = $"WARN: No identity mapping for '{identity}'. Fell back to '{_fallbackIdentity}'.";
-            var key = $"Logs/identity-warnings/{Uri.EscapeDataString(identity)}.log";
+            var key = PackagePaths.IdentityWarning(identity);
             await _store.WriteAsync(key, msg, cancellationToken).ConfigureAwait(false);
         }
         _unmapped.Clear();

--- a/src/DevOpsMigrationPlatform.Infrastructure/Services/PackageLockFileService.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Services/PackageLockFileService.cs
@@ -40,7 +40,7 @@ public sealed class PackageLockFileService : IPackageLockService
     public async Task<IAsyncDisposable> AcquireAsync(string packagePath, string jobId, CancellationToken ct)
     {
         var localRoot = ResolveLocalPath(packagePath);
-        var lockFilePath = Path.Combine(localRoot, "Checkpoints", "agent.lock");
+        var lockFilePath = Path.Combine(localRoot, PackagePaths.SystemRoot, "Checkpoints", "agent.lock");
         var dir = Path.GetDirectoryName(lockFilePath)!;
         if (!Directory.Exists(dir))
             Directory.CreateDirectory(dir);

--- a/src/DevOpsMigrationPlatform.MigrationAgent/JobAgentWorker.cs
+++ b/src/DevOpsMigrationPlatform.MigrationAgent/JobAgentWorker.cs
@@ -298,7 +298,7 @@ public sealed class JobAgentWorker : BackgroundService
                 "ForceFresh requested for discovery job {JobId} — deleting module cursors.", job.JobId);
             foreach (var module in _discoveryModules)
             {
-                var cursorPath = $"Checkpoints/{module.Name}.cursor.json";
+                var cursorPath = PackagePaths.CursorFile(module.Name);
                 try { await stateStore.DeleteAsync(cursorPath, ct).ConfigureAwait(false); }
                 catch (Exception ex)
                 {

--- a/tests/DevOpsMigrationPlatform.CLI.Migration.Tests/Commands/QueueCommandTests.cs
+++ b/tests/DevOpsMigrationPlatform.CLI.Migration.Tests/Commands/QueueCommandTests.cs
@@ -202,9 +202,9 @@ public class QueueCommandTests
 
         // Verify both fixture work items were processed by checking the idmap DB was created
         // (progress events are not observable from CLI stdout in the current streaming architecture).
-        // Org/project nesting places Checkpoints under <outputDir>/<org>/<project>/Checkpoints/
+        // Org/project nesting places idmap.db under <outputDir>/<org>/<project>/.migration/Checkpoints/
         var idmapFiles = Directory.GetFiles(outputDir, "idmap.db", SearchOption.AllDirectories);
         Assert.IsTrue(idmapFiles.Length > 0,
-            $"Checkpoints/idmap.db was not found anywhere under {outputDir} — import may not have processed any work items.");
+            $".migration/Checkpoints/idmap.db was not found anywhere under {outputDir} — import may not have processed any work items.");
     }
 }

--- a/tests/DevOpsMigrationPlatform.CLI.Migration.Tests/Commands/SimulatedMigrationCommandTests.cs
+++ b/tests/DevOpsMigrationPlatform.CLI.Migration.Tests/Commands/SimulatedMigrationCommandTests.cs
@@ -137,7 +137,7 @@ public class SimulatedMigrationCommandTests
     // ─────────────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// T010: Verifies Logs/progress.jsonl exists in the package after export.
+    /// T010: Verifies .migration/Logs/progress.jsonl exists in the package after export.
     /// </summary>
     [TestMethod]
     [TestCategory("SystemTest")]
@@ -159,7 +159,7 @@ public class SimulatedMigrationCommandTests
         Assert.AreEqual(0, result.ExitCode,
             $"CLI exited with code {result.ExitCode}.");
 
-        // Job-scoped log folder: Logs/<ticks>-<jobId>/progress.jsonl
+        // Job-scoped log folder: .migration/Logs/<ticks>-<jobId>/progress.jsonl
         var progressFiles = Directory.GetFiles(outputDir, "progress.jsonl", SearchOption.AllDirectories);
         Assert.IsTrue(progressFiles.Length > 0,
             $"Expected progress.jsonl to exist somewhere under {outputDir}");
@@ -170,7 +170,7 @@ public class SimulatedMigrationCommandTests
     }
 
     /// <summary>
-    /// T015: Verifies Logs/agent.jsonl exists in the package after export.
+    /// T015: Verifies .migration/Logs/agent.jsonl exists in the package after export.
     /// </summary>
     [TestMethod]
     [TestCategory("SystemTest")]
@@ -192,7 +192,7 @@ public class SimulatedMigrationCommandTests
         Assert.AreEqual(0, result.ExitCode,
             $"CLI exited with code {result.ExitCode}.");
 
-        // Job-scoped log folder: Logs/<ticks>-<jobId>/agent.jsonl
+        // Job-scoped log folder: .migration/Logs/<ticks>-<jobId>/agent.jsonl
         var agentFiles = Directory.GetFiles(outputDir, "agent.jsonl", SearchOption.AllDirectories);
         Assert.IsTrue(agentFiles.Length > 0,
             $"Expected agent.jsonl to exist somewhere under {outputDir}");
@@ -225,10 +225,10 @@ public class SimulatedMigrationCommandTests
         Assert.AreEqual(0, result.ExitCode,
             $"CLI exited with code {result.ExitCode}.");
 
-        // Job-scoped log folder: Logs/<ticks>-<jobId>/{progress,agent}.jsonl
+        // Job-scoped log folder: .migration/Logs/<ticks>-<jobId>/{progress,agent}.jsonl
         var logsDirs = Directory.GetDirectories(outputDir, "Logs", SearchOption.AllDirectories);
         Assert.IsTrue(logsDirs.Length > 0,
-            $"Expected Logs/ directory somewhere under {outputDir}");
+            $"Expected .migration/Logs/ directory somewhere under {outputDir}");
 
         var progressFiles = Directory.GetFiles(outputDir, "progress.jsonl", SearchOption.AllDirectories);
         Assert.IsTrue(progressFiles.Length > 0,

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Checkpointing/CheckpointingServiceTests.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Checkpointing/CheckpointingServiceTests.cs
@@ -25,7 +25,10 @@ public class CheckpointingServiceTests
     public async Task ReadCursorAsync_WhenKeyIsMissing_ReturnsNull()
     {
         _mockStateStore
-            .Setup(s => s.ReadAsync("Checkpoints/workitems.cursor.json", It.IsAny<CancellationToken>()))
+            .Setup(s => s.ReadAsync(PackagePaths.CursorFile("WorkItems"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        _mockStateStore
+            .Setup(s => s.ReadAsync(PackagePaths.LegacyCursorFile("WorkItems"), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string?)null);
 
         var result = await _sut.ReadCursorAsync("WorkItems", CancellationToken.None);
@@ -45,7 +48,7 @@ public class CheckpointingServiceTests
         var json = JsonSerializer.Serialize(entry);
 
         _mockStateStore
-            .Setup(s => s.ReadAsync("Checkpoints/workitems.cursor.json", It.IsAny<CancellationToken>()))
+            .Setup(s => s.ReadAsync(PackagePaths.CursorFile("WorkItems"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(json);
 
         var result = await _sut.ReadCursorAsync("WorkItems", CancellationToken.None);
@@ -74,7 +77,7 @@ public class CheckpointingServiceTests
 
         await _sut.WriteCursorAsync("WorkItems", entry, CancellationToken.None);
 
-        Assert.AreEqual("Checkpoints/workitems.cursor.json", capturedKey);
+        Assert.AreEqual(PackagePaths.CursorFile("WorkItems"), capturedKey);
     }
 
     [TestMethod]

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Checkpointing/CursorResumeSteps.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Checkpointing/CursorResumeSteps.cs
@@ -44,7 +44,7 @@ public class CursorResumeSteps
     public async Task WhenTheWorkItemsModuleSuccessfullyProcessesItsFirstRevisionFolder()
     {
         const string folderPath = "WorkItems/2024-01-01/00000000000001-1-1/";
-        _ctx.CursorKey = "Checkpoints/workitems.cursor.json";
+        _ctx.CursorKey = PackagePaths.CursorFile("WorkItems");
 
         _ctx.MockStateStore
             .Setup(s => s.WriteAsync(_ctx.CursorKey, It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -61,11 +61,11 @@ public class CursorResumeSteps
         await _ctx.Sut.WriteCursorAsync("WorkItems", entry, CancellationToken.None);
     }
 
-    [Then(@"""Checkpoints/workitems\.cursor\.json"" is created")]
+    [Then(@"the cursor file for the WorkItems module is created")]
     public void ThenCheckpointsWorkitemsCursorJsonIsCreated()
     {
         _ctx.MockStateStore.Verify(
-            s => s.WriteAsync("Checkpoints/workitems.cursor.json", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            s => s.WriteAsync(PackagePaths.CursorFile("WorkItems"), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -91,7 +91,7 @@ public class CursorResumeSteps
     public async Task WhenTheWorkItemsModuleProcessesTheNthRevisionFolder(int n)
     {
         var folderPath = _ctx.AllFolders[n - 1];
-        _ctx.CursorKey = "Checkpoints/workitems.cursor.json";
+        _ctx.CursorKey = PackagePaths.CursorFile("WorkItems");
 
         _ctx.MockStateStore
             .Setup(s => s.WriteAsync(_ctx.CursorKey, It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -108,7 +108,7 @@ public class CursorResumeSteps
         await _ctx.Sut.WriteCursorAsync("WorkItems", entry, CancellationToken.None);
     }
 
-    [Then(@"""Checkpoints/workitems\.cursor\.json"" is updated to record the (\d+)(?:st|nd|rd|th) folder path")]
+    [Then(@"the cursor file for the WorkItems module is updated to record the (\d+)(?:st|nd|rd|th) folder path")]
     public void ThenCheckpointsWorkitemsCursorJsonIsUpdatedToRecordTheNthFolderPath(int n)
     {
         Assert.IsNotNull(_ctx.WrittenCursorEntry);
@@ -117,7 +117,7 @@ public class CursorResumeSteps
 
     // ── Scenario 3: Resume skips all revision folders up to and including the cursor position ─────
 
-    [Given(@"""Checkpoints/workitems\.cursor\.json"" records ""(.+?)""")]
+    [Given("the cursor file for the WorkItems module records {string}")]
     public void GivenCheckpointsWorkitemsCursorJsonRecords(string cursorValue)
     {
         _ctx.InitialCursorValue = cursorValue;
@@ -129,7 +129,7 @@ public class CursorResumeSteps
         };
         var json = JsonSerializer.Serialize(cursorEntry);
         _ctx.MockStateStore
-            .Setup(s => s.ReadAsync("Checkpoints/workitems.cursor.json", It.IsAny<CancellationToken>()))
+            .Setup(s => s.ReadAsync(PackagePaths.CursorFile("WorkItems"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(json);
     }
 
@@ -181,11 +181,14 @@ public class CursorResumeSteps
 
     // ── Scenario 4: A run with no cursor starts from the beginning of the package ─────
 
-    [Given(@"""Checkpoints/workitems\.cursor\.json"" does not exist")]
+    [Given(@"the cursor file for the WorkItems module does not exist")]
     public void GivenCheckpointsWorkitemsCursorJsonDoesNotExist()
     {
         _ctx.MockStateStore
-            .Setup(s => s.ReadAsync("Checkpoints/workitems.cursor.json", It.IsAny<CancellationToken>()))
+            .Setup(s => s.ReadAsync(PackagePaths.CursorFile("WorkItems"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        _ctx.MockStateStore
+            .Setup(s => s.ReadAsync(PackagePaths.LegacyCursorFile("WorkItems"), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string?)null);
     }
 
@@ -251,7 +254,7 @@ public class CursorResumeSteps
     public async Task WhenTheWorkItemsModuleIsRestarted()
     {
         _ctx.MockStateStore
-            .Setup(s => s.ReadAsync("Checkpoints/workitems.cursor.json", It.IsAny<CancellationToken>()))
+            .Setup(s => s.ReadAsync(PackagePaths.CursorFile("WorkItems"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_ctx.InitialCursorValue);
 
         var cursorEntry = await _ctx.Sut.ReadCursorAsync("WorkItems", CancellationToken.None);
@@ -289,7 +292,7 @@ public class CursorResumeSteps
     {
         // The module holds a reference to ICheckpointingService (the real SUT).
         // MockStateStore has NO WriteAsync setup — any direct call from "module code" would throw.
-        _ctx.CursorKey = "Checkpoints/workitems.cursor.json";
+        _ctx.CursorKey = PackagePaths.CursorFile("WorkItems");
     }
 
     [When(@"the cursor is updated")]
@@ -318,7 +321,7 @@ public class CursorResumeSteps
         // Verify the platform delegated to IStateStore exactly once via CheckpointingService.
         _ctx.MockStateStore.Verify(
             s => s.WriteAsync(
-                "Checkpoints/workitems.cursor.json",
+                PackagePaths.CursorFile("WorkItems"),
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
@@ -339,14 +342,14 @@ public class CursorResumeSteps
     {
         _ctx.MockStateStore
             .Setup(s => s.WriteAsync(
-                "Checkpoints/workitems.cursor.json", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                PackagePaths.CursorFile("WorkItems"), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Callback<string, string, CancellationToken>((_, json, _) =>
                 _ctx.CursorsByModule["WorkItems"] = JsonSerializer.Deserialize<CursorEntry>(json))
             .Returns(Task.CompletedTask);
 
         _ctx.MockStateStore
             .Setup(s => s.WriteAsync(
-                "Checkpoints/areapaths.cursor.json", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                PackagePaths.CursorFile("AreaPaths"), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Callback<string, string, CancellationToken>((_, json, _) =>
                 _ctx.CursorsByModule["AreaPaths"] = JsonSerializer.Deserialize<CursorEntry>(json))
             .Returns(Task.CompletedTask);
@@ -372,7 +375,7 @@ public class CursorResumeSteps
         await _ctx.Sut.WriteCursorAsync("AreaPaths", areaPathsCursor, CancellationToken.None);
     }
 
-    [Then(@"""Checkpoints/workitems\.cursor\.json"" and ""Checkpoints/areapaths\.cursor\.json"" are independent files")]
+    [Then(@"the WorkItems module and the AreaPaths module have independent cursor files")]
     public void ThenBothCursorFilesAreIndependent()
     {
         Assert.IsNotNull(_ctx.CursorsByModule["WorkItems"]);
@@ -380,11 +383,11 @@ public class CursorResumeSteps
 
         _ctx.MockStateStore.Verify(
             s => s.WriteAsync(
-                "Checkpoints/workitems.cursor.json", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                PackagePaths.CursorFile("WorkItems"), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Once);
         _ctx.MockStateStore.Verify(
             s => s.WriteAsync(
-                "Checkpoints/areapaths.cursor.json", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                PackagePaths.CursorFile("AreaPaths"), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Checkpointing/FileSystemStateStoreTests.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Checkpointing/FileSystemStateStoreTests.cs
@@ -30,27 +30,27 @@ public class FileSystemStateStoreTests
     [TestMethod]
     public async Task WriteAsync_WhenDirectoryDoesNotExist_CreatesDirectoryAndWritesFile()
     {
-        await _sut.WriteAsync("Checkpoints/workitems.cursor.json", "{}", CancellationToken.None);
+        await _sut.WriteAsync(".migration/Checkpoints/workitems.cursor.json", "{}", CancellationToken.None);
 
-        var fullPath = Path.Combine(_root, "Checkpoints", "workitems.cursor.json");
+        var fullPath = Path.Combine(_root, ".migration", "Checkpoints", "workitems.cursor.json");
         Assert.IsTrue(File.Exists(fullPath));
     }
 
     [TestMethod]
     public async Task WriteAsync_WhenDirectoryAlreadyExists_WritesFile()
     {
-        Directory.CreateDirectory(Path.Combine(_root, "Checkpoints"));
+        Directory.CreateDirectory(Path.Combine(_root, ".migration", "Checkpoints"));
 
-        await _sut.WriteAsync("Checkpoints/workitems.cursor.json", "data", CancellationToken.None);
+        await _sut.WriteAsync(".migration/Checkpoints/workitems.cursor.json", "data", CancellationToken.None);
 
-        var fullPath = Path.Combine(_root, "Checkpoints", "workitems.cursor.json");
+        var fullPath = Path.Combine(_root, ".migration", "Checkpoints", "workitems.cursor.json");
         Assert.AreEqual("data", File.ReadAllText(fullPath));
     }
 
     [TestMethod]
     public async Task ReadAsync_WhenFileDoesNotExist_ReturnsNull()
     {
-        var result = await _sut.ReadAsync("Checkpoints/missing.cursor.json", CancellationToken.None);
+        var result = await _sut.ReadAsync(".migration/Checkpoints/missing.cursor.json", CancellationToken.None);
 
         Assert.IsNull(result);
     }
@@ -58,9 +58,9 @@ public class FileSystemStateStoreTests
     [TestMethod]
     public async Task ReadAsync_WhenFileExists_ReturnsContent()
     {
-        await _sut.WriteAsync("Checkpoints/workitems.cursor.json", "hello", CancellationToken.None);
+        await _sut.WriteAsync(".migration/Checkpoints/workitems.cursor.json", "hello", CancellationToken.None);
 
-        var result = await _sut.ReadAsync("Checkpoints/workitems.cursor.json", CancellationToken.None);
+        var result = await _sut.ReadAsync(".migration/Checkpoints/workitems.cursor.json", CancellationToken.None);
 
         Assert.AreEqual("hello", result);
     }
@@ -68,9 +68,9 @@ public class FileSystemStateStoreTests
     [TestMethod]
     public async Task ExistsAsync_WhenFileExists_ReturnsTrue()
     {
-        await _sut.WriteAsync("Checkpoints/workitems.cursor.json", "{}", CancellationToken.None);
+        await _sut.WriteAsync(".migration/Checkpoints/workitems.cursor.json", "{}", CancellationToken.None);
 
-        var exists = await _sut.ExistsAsync("Checkpoints/workitems.cursor.json", CancellationToken.None);
+        var exists = await _sut.ExistsAsync(".migration/Checkpoints/workitems.cursor.json", CancellationToken.None);
 
         Assert.IsTrue(exists);
     }
@@ -78,7 +78,7 @@ public class FileSystemStateStoreTests
     [TestMethod]
     public async Task ExistsAsync_WhenFileMissing_ReturnsFalse()
     {
-        var exists = await _sut.ExistsAsync("Checkpoints/missing.cursor.json", CancellationToken.None);
+        var exists = await _sut.ExistsAsync(".migration/Checkpoints/missing.cursor.json", CancellationToken.None);
 
         Assert.IsFalse(exists);
     }
@@ -86,9 +86,9 @@ public class FileSystemStateStoreTests
     [TestMethod]
     public async Task WriteAsync_NormalisesForwardSlashesToPlatformSeparator()
     {
-        await _sut.WriteAsync("Checkpoints/sub/nested.json", "x", CancellationToken.None);
+        await _sut.WriteAsync(".migration/Checkpoints/sub/nested.json", "x", CancellationToken.None);
 
-        var fullPath = Path.Combine(_root, "Checkpoints", "sub", "nested.json");
+        var fullPath = Path.Combine(_root, ".migration", "Checkpoints", "sub", "nested.json");
         Assert.IsTrue(File.Exists(fullPath));
     }
 }

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Export/ExportCommentsSteps.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Export/ExportCommentsSteps.cs
@@ -282,7 +282,7 @@ public class ExportCommentsSteps
     public void ThenCommentPaginationCursorIsProperlyManaged()
     {
         // Inline comment fetching uses the main WorkItems cursor (not a separate comments cursor).
-        var cursorPath = Path.Combine(_context.PackageRoot, "Checkpoints", "workitems.cursor.json");
+        var cursorPath = Path.Combine(_context.PackageRoot, PackagePaths.SystemRoot, "Checkpoints", "workitems.cursor.json");
         Assert.IsTrue(File.Exists(cursorPath), "WorkItems cursor file should exist");
 
         var json = File.ReadAllText(cursorPath);
@@ -439,7 +439,7 @@ public class ExportCommentsSteps
     public void ThenTheCursorAdvancesToWorkItem(int expectedWorkItemId)
     {
         // The main WorkItems cursor's lastProcessed path contains the last work item ID.
-        var cursorPath = Path.Combine(_context.PackageRoot, "Checkpoints", "workitems.cursor.json");
+        var cursorPath = Path.Combine(_context.PackageRoot, PackagePaths.SystemRoot, "Checkpoints", "workitems.cursor.json");
         Assert.IsTrue(File.Exists(cursorPath), "WorkItems cursor file should exist");
 
         var json = File.ReadAllText(cursorPath);

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Import/ImportCursorResumeSteps.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Import/ImportCursorResumeSteps.cs
@@ -58,10 +58,10 @@ public class ImportCursorResumeSteps
         var cursorJson = JsonSerializer.Serialize(cursor);
 
         _ctx.MockStateStore
-            .Setup(s => s.ReadAsync("Checkpoints/workitems.cursor.json", It.IsAny<CancellationToken>()))
+            .Setup(s => s.ReadAsync(PackagePaths.CursorFile("workitems"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(cursorJson);
         _ctx.MockStateStore
-            .Setup(s => s.WriteAsync("Checkpoints/workitems.cursor.json", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.WriteAsync(PackagePaths.CursorFile("workitems"), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
     }
 
@@ -118,10 +118,10 @@ public class ImportCursorResumeSteps
         var cursorJson = JsonSerializer.Serialize(cursor);
 
         _ctx.MockStateStore
-            .Setup(s => s.ReadAsync("Checkpoints/workitems.cursor.json", It.IsAny<CancellationToken>()))
+            .Setup(s => s.ReadAsync(PackagePaths.CursorFile("workitems"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(cursorJson);
         _ctx.MockStateStore
-            .Setup(s => s.WriteAsync("Checkpoints/workitems.cursor.json", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.WriteAsync(PackagePaths.CursorFile("workitems"), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
     }
 
@@ -157,14 +157,17 @@ public class ImportCursorResumeSteps
         });
         // Return null once cursor is deleted so ForceFresh starts fresh.
         _ctx.MockStateStore
-            .Setup(s => s.ReadAsync("Checkpoints/workitems.cursor.json", It.IsAny<CancellationToken>()))
+            .Setup(s => s.ReadAsync(PackagePaths.CursorFile("workitems"), It.IsAny<CancellationToken>()))
             .Returns((string _, CancellationToken ct) =>
                 Task.FromResult<string?>(_ctx.CursorWasDeleted ? null : cursorJson));
         _ctx.MockStateStore
-            .Setup(s => s.WriteAsync("Checkpoints/workitems.cursor.json", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.ReadAsync(PackagePaths.LegacyCursorFile("workitems"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        _ctx.MockStateStore
+            .Setup(s => s.WriteAsync(PackagePaths.CursorFile("workitems"), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         _ctx.MockStateStore
-            .Setup(s => s.DeleteAsync("Checkpoints/workitems.cursor.json", It.IsAny<CancellationToken>()))
+            .Setup(s => s.DeleteAsync(PackagePaths.CursorFile("workitems"), It.IsAny<CancellationToken>()))
             .Callback(() => _ctx.CursorWasDeleted = true)
             .Returns(Task.CompletedTask);
     }

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Import/RerunDeltaImportSteps.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Import/RerunDeltaImportSteps.cs
@@ -40,7 +40,7 @@ public class RerunDeltaImportSteps
         };
         var cursorJson = JsonSerializer.Serialize(cursor);
         _ctx.MockStateStore
-            .Setup(s => s.ReadAsync("Checkpoints/workitems.cursor.json", It.IsAny<CancellationToken>()))
+            .Setup(s => s.ReadAsync(PackagePaths.CursorFile("workitems"), It.IsAny<CancellationToken>()))
             .ReturnsAsync(cursorJson);
         _ctx.CursorReadConfigured = true;
     }
@@ -160,12 +160,15 @@ public class RerunDeltaImportSteps
         });
 
         _ctx.MockStateStore
-            .Setup(s => s.ReadAsync("Checkpoints/workitems.cursor.json", It.IsAny<CancellationToken>()))
+            .Setup(s => s.ReadAsync(PackagePaths.CursorFile("workitems"), It.IsAny<CancellationToken>()))
             .Returns((string _, CancellationToken _) =>
                 Task.FromResult<string?>(_ctx.CursorWasDeleted ? null : cursorJson));
+        _ctx.MockStateStore
+            .Setup(s => s.ReadAsync(PackagePaths.LegacyCursorFile("workitems"), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
         _ctx.CursorReadConfigured = true;
         _ctx.MockStateStore
-            .Setup(s => s.DeleteAsync("Checkpoints/workitems.cursor.json", It.IsAny<CancellationToken>()))
+            .Setup(s => s.DeleteAsync(PackagePaths.CursorFile("workitems"), It.IsAny<CancellationToken>()))
             .Callback(() => _ctx.CursorWasDeleted = true)
             .Returns(Task.CompletedTask);
 
@@ -208,14 +211,17 @@ public class RerunDeltaImportSteps
     {
         // StateStore: cursor writes
         _ctx.MockStateStore
-            .Setup(s => s.WriteAsync("Checkpoints/workitems.cursor.json", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.WriteAsync(PackagePaths.CursorFile("workitems"), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         // StateStore: if ReadAsync not already set up, default to no cursor
         if (!_ctx.CursorReadConfigured)
         {
             _ctx.MockStateStore
-                .Setup(s => s.ReadAsync("Checkpoints/workitems.cursor.json", It.IsAny<CancellationToken>()))
+                .Setup(s => s.ReadAsync(PackagePaths.CursorFile("workitems"), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string?)null);
+            _ctx.MockStateStore
+                .Setup(s => s.ReadAsync(PackagePaths.LegacyCursorFile("workitems"), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((string?)null);
         }
 

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Platform/ExclusivePackageLockSteps.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Platform/ExclusivePackageLockSteps.cs
@@ -88,7 +88,7 @@ public class ExclusivePackageLockSteps
     public void GivenStaleLockFileExistsForAgent(string agentId)
     {
         _staleLockAgentId = agentId;
-        var checkpointsDir = Path.Combine(_ctx.TempDir, "Checkpoints");
+        var checkpointsDir = Path.Combine(_ctx.TempDir, PackagePaths.SystemRoot, "Checkpoints");
         Directory.CreateDirectory(checkpointsDir);
 
         var lockContent = JsonSerializer.Serialize(new
@@ -130,7 +130,7 @@ public class ExclusivePackageLockSteps
     {
         // After acquiring the new lock, the stale content has been replaced.
         // The lock file now exists but belongs to the new agent, not the stale one.
-        var lockFilePath = Path.Combine(_ctx.TempDir, "Checkpoints", "agent.lock");
+        var lockFilePath = Path.Combine(_ctx.TempDir, PackagePaths.SystemRoot, "Checkpoints", "agent.lock");
         Assert.IsTrue(File.Exists(lockFilePath), "Lock file should exist (newly acquired).");
 
         var content = File.ReadAllText(lockFilePath);
@@ -168,7 +168,7 @@ public class ExclusivePackageLockSteps
     [Then("the lock file no longer exists in the package Checkpoints directory")]
     public void ThenLockFileNoLongerExists()
     {
-        var lockFilePath = Path.Combine(_ctx.TempDir, "Checkpoints", "agent.lock");
+        var lockFilePath = Path.Combine(_ctx.TempDir, PackagePaths.SystemRoot, "Checkpoints", "agent.lock");
         Assert.IsFalse(File.Exists(lockFilePath), "Lock file should have been deleted on dispose.");
     }
 

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Telemetry/PackageLoggerProviderRotationTests.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Telemetry/PackageLoggerProviderRotationTests.cs
@@ -16,7 +16,7 @@ public class PackageLoggerProviderRotationTests
 {
     /// <summary>
     /// Verifies that when log output stays under the segment size limit,
-    /// all writes go to the initial <c>Logs/agent.jsonl</c> path.
+    /// all writes go to the initial <c>.migration/Logs/agent.jsonl</c> path.
     /// </summary>
     [TestMethod]
     public async Task FlushBatch_UnderLimit_WritesToInitialSegment()
@@ -47,7 +47,7 @@ public class PackageLoggerProviderRotationTests
         // Assert — all appends to the initial segment.
         Assert.IsTrue(appendedPaths.Count > 0, "Expected at least one flush.");
         foreach (var path in appendedPaths)
-            Assert.AreEqual("Logs/agent.jsonl", path);
+            Assert.AreEqual($"{PackagePaths.Logs}/agent.jsonl", path);
     }
 
     /// <summary>
@@ -101,9 +101,9 @@ public class PackageLoggerProviderRotationTests
         Assert.IsTrue(appendedPaths.Count > 0, "Expected at least one flush.");
         Assert.IsTrue(totalBytesAppended > 1 * 1024 * 1024,
             $"Expected >1 MB of data to be appended, but got {totalBytesAppended} bytes.");
-        Assert.IsTrue(appendedPaths.Exists(p => p == "Logs/agent.jsonl"),
+        Assert.IsTrue(appendedPaths.Exists(p => p == $"{PackagePaths.Logs}/agent.jsonl"),
             "Expected initial segment.");
-        Assert.IsTrue(appendedPaths.Exists(p => p == "Logs/agent-001.jsonl"),
+        Assert.IsTrue(appendedPaths.Exists(p => p == $"{PackagePaths.Logs}/agent-001.jsonl"),
             $"Expected rotation to agent-001.jsonl after exceeding 1 MB. " +
             $"Total bytes: {totalBytesAppended}, flushes: {appendedPaths.Count}.");
     }
@@ -148,7 +148,7 @@ public class PackageLoggerProviderRotationTests
         // Assert — all writes to initial segment only.
         Assert.IsTrue(appendedPaths.Count > 0, "Expected at least one flush.");
         foreach (var path in appendedPaths)
-            Assert.AreEqual("Logs/agent.jsonl", path);
+            Assert.AreEqual($"{PackagePaths.Logs}/agent.jsonl", path);
     }
 
     [TestMethod]
@@ -158,7 +158,7 @@ public class PackageLoggerProviderRotationTests
         var opts = Options.Create(new DiagnosticLogOptions());
         using var provider = new PackageLoggerProvider(state, opts);
 
-        Assert.AreEqual("Logs/agent.jsonl", provider.CurrentLogPath);
+        Assert.AreEqual($"{PackagePaths.Logs}/agent.jsonl", provider.CurrentLogPath);
     }
 }
 #endif


### PR DESCRIPTION
This pull request updates documentation and code comments throughout the project to standardize and clarify the use of the `.migration/` dotfolder for storing migration state, logs, and checkpoints. The changes ensure that all references to persistent state paths (such as `Checkpoints/` and `Logs/`) now point to the `.migration/` subdirectory, improving consistency and supporting legacy fallback for older package formats.

**Key changes include:**

**Migration State and Checkpoints Path Updates:**

- All documentation references to `Checkpoints/` have been updated to `.migration/Checkpoints/`, including cursor files, id maps, and job phase records, to reflect the new standard location for migration state. [[1]](diffhunk://#diff-7304ae239c33c4ecddbdcf66fbf1068d098d1e225f0857e14f914d731e0eacc7L10-R10) [[2]](diffhunk://#diff-7304ae239c33c4ecddbdcf66fbf1068d098d1e225f0857e14f914d731e0eacc7L64-R67) [[3]](diffhunk://#diff-7304ae239c33c4ecddbdcf66fbf1068d098d1e225f0857e14f914d731e0eacc7L81-R81) [[4]](diffhunk://#diff-7304ae239c33c4ecddbdcf66fbf1068d098d1e225f0857e14f914d731e0eacc7L103-R103) [[5]](diffhunk://#diff-7304ae239c33c4ecddbdcf66fbf1068d098d1e225f0857e14f914d731e0eacc7L118-R118) [[6]](diffhunk://#diff-aafee1e304d2b4a7cc0d7511dd3e6f79a6ca0d20a58b904da82a74a2bac52d7aL104-R106) [[7]](diffhunk://#diff-adfd9b4d0cac875c5812306af4010a022f2208762cc17c528869962d6c9600c2L89-R89) [[8]](diffhunk://#diff-028292a8cf9cfd4dc81b67f2214f4f26decd65a3835b97b08cde9868fab9ccd3L407-R407) [[9]](diffhunk://#diff-028292a8cf9cfd4dc81b67f2214f4f26decd65a3835b97b08cde9868fab9ccd3L504-R504) [[10]](diffhunk://#diff-f2f15ff1586dd06404b1887f54ebf6ba46a40224c6d3089c8e40593cbdda8f11L64-R64) [[11]](diffhunk://#diff-f2f15ff1586dd06404b1887f54ebf6ba46a40224c6d3089c8e40593cbdda8f11L80-R81) [[12]](diffhunk://#diff-f2f15ff1586dd06404b1887f54ebf6ba46a40224c6d3089c8e40593cbdda8f11L116-R116) [[13]](diffhunk://#diff-f2f15ff1586dd06404b1887f54ebf6ba46a40224c6d3089c8e40593cbdda8f11L170-R170) [[14]](diffhunk://#diff-f2f15ff1586dd06404b1887f54ebf6ba46a40224c6d3089c8e40593cbdda8f11L196-R196) [[15]](diffhunk://#diff-f2f15ff1586dd06404b1887f54ebf6ba46a40224c6d3089c8e40593cbdda8f11L383-R383) [[16]](diffhunk://#diff-30c421211ce48f2bd27cd2866430846fc14302f8c10ad2eea7d0dabd4ae436beL23-R23) [[17]](diffhunk://#diff-27b8f3a8ebe4ccba1abe89a9d56ae936298659cb083019605328dd89850205edL30-R30)

**Logs Path and CLI Documentation Updates:**

- All references to `Logs/` have been updated to `.migration/Logs/`, including CLI command documentation and validation reporting. [[1]](diffhunk://#diff-13f822cb0301574ab937007caab5dccdaa4c3f9acf2b9b4e1a3c4b0c70c8ca08L36-R36) [[2]](diffhunk://#diff-13f822cb0301574ab937007caab5dccdaa4c3f9acf2b9b4e1a3c4b0c70c8ca08L122-R122) [[3]](diffhunk://#diff-d21900f8fbee9c9d0bfcf78407791d5e3de6977b2258eb848fb9a90f8097f7d8L65-R70) [[4]](diffhunk://#diff-d21900f8fbee9c9d0bfcf78407791d5e3de6977b2258eb848fb9a90f8097f7d8L87-R90) [[5]](diffhunk://#diff-30c421211ce48f2bd27cd2866430846fc14302f8c10ad2eea7d0dabd4ae436beL40-R40) [[6]](diffhunk://#diff-f2f15ff1586dd06404b1887f54ebf6ba46a40224c6d3089c8e40593cbdda8f11L80-R81) [[7]](diffhunk://#diff-27b8f3a8ebe4ccba1abe89a9d56ae936298659cb083019605328dd89850205edL54-R54)

**Legacy Fallback and Backward Compatibility:**

- Documentation now explicitly describes legacy fallback behavior: code will attempt to read from `.migration/` first and fall back to root-level `Checkpoints/` and `Logs/` for packages created before the dotfolder change. [[1]](diffhunk://#diff-d21900f8fbee9c9d0bfcf78407791d5e3de6977b2258eb848fb9a90f8097f7d8R33-R42) [[2]](diffhunk://#diff-d21900f8fbee9c9d0bfcf78407791d5e3de6977b2258eb848fb9a90f8097f7d8L87-R90)

**Idempotency and Import Logic:**

- Idempotency enforcement and import logic references now use `.migration/Checkpoints/idmap.db` instead of the previous `Checkpoints/idmap.db` path. [[1]](diffhunk://#diff-51ad7e5ac73736b60b46b49eb3f4b2f7966e54bdbb4043472beb463bce8b55bbL37-R40) [[2]](diffhunk://#diff-028292a8cf9cfd4dc81b67f2214f4f26decd65a3835b97b08cde9868fab9ccd3L407-R407)

**System Architecture and Guardrails:**

- System architecture and guardrails documentation updated to require all persistent state, including progress and resume state, to be stored under `.migration/Checkpoints/` and `.migration/Logs/`. [[1]](diffhunk://#diff-27b8f3a8ebe4ccba1abe89a9d56ae936298659cb083019605328dd89850205edL30-R30) [[2]](diffhunk://#diff-27b8f3a8ebe4ccba1abe89a9d56ae936298659cb083019605328dd89850205edL54-R54) [[3]](diffhunk://#diff-f2f15ff1586dd06404b1887f54ebf6ba46a40224c6d3089c8e40593cbdda8f11L64-R64) [[4]](diffhunk://#diff-f2f15ff1586dd06404b1887f54ebf6ba46a40224c6d3089c8e40593cbdda8f11L80-R81) [[5]](diffhunk://#diff-f2f15ff1586dd06404b1887f54ebf6ba46a40224c6d3089c8e40593cbdda8f11L116-R116) [[6]](diffhunk://#diff-f2f15ff1586dd06404b1887f54ebf6ba46a40224c6d3089c8e40593cbdda8f11L170-R170) [[7]](diffhunk://#diff-f2f15ff1586dd06404b1887f54ebf6ba46a40224c6d3089c8e40593cbdda8f11L196-R196) [[8]](diffhunk://#diff-f2f15ff1586dd06404b1887f54ebf6ba46a40224c6d3089c8e40593cbdda8f11L383-R383)

These changes ensure future consistency and clarity in the handling of migration state and logs, and improve support for both new and legacy package formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation & Chores

* **Documentation Updates**: Updated all documentation to reflect reorganised package storage locations. Checkpoint and log files now reside within a `.migration/` subdirectory for improved structure and organisation.

* **Path Reorganisation**: Migration packages now store checkpoint cursors and diagnostic logs under `.migration/Checkpoints/` and `.migration/Logs/` respectively, with backward-compatible fallback support for legacy locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->