### PR TITLE
feat: add metrics tracking for work item export progress

### DIFF
--- a/analysis/separation-of-concerns.md
+++ b/analysis/separation-of-concerns.md
@@ -65,26 +65,79 @@ in `Abstractions/ControlPlane/`.
 
 ### Project reference topology — enforced by compiler
 
+**Abstractions layer** (contract assemblies only — no implementation code):
+
 | Project | Abstractions | Abstractions.ControlPlane | Abstractions.Agent |
 |---------|:---:|:---:|:---:|
 | `CLI.Migration` | ✅ | ❌ | ❌ |
 | `TUI` | ✅ | ❌ | ❌ |
-| `ControlPlane` / `ControlPlaneHost` | ✅ | ✅ | ❌ |
+| `ControlPlane` | ✅ | ✅ | ❌ |
+| `ControlPlaneHost` | ✅ | ✅ | ❌ |
 | `MigrationAgent` | ✅ | ❌ | ✅ |
 | `CLI.TfsMigration` (.NET 4.8) | ✅ | ❌ | ✅ |
-| `Infrastructure` | ✅ | ❌ | ✅ |
+| `Infrastructure` | ✅ | ❌ | ❌ |
+| `Infrastructure.ControlPlane` | ✅ | ✅ | ❌ |
+| `Infrastructure.Agent` | ✅ | ❌ | ✅ |
+| `Infrastructure.AzureDevOps` | ✅ | ❌ | ✅ |
+| `Infrastructure.Simulated` | ✅ | ❌ | ✅ |
+| `Infrastructure.TfsObjectModel` | ✅ | ❌ | ✅ |
+| `ServiceDefaults` | ✅ | ❌ | ❌ |
+| `AppHost` | — | — | — |
+
+**Implementation layer** (composition roots wire concrete types):
+
+| Project | Infrastructure | Infra.ControlPlane | Infra.Agent | Infra.AzureDevOps | Infra.Simulated | Infra.TfsObjectModel |
+|---------|:---:|:---:|:---:|:---:|:---:|:---:|
+| `CLI.Migration` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `TUI` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `ControlPlane` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `ControlPlaneHost` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `MigrationAgent` | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
+| `CLI.TfsMigration` | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |
+| `Infrastructure.ControlPlane` | ✅ | — | ❌ | ❌ | ❌ | ❌ |
+| `Infrastructure.Agent` | ✅ | ❌ | — | ❌ | ❌ | ❌ |
+| `Infrastructure.AzureDevOps` | ✅ | ❌ | ✅ | — | ❌ | ❌ |
+| `Infrastructure.Simulated` | ✅ | ❌ | ✅ | ❌ | — | ❌ |
+| `Infrastructure.TfsObjectModel` | ✅ | ❌ | ✅ | ❌ | ❌ | — |
+
+The CLI references base `Infrastructure` for config binding and serialization only —
+no Agent or CP implementations are reachable.
+
+`ControlPlaneHost` can see `Infrastructure.ControlPlane` (CP metric stores, lifecycle
+metrics) but cannot see `Infrastructure.Agent` (artefact store, export orchestrators,
+progress sinks). A developer cannot accidentally `new FileSystemArtefactStore()` in the
+CP composition root — the compiler will reject it.
+
+`AppHost` references `ControlPlaneHost` and `MigrationAgent` as Aspire project resources
+only — no compile-time type dependency.
 
 Every component talks to the ControlPlane exclusively via HTTP contracts in base
 `Abstractions`. Only `ControlPlane`/`ControlPlaneHost` references `Abstractions.ControlPlane`.
 The CP-internal store and OTel interfaces are invisible to everything outside the CP process.
+
+**Test projects** mirror the topology of their system-under-test:
+
+| Test project | References (beyond test frameworks) |
+|---|---|
+| `Infrastructure.Tests` | `Abstractions`, `Abstractions.Agent`, `Infrastructure`, `Infrastructure.AzureDevOps`, `Infrastructure.Simulated` |
+| `Infrastructure.Simulated.Tests` | `Abstractions`, `Abstractions.Agent`, `Infrastructure`, `Infrastructure.Simulated` |
+| `CLI.Migration.Tests` | `Abstractions`, `CLI.Migration` |
+| `ControlPlane.Tests` | `Abstractions`, `Abstractions.ControlPlane`, `ControlPlane` |
+
+Test projects MUST NOT reference across component boundaries:
+- `Infrastructure.Tests` must NOT reference `CLI.Migration` (current violation — remove)
+- `CLI.Migration.Tests` must NOT reference `Infrastructure` or `Infrastructure.AzureDevOps` (current violation — remove)
 
 ---
 
 ## `DevOpsMigrationPlatform.Abstractions` — truly cross-cutting
 
 Shared types that all three components (CLI, ControlPlane, Agent) legitimately depend on.
+Every folder name is a business noun or a platform capability — no technical buckets.
 
-### `Domain/`
+### `Jobs/`
+The central unit of work in the system. A job is queued by the CLI, scheduled by the
+ControlPlane, and executed by the Agent.
 ```
 Job.cs
 MigrationJob.cs
@@ -96,16 +149,26 @@ JobPackage.cs
 JobResume.cs
 JobGuardrails.cs
 JobPolicies.cs
-ProgressEvent.cs                  ← flows CLI → CP → Agent → CLI
-DiagnosticLogRecord.cs            ← flows CLI → CP → Agent → CLI
-OrganisationEndpoint.cs
-OrganisationEndpointAuthentication.cs
-ScopedOrganisationEndpoint.cs
 ResumeDecision.cs
 ResumeDecisionStatus.cs
 ResumeRejectedException.cs
-ValidationContext.cs
-FilterOperator.cs
+MigrationErrorCategory.cs         ← moved from Errors/
+MigrationException.cs             ← moved from Errors/
+```
+
+### `Streaming/`
+Real-time event payloads that flow between all three components via SSE.
+```
+ProgressEvent.cs                  ← flows Agent → CP → CLI
+DiagnosticLogRecord.cs            ← flows Agent → CP → CLI
+```
+
+### `Organisations/`
+The organisational topology: endpoints, authentication, and project scoping.
+```
+OrganisationEndpoint.cs
+OrganisationEndpointAuthentication.cs
+ScopedOrganisationEndpoint.cs
 ```
 
 ### `Configuration/`
@@ -140,7 +203,8 @@ DependencyCounters.cs             ← embedded in DiscoveryCounters
 ```
 
 ### `Options/`
-Config schema — cross-cutting. Includes backend-specific endpoint option types
+Config schema — cross-cutting. This is a .NET framework idiom (`IOptions<T>`) that is
+well-understood in the ecosystem. Includes backend-specific endpoint option types
 (currently in `Infrastructure.AzureDevOps.Options` and `Infrastructure.Simulated.Options`)
 because they are config schema, not execution contracts.
 ```
@@ -149,12 +213,16 @@ AzureDevOpsEndpointOptions.cs     ← moved from Infrastructure.AzureDevOps.Opti
 AzureDevOpsOrganisationEntry.cs   ← moved from Infrastructure.AzureDevOps.Options
 SimulatedEndpointOptions.cs       ← moved from Infrastructure.Simulated.Options
 SimulatedOrganisationEntry.cs     ← moved from Infrastructure.Simulated.Options
-CommentsExtensionOptionsConfig.cs
+SimulatedProjectConfig.cs         ← moved from Infrastructure.Simulated.Options
+SimulatedWorkItemTypeConfig.cs    ← moved from Infrastructure.Simulated.Options
+SimulatedGeneratorConfig.cs       ← moved from Infrastructure.Simulated.Options
+CommentsExtensionOptionsConfig.cs ← moved from Modules/
 DiscoveryOptions.cs
-EmbeddedImagesExtensionOptionsConfig.cs
+EmbeddedImagesExtensionOptionsConfig.cs ← moved from Modules/
 EnabledExtensionOptions.cs
 EndpointAuthenticationOptions.cs
 FilterMode.cs
+FilterOperator.cs                 ← moved from Domain/ (config filter concern)
 IModuleOptions.cs
 MigrationCheckpointsOptions.cs
 MigrationEndpointOptions.cs
@@ -172,6 +240,7 @@ WorkItemResolutionStrategyOptionsConfig.cs
 WorkItemsExtensionsOptions.cs
 WorkItemsModuleOptions.cs
 WorkItemsScopeOptions.cs
+ConfigTokenResolver.cs            ← moved from Utilities/; renamed from TokenResolver
 ```
 
 ### `Serialization/`
@@ -183,15 +252,9 @@ PolymorphicEndpointOptionsConverter.cs
 MigrationPlatformJsonContext.cs   ← (or equivalent serializer setup)
 ```
 
-### `Errors/`
-```
-MigrationErrorCategory.cs
-MigrationException.cs
-PackageLockConflictException.cs
-```
-
 ### `Validation/`
 ```
+ValidationContext.cs              ← moved from Domain/
 ValidationError.cs
 ValidationResult.cs
 ```
@@ -242,28 +305,6 @@ IJobSnapshotStore.cs              ← CP persists incoming agent snapshots
 Contracts used exclusively inside the Migration Agent and `CLI.TfsMigration`
 (the TFS Export Agent running inline).
 
-### `Storage/`
-```
-IArtefactStore.cs
-IStateStore.cs
-```
-
-### `Checkpointing/`
-```
-CursorEntry.cs
-CursorStage.cs
-JobPhaseRecord.cs
-```
-
-### `Runtime/`
-Agent lifecycle singletons — set when a lease is acquired, cleared on release.
-```
-ActiveLeaseState.cs
-ActivePackageState.cs
-PackagePaths.cs
-PathUtilities.cs                  ← moved from Utilities/; rename to PackagePathUtilities
-```
-
 ### `WorkItems/`
 ```
 WorkItemRevision.cs
@@ -285,22 +326,18 @@ FetchedWorkItem.cs
 IdMapEntry.cs
 ```
 
-### `Attachments/`
+### `Discovery/`
+Inventory, dependency analysis, and project/repo discovery — the Agent's first phase.
 ```
-AttachmentMetadata.cs
-AttachmentCounters.cs
-AttachmentDownloadResult.cs
-AttachmentMapEntry.cs
-EmbeddedImageMetadata.cs
-EmbeddedImageDownloadResult.cs
-```
-
-### `Export/`
-```
-ExportContext.cs
-BatchContinuationToken.cs
-RevisionProcessResult.cs
 DiscoveryContext.cs
+ICatalogService.cs
+IInventoryService.cs
+IInventoryServiceFactory.cs
+IProjectDiscoveryService.cs
+IRepoDiscoveryService.cs
+IWorkItemDiscoveryService.cs
+IDependencyDiscoveryService.cs
+IDependencyDiscoveryServiceFactory.cs
 InventoryReport.cs
 InventorySummary.cs
 InventoryProgressEvent.cs
@@ -310,51 +347,89 @@ DependencySummary.cs
 DependencyProgressEvent.cs
 ```
 
+### `Export/`
+Work item revision extraction — reading from source, writing to package.
+```
+ExportContext.cs
+BatchContinuationToken.cs
+RevisionProcessResult.cs
+IWorkItemRevisionSource.cs
+IWorkItemRevisionSourceFactory.cs
+IRevisionFolderProcessor.cs
+IRevisionFolderProcessorFactory.cs
+IWorkItemFetchService.cs
+IWorkItemCommentSource.cs
+IWorkItemCommentSourceFactory.cs
+IWorkItemQueryWindowStrategy.cs
+WorkItemQueryWindow.cs
+IQueryFingerprintService.cs
+```
+
 ### `Import/`
+Work item creation in the target system.
 ```
 ImportContext.cs
 ImportedWorkItemResult.cs
+IWorkItemImportTarget.cs
+IWorkItemImportTargetFactory.cs
+IWorkItemResolutionStrategy.cs
+IWorkItemResolutionStrategyFactory.cs
+IWorkItemLinkAnalysisService.cs
 ```
 
-### `Services/`
+### `Attachments/`
+Binary content — downloads from source, streams to package.
 ```
-ICatalogService.cs
-IInventoryService.cs
-IInventoryServiceFactory.cs
-IProjectDiscoveryService.cs
-IRepoDiscoveryService.cs
-IWorkItemDiscoveryService.cs
-IDependencyDiscoveryService.cs
-IDependencyDiscoveryServiceFactory.cs
+AttachmentMetadata.cs
+AttachmentCounters.cs
+AttachmentDownloadResult.cs
+AttachmentMapEntry.cs
+EmbeddedImageMetadata.cs
+EmbeddedImageDownloadResult.cs
 IAttachmentBinarySource.cs
-ICheckpointingService.cs
-ICheckpointingServiceFactory.cs
 IEmbeddedImageDownloader.cs
 IEmbeddedImageExportService.cs
+```
+
+### `Identity/`
+Mapping source identities to target identities.
+```
 IIdentityMappingService.cs
-IIdMapStore.cs
-IIdMapStoreFactory.cs
+```
+
+### `Storage/`
+Package persistence — artefact store, state store, and package-level services.
+```
+IArtefactStore.cs
+IStateStore.cs
 IPackageLockService.cs
 IPackageStoreFactory.cs
 IPackageValidator.cs
+IIdMapStore.cs
+IIdMapStoreFactory.cs
+PackageLockConflictException.cs   ← moved from Abstractions/Errors/
+```
+
+### `Checkpointing/`
+Cursor-based resume and phase tracking.
+```
+CursorEntry.cs
+CursorStage.cs
+JobPhaseRecord.cs
+ICheckpointingService.cs
+ICheckpointingServiceFactory.cs
 IPhaseTrackingService.cs
 IPhaseTrackingServiceFactory.cs
-IProgressSink.cs
-IQueryFingerprintService.cs
-IRevisionFolderProcessor.cs
-IRevisionFolderProcessorFactory.cs
-IWorkItemCommentSource.cs
-IWorkItemCommentSourceFactory.cs
-IWorkItemFetchService.cs
-IWorkItemImportTarget.cs
-IWorkItemImportTargetFactory.cs
-IWorkItemLinkAnalysisService.cs
-IWorkItemQueryWindowStrategy.cs
-WorkItemQueryWindow.cs
-IWorkItemResolutionStrategy.cs
-IWorkItemResolutionStrategyFactory.cs
-IWorkItemRevisionSource.cs
-IWorkItemRevisionSourceFactory.cs
+```
+
+### `Lease/`
+Agent session state — set when a lease is acquired, cleared on release.
+```
+ActiveLeaseState.cs
+ActivePackageState.cs
+PackagePaths.cs
+PackagePathUtilities.cs
+IProgressSink.cs                  ← agent lifecycle progress reporting
 ```
 
 ### `Telemetry/`
@@ -367,62 +442,268 @@ IMigrationMetrics.cs
 ```
 
 ### `Modules/`
+The Agent's plugin system — module contracts only, no configuration schema.
 ```
 IModule.cs
 IDiscoveryModule.cs
 WorkItemsModuleExtensions.cs
-CommentsExtensionOptions.cs
-EmbeddedImagesExtensionOptions.cs
 ```
 
 ---
 
-## Migration path
+## `DevOpsMigrationPlatform.Infrastructure` — cross-cutting implementations
 
-### Step 1 — Delete in-process fallback from `LocalStackHost`
+Config binding, serialization, options validation, and DI extension methods that all
+composition roots need. No Agent-specific or CP-specific implementations.
 
-Remove `StartControlPlaneInProcessAsync()` and `StartAgentInProcessAsync()`.
-When published binaries are not found, fail with an actionable error:
-`"ControlPlane/Agent binaries not found. Run 'build.ps1 Install' to publish."`.
+### `Config/`
+Options binding and validation.
+```
+MigrationPlatformServiceExtensions.cs   ← AddMigrationPlatformOptions(), AddMigrationPlatformPolymorphicSerializers()
+MigrationOptionsValidator.cs
+DiscoveryOptionsOrganisationsBinder.cs
+```
 
-This immediately removes the need for three project references:
-`ControlPlane`, `MigrationAgent`, and most of `Infrastructure`.
+### `Serialization/`
+Polymorphic JSON converters and type registry.
+After Phase 1 Step 1.5, the cross-cutting converters move to `Abstractions/Serialization/`.
+What remains here are internal helpers:
+```
+EndpointOptionsTypeRegistry.cs
+EndpointOptionsRegistration.cs
+PolymorphicOrganisationEntryConverter.cs  ← if not also moved to Abstractions
+```
 
-### Step 2 — Move config-schema types to `Abstractions/Options/`
+### `Telemetry/`
+Cross-cutting telemetry utilities used by both Agent and CP:
+```
+DataClassificationLogProcessor.cs
+DataClassificationExtensions.cs
+```
 
-Move `AzureDevOpsEndpointOptions`, `AzureDevOpsOrganisationEntry`,
-`SimulatedEndpointOptions`, `SimulatedOrganisationEntry` from their
-`Infrastructure.*` projects into `Abstractions/Options/`.
+### `Polyfills/`
+```
+IsExternalInit.cs                       ← .NET 4.8 only
+```
 
-Move endpoint type-registration extension methods (`AddEndpointOptionsType`,
-`AddOrganisationEntryType`) to `Abstractions` so any component can register
-polymorphic config types without referencing `Infrastructure`.
+---
 
-### Step 3 — Move serialization to `Abstractions/Serialization/`
+## `DevOpsMigrationPlatform.Infrastructure.ControlPlane` — CP-only implementations
 
-Move `PolymorphicEndpointOptionsConverter` and `AddMigrationPlatformPolymorphicSerializers()`
-from `Infrastructure.Serialization` to `Abstractions/Serialization/`.
+Concrete implementations of `Abstractions.ControlPlane` interfaces. Only
+`ControlPlaneHost` references this project.
 
-### Step 4 — Extract `IPreFlightValidator` to `Abstractions/Configuration/`
+```xml
+<!-- Infrastructure.ControlPlane.csproj -->
+<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions.ControlPlane\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure\..." />
+```
 
-`QueueCommand` currently references `AzureDevOpsValidation` (concrete class in
-`Infrastructure.AzureDevOps`). Extract `IPreFlightValidator` interface to
-`Abstractions/Configuration/`. The implementation stays in `Infrastructure.AzureDevOps`
-and is resolved via DI — the CLI never holds a direct reference.
+### `Metrics/`
+```
+InMemoryJobMetricsStore.cs        ← implements IJobMetricsStore
+InMemoryJobSnapshotStore.cs       ← implements IJobSnapshotStore
+JobLifecycleMetrics.cs            ← implements IJobLifecycleMetrics
+SnapshotMetricExporter.cs         ← OTel metric exporter for CP
+TelemetryServiceExtensions.cs     ← AddControlPlaneTelemetryServices() — registers CP-only metrics
+```
 
-### Step 5 — Remove concrete `ConfigurationService` usage from CLI commands
+---
 
-`QueueCommand`, `ConfigNewCommand`, `ConfigureCommand`, `PrepareCommand` all
-`new` up `ConfigurationService` (a concrete class in `Infrastructure.Services`).
-Register it via `IConfigurationService` from a CLI composition-root extension method.
-The concrete class stays in `Infrastructure`.
+## `DevOpsMigrationPlatform.Infrastructure.Agent` — Agent-only implementations
 
-### Step 6 — Move `TokenResolver` to `Abstractions/Options/`
+Concrete implementations of `Abstractions.Agent` interfaces. Only `MigrationAgent`
+and `CLI.TfsMigration` reference this project.
 
-Currently in `Utilities/`. It resolves config tokens (`{env:VAR}`) — a cross-cutting
-config concern. Rename to `ConfigTokenResolver` for clarity.
+```xml
+<!-- Infrastructure.Agent.csproj -->
+<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions.Agent\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure\..." />
+```
 
-### Step 7 — Remove all invalid project references
+### `Storage/`
+```
+FileSystemArtefactStore.cs        ← implements IArtefactStore
+AzureBlobArtefactStore.cs         ← implements IArtefactStore (stub, NET481 only)
+FileSystemPackageStoreFactory.cs  ← implements IPackageStoreFactory (moved from Factories/)
+```
+
+### `Checkpointing/`
+```
+CheckpointingService.cs           ← implements ICheckpointingService
+CheckpointingServiceFactory.cs    ← implements ICheckpointingServiceFactory
+FileSystemStateStore.cs           ← implements IStateStore
+PhaseTrackingService.cs           ← implements IPhaseTrackingService (moved from JobEngine/)
+PhaseTrackingServiceFactory.cs    ← implements IPhaseTrackingServiceFactory (moved from JobEngine/)
+```
+
+### `Export/`
+```
+WorkItemExportOrchestrator.cs
+EmbeddedImageExportService.cs     ← implements IEmbeddedImageExportService
+CompositeWorkItemRevisionSourceFactory.cs ← implements IWorkItemRevisionSourceFactory
+```
+
+### `Import/`
+```
+WorkItemImportOrchestrator.cs
+CompositeWorkItemImportTargetFactory.cs   ← implements IWorkItemImportTargetFactory
+CompositeWorkItemResolutionStrategyFactory.cs ← implements IWorkItemResolutionStrategyFactory
+RevisionFolderProcessor.cs
+RevisionFolderProcessorFactory.cs         ← implements IRevisionFolderProcessorFactory
+WorkItemRevisionFolderParser.cs
+SqliteIdMapStore.cs               ← implements IIdMapStore
+IdMapStoreFactory.cs              ← implements IIdMapStoreFactory
+PassThroughIdentityMappingService.cs ← implements IIdentityMappingService
+NullResolutionStrategy.cs         ← implements IWorkItemResolutionStrategy
+```
+
+### `Discovery/`
+```
+CatalogService.cs                 ← implements ICatalogService (moved from Services/)
+InventoryService.cs               ← implements IInventoryService (moved from Services/)
+DependencyDiscoveryService.cs     ← implements IDependencyDiscoveryService (moved from Services/)
+QueryFingerprintService.cs        ← implements IQueryFingerprintService (moved from Services/)
+PackageLockFileService.cs         ← implements IPackageLockService (moved from Services/)
+FileSystemIdentityMappingService.cs ← implements IIdentityMappingService (moved from Services/)
+```
+
+### `Modules/`
+```
+WorkItemsModule.cs                ← implements IModule
+InventoryDiscoveryModule.cs       ← implements IDiscoveryModule
+DependencyDiscoveryModule.cs      ← implements IDiscoveryModule
+ModuleServiceCollectionExtensions.cs ← AddWorkItemsModule(), AddInventoryDiscoveryModule(), AddDependencyDiscoveryModule()
+```
+
+### `Modules/Discovery/`
+Internal utilities for dependency analysis:
+```
+ProjectDependencyRecord.cs
+MermaidUtilities.cs
+MermaidDiagramBuilder.cs
+TransitiveDependencyEdge.cs
+ProjectPairKey.cs
+TransitiveDependencyWalker.cs
+TransitiveMermaidBuilder.cs
+UnionFindComponentLabeler.cs
+```
+
+### `Telemetry/`
+Agent-side telemetry: progress sinks, metric implementations, log providers.
+```
+DiscoveryMetrics.cs               ← implements IDiscoveryMetrics
+MigrationMetrics.cs               ← implements IMigrationMetrics
+AnsiProgressSink.cs               ← implements IProgressSink
+CompositeProgressSink.cs          ← implements IProgressSink
+ControlPlaneProgressSink.cs       ← implements IProgressSink (Agent pushes to CP)
+PackageProgressSink.cs            ← implements IProgressSink (writes to package)
+ControlPlaneTelemetryClient.cs    ← implements IControlPlaneTelemetryClient
+ControlPlaneLoggerProvider.cs     ← ILoggerProvider (forwards logs to CP)
+PackageLoggerProvider.cs          ← ILoggerProvider (writes logs to package)
+TelemetryServiceExtensions.cs     ← AddAgentTelemetryServices() — registers Agent-only telemetry
+DiagnosticsServiceExtensions.cs   ← AddDiagnosticsServices() — Agent diagnostic log pipeline
+```
+
+### `Validation/`
+```
+PackageValidator.cs               ← implements IPackageValidator
+```
+
+### `DI/`
+Factory dispatcher registration — used by `Infrastructure.AzureDevOps` and `Infrastructure.Simulated`:
+```
+FactoryRegistrationExtensions.cs  ← moved from Extensions/
+```
+
+---
+
+## Migration plan
+
+Each step is independently buildable. Run `dotnet clean && dotnet build --no-incremental`
+after each step. Do not combine steps — a broken intermediate state is harder to diagnose.
+
+---
+
+### Phase 1 — Sever the CLI ↔ Agent/CP compile-time coupling
+
+#### Step 1.1 — Delete in-process fallback from `LocalStackHost`
+
+**Why:** This single class is the root cause of all five invalid project references.
+Removing it makes Steps 1.2–1.5 possible.
+
+| Action | Target |
+|--------|--------|
+| Delete method | `LocalStackHost.StartControlPlaneInProcessAsync()` |
+| Delete method | `LocalStackHost.StartAgentInProcessAsync()` |
+| Replace fallback | When published binaries not found → `throw new InvalidOperationException("ControlPlane/Agent binaries not found. Run 'build.ps1 Install' to publish.")` |
+| Remove using | Any `using` for `ControlPlane`, `MigrationAgent`, `Infrastructure` namespaces in `LocalStackHost.cs` |
+
+**Verify:** CLI still launches CP + Agent via `ChildProcessHost` in process-per-component mode.
+
+#### Step 1.2 — Extract `IPreFlightValidator` interface
+
+**Why:** `QueueCommand` currently calls `AzureDevOpsValidation` (concrete class in
+`Infrastructure.AzureDevOps`) directly. The CLI must depend on an abstraction.
+
+| Action | Detail |
+|--------|--------|
+| Create file | `Abstractions/Configuration/IPreFlightValidator.cs` |
+| Extract interface | From `AzureDevOpsValidation` public surface |
+| Update `QueueCommand` | Inject `IPreFlightValidator` instead of `new AzureDevOpsValidation(...)` |
+| Register in DI | `Infrastructure.AzureDevOps` registers `AzureDevOpsValidation` as `IPreFlightValidator` |
+
+#### Step 1.3 — Remove direct `ConfigurationService` instantiation
+
+**Why:** CLI commands `new` up a concrete class from `Infrastructure.Services`.
+
+| Action | Detail |
+|--------|--------|
+| Update | `QueueCommand`, `ConfigNewCommand`, `ConfigureCommand`, `PrepareCommand` |
+| Change | Replace `new ConfigurationService(...)` → constructor-inject `IConfigurationService` |
+| Register | In `MigrationCliServiceCollectionExtensions`, add `services.AddSingleton<IConfigurationService, ConfigurationService>()` — but this still requires Infrastructure reference |
+| Split registration | Create `Abstractions/Configuration/ConfigurationServiceCollectionExtensions.cs` with `AddConfigurationService(this IServiceCollection)` method that takes a factory delegate |
+| Actual registration | Move to `Infrastructure` as an extension method that the CLI's composition root calls |
+
+#### Step 1.4 — Move config-schema types to `Abstractions/Options/`
+
+**Why:** The CLI needs these to deserialise config files. Currently they live in
+`Infrastructure.AzureDevOps` and `Infrastructure.Simulated`, forcing a reference.
+
+| Source | Destination |
+|--------|-------------|
+| `Infrastructure.AzureDevOps/Options/AzureDevOpsEndpointOptions.cs` | `Abstractions/Options/AzureDevOpsEndpointOptions.cs` |
+| `Infrastructure.AzureDevOps/Options/AzureDevOpsOrganisationEntry.cs` | `Abstractions/Options/AzureDevOpsOrganisationEntry.cs` |
+| `Infrastructure.Simulated/Options/SimulatedEndpointOptions.cs` | `Abstractions/Options/SimulatedEndpointOptions.cs` |
+| `Infrastructure.Simulated/Options/SimulatedOrganisationEntry.cs` | `Abstractions/Options/SimulatedOrganisationEntry.cs` |
+| `Infrastructure.Simulated/Options/SimulatedProjectConfig.cs` | `Abstractions/Options/SimulatedProjectConfig.cs` |
+| `Infrastructure.Simulated/Options/SimulatedWorkItemTypeConfig.cs` | `Abstractions/Options/SimulatedWorkItemTypeConfig.cs` |
+| `Infrastructure.Simulated/Options/SimulatedGeneratorConfig.cs` | `Abstractions/Options/SimulatedGeneratorConfig.cs` |
+
+Update namespaces from `DevOpsMigrationPlatform.Infrastructure.*.Options` →
+`DevOpsMigrationPlatform.Abstractions.Options`.
+
+Also move:
+| Source | Destination |
+|--------|-------------|
+| `Infrastructure/Extensions/EndpointOptionsRegistrationExtensions.cs` | `Abstractions/Options/EndpointOptionsRegistrationExtensions.cs` |
+
+#### Step 1.5 — Move serialization to `Abstractions/Serialization/`
+
+**Why:** Polymorphic JSON converters are needed by CLI, CP, and Agent to deserialise
+config and job payloads. Currently in `Infrastructure.Serialization`.
+
+| Source | Destination |
+|--------|-------------|
+| `Infrastructure/Serialization/PolymorphicEndpointOptionsConverter.cs` | `Abstractions/Serialization/PolymorphicEndpointOptionsConverter.cs` |
+| `Infrastructure/Serialization/MigrationPlatformJsonContext.cs` (if exists) | `Abstractions/Serialization/MigrationPlatformJsonContext.cs` |
+
+Update namespace: `DevOpsMigrationPlatform.Infrastructure.Serialization` →
+`DevOpsMigrationPlatform.Abstractions.Serialization`.
+
+#### Step 1.6 — Remove all invalid project references
 
 Delete from `CLI.Migration.csproj`:
 ```xml
@@ -433,10 +714,474 @@ Delete from `CLI.Migration.csproj`:
 <ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure.Simulated\..." />
 ```
 
-### Step 8 — Create `Abstractions.ControlPlane` and `Abstractions.Agent` projects
+**Build gate:** `CLI.Migration` must compile with only `Abstractions` as a project reference.
+Any remaining compile error means a dependency was missed in Steps 1.1–1.5.
 
-Split the files from `DevOpsMigrationPlatform.Abstractions` into the three projects
-as specified above. Update all consuming projects to reference the correct subset.
+#### Step 1.7 — Remove `LogDownloadController` from ControlPlane
+
+**Why:** `LogDownloadController` injects `IPackageStoreFactory` and `IArtefactStore` to
+serve log files. This forces the ControlPlane to reference Agent-internal contracts.
+Operators can access logs directly from the well-known package directory.
+
+| Action | Detail |
+|--------|--------|
+| Delete | `ControlPlane/Controllers/LogDownloadController.cs` |
+| Add field | `JobDiagnostics.LogPath` (string) — the Agent populates this with the absolute path to the package log directory |
+| Update Agent | Set `JobDiagnostics.LogPath` when reporting diagnostics to CP |
+| Update CLI | Display log path to operator: `"Logs available at: {logPath}"` |
+
+After this step, ControlPlane has zero dependency on `IArtefactStore`, `IPackageStoreFactory`,
+or any other Agent-internal contract.
+
+#### Step 1.8 — Move ControlPlane → Infrastructure registration to ControlPlaneHost
+
+**Why:** `ControlPlane/Services/ControlPlaneServiceExtensions.cs` directly references
+`DevOpsMigrationPlatform.Infrastructure.Factories` and hard-codes
+`FileSystemPackageStoreFactory`. The ControlPlane library project must not reference
+`Infrastructure`.
+
+| Action | Detail |
+|--------|--------|
+| Move registration | `services.AddSingleton<IPackageStoreFactory, FileSystemPackageStoreFactory>()` from `ControlPlane/Services/ControlPlaneServiceExtensions.cs` to `ControlPlaneHost/Program.cs` |
+| Remove using | `using DevOpsMigrationPlatform.Infrastructure.Factories` from ControlPlane |
+| Remove reference | `ControlPlane.csproj` must NOT reference `Infrastructure` |
+| Verify | `ControlPlane.csproj` references only `Abstractions` + `Abstractions.ControlPlane` |
+
+Note: After Step 1.7, the `IPackageStoreFactory` registration may no longer be needed
+in the ControlPlane at all. If no other CP service uses it, delete it entirely.
+
+#### Step 1.9 — Fix test project references
+
+**Why:** Test projects must not reference across component boundaries. The test project
+should only reference its system-under-test and the abstraction layers it needs.
+
+| Test project | Remove reference | Reason |
+|---|---|---|
+| `Infrastructure.Tests` | `CLI.Migration` | Infrastructure tests must not depend on CLI |
+| `CLI.Migration.Tests` | `Infrastructure` | CLI tests must mock abstractions, not use concrete infra |
+| `CLI.Migration.Tests` | `Infrastructure.AzureDevOps` | CLI tests must mock abstractions, not use concrete infra |
+
+For any test that currently depends on the removed reference:
+- If it tests CLI+Infrastructure integration → move to a dedicated integration test project
+- If it uses concrete types for test setup → replace with mocks of the abstraction interfaces
+- If it only uses config types → those are now in `Abstractions/Options/` (no reference needed)
+
+---
+
+### Phase 2 — Restructure `Abstractions` folders (screaming architecture)
+
+All moves within the same project. No assembly boundary changes. Every step is a
+namespace update + file move. Run build after each step.
+
+#### Step 2.1 — Dissolve `Models/` into business-noun folders
+
+`Models/` is the largest technical bucket (70 files). Every file moves to a folder
+named after the business concept it represents.
+
+**Create new folders:** `Jobs/`, `Streaming/`, `Organisations/`, `ControlPlane/`
+(ControlPlane/ may already exist for `IControlPlaneClient.cs`).
+
+| Source file in `Models/` | Destination folder | Notes |
+|--------------------------|-------------------|-------|
+| `Job.cs` | `Jobs/` | |
+| `MigrationJob.cs` | `Jobs/` | |
+| `DiscoveryJob.cs` | `Jobs/` | |
+| `DiscoveryJobType.cs` | `Jobs/` | |
+| `JobModule.cs` | `Jobs/` | |
+| `JobModuleScope.cs` | `Jobs/` | |
+| `JobPackage.cs` | `Jobs/` | |
+| `JobResume.cs` | `Jobs/` | |
+| `JobGuardrails.cs` | `Jobs/` | |
+| `JobPolicies.cs` | `Jobs/` | |
+| `ResumeDecision.cs` | `Jobs/` | |
+| `ResumeDecisionStatus.cs` | `Jobs/` | |
+| `ResumeRejectedException.cs` | `Jobs/` | |
+| `ProgressEvent.cs` | `Streaming/` | |
+| `DiagnosticLogRecord.cs` | `Streaming/` | |
+| `OrganisationEndpoint.cs` | `Organisations/` | |
+| `OrganisationEndpointAuthentication.cs` | `Organisations/` | |
+| `ScopedOrganisationEndpoint.cs` | `Organisations/` | |
+| `ValidationContext.cs` | `Validation/` | merge with existing |
+| `FilterOperator.cs` | `Options/` | config filter concern |
+| `JobSummary.cs` | `ControlPlane/` | |
+| `JobMetrics.cs` | `ControlPlane/` | |
+| `JobSnapshot.cs` | `ControlPlane/` | |
+| `JobBootstrap.cs` | `ControlPlane/` | |
+| `JobScopeCounters.cs` | `ControlPlane/` | |
+| `JobDiagnostics.cs` | `ControlPlane/` | |
+| `MigrationCounters.cs` | `ControlPlane/` | |
+| `MigrationDiagnostics.cs` | `ControlPlane/` | |
+| `OrgSnapshot.cs` | `ControlPlane/` | |
+| `ProjectSnapshot.cs` | `ControlPlane/` | |
+| `ProjectStatus.cs` | `ControlPlane/` | |
+| `TargetStatus.cs` | `ControlPlane/` | |
+| `DiscoveryCounters.cs` | `ControlPlane/` | |
+| `InventoryCounters.cs` | `ControlPlane/` | |
+| `DependencyCounters.cs` | `ControlPlane/` | |
+
+**Remaining `Models/` files are Agent-internal.** They stay in `Models/` temporarily —
+they move to `Abstractions.Agent` in Phase 3:
+
+| File | Phase 3 destination |
+|------|-------------------|
+| `WorkItemRevision.cs` | `Agent/WorkItems/` |
+| `WorkItemField.cs` | `Agent/WorkItems/` |
+| `WorkItemComment.cs` | `Agent/WorkItems/` |
+| `WorkItemIdentityRef.cs` | `Agent/WorkItems/` |
+| `WorkItemRelations.cs` | `Agent/WorkItems/` |
+| `WorkItemCounters.cs` | `Agent/WorkItems/` |
+| `WorkItemFetchScope.cs` | `Agent/WorkItems/` |
+| `WorkItemFieldFilterEvaluator.cs` | `Agent/WorkItems/` |
+| `WorkItemFieldFilterOptions.cs` | `Agent/WorkItems/` |
+| `WorkItemQueryChunk.cs` | `Agent/WorkItems/` |
+| `WorkItemQueryCountChunk.cs` | `Agent/WorkItems/` |
+| `ExternalWorkItemLink.cs` | `Agent/WorkItems/` |
+| `HyperlinkWorkItemLink.cs` | `Agent/WorkItems/` |
+| `RelatedWorkItemLink.cs` | `Agent/WorkItems/` |
+| `LinkScope.cs` | `Agent/WorkItems/` |
+| `FetchedWorkItem.cs` | `Agent/WorkItems/` |
+| `IdMapEntry.cs` | `Agent/WorkItems/` |
+| `AttachmentMetadata.cs` | `Agent/Attachments/` |
+| `AttachmentCounters.cs` | `Agent/Attachments/` |
+| `AttachmentDownloadResult.cs` | `Agent/Attachments/` |
+| `AttachmentMapEntry.cs` | `Agent/Attachments/` |
+| `EmbeddedImageMetadata.cs` | `Agent/Attachments/` |
+| `EmbeddedImageDownloadResult.cs` | `Agent/Attachments/` |
+| `ExportContext.cs` | `Agent/Export/` |
+| `BatchContinuationToken.cs` | `Agent/Export/` |
+| `RevisionProcessResult.cs` | `Agent/Export/` |
+| `DiscoveryContext.cs` | `Agent/Discovery/` |
+| `InventoryReport.cs` | `Agent/Discovery/` |
+| `InventorySummary.cs` | `Agent/Discovery/` |
+| `InventoryProgressEvent.cs` | `Agent/Discovery/` |
+| `ProjectDiscoverySummary.cs` | `Agent/Discovery/` |
+| `DependencyRecord.cs` | `Agent/Discovery/` |
+| `DependencySummary.cs` | `Agent/Discovery/` |
+| `DependencyProgressEvent.cs` | `Agent/Discovery/` |
+| `ImportContext.cs` | `Agent/Import/` |
+| `ImportedWorkItemResult.cs` | `Agent/Import/` |
+
+**After Step 2.1:** `Models/` contains only Agent-internal files (tagged for Phase 3).
+Delete `Models/` after Phase 3.
+
+#### Step 2.2 — Dissolve `Services/` into business-noun folders
+
+`Services/` has 41 interfaces. Every interface moves beside the models it operates on.
+
+| Source file in `Services/` | Destination folder | Notes |
+|----------------------------|-------------------|-------|
+| `IConfigurationService.cs` | `Configuration/` | stays in Abstractions |
+| `IJobRunner.cs` | `ControlPlane/` | HTTP contract — stays in Abstractions |
+
+**Remaining 39 files are Agent-internal.** They stay in `Services/` temporarily —
+they move to `Abstractions.Agent` in Phase 3:
+
+| File | Phase 3 destination |
+|------|-------------------|
+| `ICatalogService.cs` | `Agent/Discovery/` |
+| `IInventoryService.cs` | `Agent/Discovery/` |
+| `IInventoryServiceFactory.cs` | `Agent/Discovery/` |
+| `IProjectDiscoveryService.cs` | `Agent/Discovery/` |
+| `IRepoDiscoveryService.cs` | `Agent/Discovery/` |
+| `IWorkItemDiscoveryService.cs` | `Agent/Discovery/` |
+| `IDependencyDiscoveryService.cs` | `Agent/Discovery/` |
+| `IDependencyDiscoveryServiceFactory.cs` | `Agent/Discovery/` |
+| `IWorkItemRevisionSource.cs` | `Agent/Export/` |
+| `IWorkItemRevisionSourceFactory.cs` | `Agent/Export/` |
+| `IRevisionFolderProcessor.cs` | `Agent/Export/` |
+| `IRevisionFolderProcessorFactory.cs` | `Agent/Export/` |
+| `IWorkItemFetchService.cs` | `Agent/Export/` |
+| `IWorkItemCommentSource.cs` | `Agent/Export/` |
+| `IWorkItemCommentSourceFactory.cs` | `Agent/Export/` |
+| `IWorkItemQueryWindowStrategy.cs` | `Agent/Export/` |
+| `WorkItemQueryWindow.cs` | `Agent/Export/` |
+| `IQueryFingerprintService.cs` | `Agent/Export/` |
+| `IWorkItemImportTarget.cs` | `Agent/Import/` |
+| `IWorkItemImportTargetFactory.cs` | `Agent/Import/` |
+| `IWorkItemResolutionStrategy.cs` | `Agent/Import/` |
+| `IWorkItemResolutionStrategyFactory.cs` | `Agent/Import/` |
+| `IWorkItemLinkAnalysisService.cs` | `Agent/Import/` |
+| `IAttachmentBinarySource.cs` | `Agent/Attachments/` |
+| `IEmbeddedImageDownloader.cs` | `Agent/Attachments/` |
+| `IEmbeddedImageExportService.cs` | `Agent/Attachments/` |
+| `IIdentityMappingService.cs` | `Agent/Identity/` |
+| `ICheckpointingService.cs` | `Agent/Checkpointing/` |
+| `ICheckpointingServiceFactory.cs` | `Agent/Checkpointing/` |
+| `IPhaseTrackingService.cs` | `Agent/Checkpointing/` |
+| `IPhaseTrackingServiceFactory.cs` | `Agent/Checkpointing/` |
+| `IPackageLockService.cs` | `Agent/Storage/` |
+| `IPackageStoreFactory.cs` | `Agent/Storage/` |
+| `IPackageValidator.cs` | `Agent/Storage/` |
+| `IIdMapStore.cs` | `Agent/Storage/` |
+| `IIdMapStoreFactory.cs` | `Agent/Storage/` |
+| `IProgressSink.cs` | `Agent/Lease/` |
+| `IModule.cs` | `Agent/Modules/` |
+| `IDiscoveryModule.cs` | `Agent/Modules/` |
+
+**After Step 2.2:** `Services/` contains only Agent-internal files (tagged for Phase 3).
+Delete `Services/` after Phase 3.
+
+#### Step 2.3 — Dissolve `Errors/`
+
+| Source | Destination | Notes |
+|--------|-------------|-------|
+| `Errors/MigrationErrorCategory.cs` | `Jobs/MigrationErrorCategory.cs` | job-level error classification |
+| `Errors/MigrationException.cs` | `Jobs/MigrationException.cs` | job-level exception |
+| `Errors/PackageLockConflictException.cs` | stays in `Errors/` temporarily | moves to `Agent/Storage/` in Phase 3 |
+
+Delete `Errors/` after Phase 3.
+
+#### Step 2.4 — Move root-level files into proper folders
+
+| Source | Destination | Notes |
+|--------|-------------|-------|
+| `Abstractions/IControlPlaneClient.cs` | `Abstractions/ControlPlane/IControlPlaneClient.cs` | HTTP contract |
+| `Abstractions/ActiveLeaseState.cs` | stays at root temporarily | moves to `Agent/Lease/` in Phase 3 |
+| `Abstractions/ActivePackageState.cs` | stays at root temporarily | moves to `Agent/Lease/` in Phase 3 |
+| `Abstractions/PackagePaths.cs` | stays at root temporarily | moves to `Agent/Lease/` in Phase 3 |
+
+#### Step 2.5 — Dissolve `Utilities/`
+
+| Source | Destination | Rename |
+|--------|-------------|--------|
+| `Abstractions/Utilities/TokenResolver.cs` | `Abstractions/Options/ConfigTokenResolver.cs` | class: `TokenResolver` → `ConfigTokenResolver` |
+| `Abstractions/Utilities/PathUtilities.cs` | stays temporarily | moves to `Agent/Lease/PackagePathUtilities.cs` in Phase 3 |
+| `CLI.Migration/Utilities/PathUtilities.cs` | `CLI.Migration/Services/CliPathUtilities.cs` | rename to distinguish from Agent version |
+| `CLI.Migration/Utilities/ExceptionSanitizer.cs` | `CLI.Migration/Services/ExceptionSanitizer.cs` | |
+
+Delete `Abstractions/Utilities/` after Phase 3.
+Delete `CLI.Migration/Utilities/` after this step.
+
+#### Step 2.6 — Move extension options out of `Modules/`
+
+| Source | Destination |
+|--------|-------------|
+| `Abstractions/Modules/CommentsExtensionOptions.cs` | `Abstractions/Options/CommentsExtensionOptionsConfig.cs` |
+| `Abstractions/Modules/EmbeddedImagesExtensionOptions.cs` | `Abstractions/Options/EmbeddedImagesExtensionOptionsConfig.cs` |
+
+`Modules/` retains `WorkItemsModuleExtensions.cs` temporarily (Phase 3 moves it to Agent).
+
+#### Step 2.7 — Separate `Telemetry/` cross-cutting from Agent/CP-specific
+
+| Source | Destination | Notes |
+|--------|-------------|-------|
+| `Telemetry/IJobLifecycleMetrics.cs` | stays temporarily | Phase 3: `Abstractions.ControlPlane/Metrics/` |
+| `Telemetry/IJobMetricsStore.cs` | stays temporarily | Phase 3: `Abstractions.ControlPlane/Metrics/` |
+| `Telemetry/IJobSnapshotStore.cs` | stays temporarily | Phase 3: `Abstractions.ControlPlane/Metrics/` |
+| `Telemetry/IControlPlaneTelemetryClient.cs` | `ControlPlane/IControlPlaneTelemetryClient.cs` | HTTP contract — cross-cutting |
+| `Telemetry/IDiscoveryMetrics.cs` | stays temporarily | Phase 3: `Abstractions.Agent/Telemetry/` |
+| `Telemetry/IWorkItemExportMetrics.cs` | stays temporarily | Phase 3: `Abstractions.Agent/Telemetry/` |
+| `Telemetry/IAttachmentDownloadMetrics.cs` | stays temporarily | Phase 3: `Abstractions.Agent/Telemetry/` |
+| `Telemetry/IMigrationMetrics.cs` | stays temporarily | Phase 3: `Abstractions.Agent/Telemetry/` |
+
+Remaining 10 files (`DataClassification.cs`, `WellKnown*.cs`, etc.) stay in
+`Abstractions/Telemetry/` — they are genuinely cross-cutting.
+
+---
+
+### Phase 3 — Extract `Abstractions.ControlPlane` and `Abstractions.Agent` projects
+
+#### Step 3.1 — Create `Abstractions.ControlPlane` project
+
+```
+src/DevOpsMigrationPlatform.Abstractions.ControlPlane/
+  DevOpsMigrationPlatform.Abstractions.ControlPlane.csproj
+  Metrics/
+    IJobLifecycleMetrics.cs
+    IJobMetricsStore.cs
+    IJobSnapshotStore.cs
+```
+
+```xml
+<!-- Abstractions.ControlPlane.csproj -->
+<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\DevOpsMigrationPlatform.Abstractions.csproj" />
+```
+
+| Move from | Move to |
+|-----------|---------|
+| `Abstractions/Telemetry/IJobLifecycleMetrics.cs` | `Abstractions.ControlPlane/Metrics/IJobLifecycleMetrics.cs` |
+| `Abstractions/Telemetry/IJobMetricsStore.cs` | `Abstractions.ControlPlane/Metrics/IJobMetricsStore.cs` |
+| `Abstractions/Telemetry/IJobSnapshotStore.cs` | `Abstractions.ControlPlane/Metrics/IJobSnapshotStore.cs` |
+
+Update namespace: `DevOpsMigrationPlatform.Abstractions.Telemetry` →
+`DevOpsMigrationPlatform.Abstractions.ControlPlane.Metrics`
+
+Add project reference in:
+- `ControlPlane.csproj`
+- `ControlPlaneHost.csproj`
+
+#### Step 3.2 — Create `Abstractions.Agent` project
+
+```
+src/DevOpsMigrationPlatform.Abstractions.Agent/
+  DevOpsMigrationPlatform.Abstractions.Agent.csproj
+  WorkItems/
+  Discovery/
+  Export/
+  Import/
+  Attachments/
+  Identity/
+  Storage/
+  Checkpointing/
+  Lease/
+  Telemetry/
+  Modules/
+```
+
+```xml
+<!-- Abstractions.Agent.csproj -->
+<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\DevOpsMigrationPlatform.Abstractions.csproj" />
+```
+
+Move all files tagged "Phase 3" in Steps 2.1–2.7:
+
+**From `Abstractions/Models/` → `Abstractions.Agent/`:**
+
+| File | Target folder |
+|------|---------------|
+| 17 WorkItem* files + links + `FetchedWorkItem` + `IdMapEntry` | `WorkItems/` |
+| 6 Attachment/EmbeddedImage files | `Attachments/` |
+| `ExportContext.cs`, `BatchContinuationToken.cs`, `RevisionProcessResult.cs` | `Export/` |
+| `DiscoveryContext.cs`, `InventoryReport.cs`, `InventorySummary.cs`, `InventoryProgressEvent.cs`, `ProjectDiscoverySummary.cs`, `DependencyRecord.cs`, `DependencySummary.cs`, `DependencyProgressEvent.cs` | `Discovery/` |
+| `ImportContext.cs`, `ImportedWorkItemResult.cs` | `Import/` |
+
+**From `Abstractions/Services/` → `Abstractions.Agent/`:**
+
+| File | Target folder |
+|------|---------------|
+| 8 Discovery interfaces + factories | `Discovery/` |
+| 10 Export interfaces + factories + `WorkItemQueryWindow.cs` | `Export/` |
+| 5 Import interfaces + factories | `Import/` |
+| 3 Attachment interfaces | `Attachments/` |
+| `IIdentityMappingService.cs` | `Identity/` |
+| 5 Checkpointing/PhaseTracking interfaces + factories | `Checkpointing/` |
+| 5 Package/IdMap interfaces + factories | `Storage/` |
+| `IProgressSink.cs` | `Lease/` |
+
+**From `Abstractions/Services/` → `Abstractions.Agent/Modules/`:**
+
+| File | Target folder |
+|------|---------------|
+| `IModule.cs` | `Modules/` |
+| `IDiscoveryModule.cs` | `Modules/` |
+
+**From `Abstractions/Modules/` → `Abstractions.Agent/Modules/`:**
+
+| File | Target folder |
+|------|---------------|
+| `WorkItemsModuleExtensions.cs` | `Modules/` |
+
+**From `Abstractions/` root → `Abstractions.Agent/Lease/`:**
+
+| File | Target folder |
+|------|---------------|
+| `ActiveLeaseState.cs` | `Lease/` |
+| `ActivePackageState.cs` | `Lease/` |
+| `PackagePaths.cs` | `Lease/` |
+
+**From `Abstractions/Utilities/` → `Abstractions.Agent/Lease/`:**
+
+| File | Target folder | Rename |
+|------|---------------|--------|
+| `PathUtilities.cs` | `Lease/` | class: `PathUtilities` → `PackagePathUtilities` |
+
+**From `Abstractions/Errors/` → `Abstractions.Agent/Storage/`:**
+
+| File | Target folder |
+|------|---------------|
+| `PackageLockConflictException.cs` | `Storage/` |
+
+**From `Abstractions/Storage/` → `Abstractions.Agent/Storage/`:**
+
+| File | Target folder |
+|------|---------------|
+| `IArtefactStore.cs` | `Storage/` |
+| `IStateStore.cs` | `Storage/` |
+
+**From `Abstractions/Checkpointing/` → `Abstractions.Agent/Checkpointing/`:**
+
+| File | Target folder |
+|------|---------------|
+| `CursorEntry.cs` | `Checkpointing/` |
+| `CursorStage.cs` | `Checkpointing/` |
+| `JobPhaseRecord.cs` | `Checkpointing/` |
+
+**From `Abstractions/Telemetry/` → `Abstractions.Agent/Telemetry/`:**
+
+| File | Target folder |
+|------|---------------|
+| `IDiscoveryMetrics.cs` | `Telemetry/` |
+| `IWorkItemExportMetrics.cs` | `Telemetry/` |
+| `IAttachmentDownloadMetrics.cs` | `Telemetry/` |
+| `IMigrationMetrics.cs` | `Telemetry/` |
+
+Update root namespace: `DevOpsMigrationPlatform.Abstractions.*` →
+`DevOpsMigrationPlatform.Abstractions.Agent.*`
+
+#### Step 3.3 — Add project references to consumers
+
+| Project | Add reference to |
+|---------|-----------------|
+| `MigrationAgent.csproj` | `Abstractions.Agent` |
+| `CLI.TfsMigration.csproj` | `Abstractions.Agent` |
+| `Infrastructure.csproj` | `Abstractions.Agent` |
+| `Infrastructure.AzureDevOps.csproj` | `Abstractions.Agent` |
+| `Infrastructure.Simulated.csproj` | `Abstractions.Agent` |
+| `Infrastructure.TfsObjectModel.csproj` | `Abstractions.Agent` |
+| `ControlPlane.csproj` | `Abstractions.ControlPlane` |
+| `ControlPlaneHost.csproj` | `Abstractions.ControlPlane` |
+
+#### Step 3.4 — Clean up empty folders
+
+Delete from `Abstractions/`:
+- `Models/` (empty after all files moved)
+- `Services/` (empty after all files moved)
+- `Errors/` (empty after all files moved)
+- `Utilities/` (empty after all files moved)
+- `Storage/` (moved to Agent)
+- `Checkpointing/` (moved to Agent)
+- `Modules/` (moved to Agent)
+
+#### Step 3.5 — Update `DevOpsMigrationPlatform.slnx`
+
+Add both new projects to the solution file.
+
+---
+
+### Phase 4 — Verification
+
+#### Step 4.1 — Build gate
+
+```powershell
+dotnet clean && dotnet build --no-incremental
+```
+
+All projects must compile. Zero warnings from missing types.
+
+#### Step 4.2 — Test gate
+
+```powershell
+dotnet test
+```
+
+All existing tests must pass. The refactoring is purely structural — no behaviour changes.
+
+#### Step 4.3 — Reference topology audit
+
+Verify that the compiler-enforced topology matches BOTH tables in the Target State section.
+Any ❌ cell that has a reference is a violation. Fix before declaring done.
+
+Specifically verify:
+- `CLI.Migration` → only `Abstractions`
+- `ControlPlane` → only `Abstractions` + `Abstractions.ControlPlane` (no `Infrastructure`, no `Abstractions.Agent`)
+- `ControlPlaneHost` → `Abstractions` + `Abstractions.ControlPlane` + `Infrastructure` + `ServiceDefaults`
+- `MigrationAgent` → `Abstractions` + `Abstractions.Agent` + `Infrastructure` + `Infrastructure.AzureDevOps` + `Infrastructure.Simulated` + `ServiceDefaults`
+- `Infrastructure.Tests` does NOT reference `CLI.Migration`
+- `CLI.Migration.Tests` does NOT reference `Infrastructure` or `Infrastructure.AzureDevOps`
+
+#### Step 4.4 — Scenario smoke test
+
+Run at least one scenario config via `launch.json` debug profile and verify observable output.
 
 ---
 
@@ -454,3 +1199,62 @@ resolves `IWorkItemDiscoveryService`, `IProgressSink`, etc. This is by design.
 `WorkItemExportOrchestrator`, etc.) and uses `IArtefactStore`, `ICheckpointingService`,
 and other Agent-internal contracts. It correctly references `Abstractions` +
 `Abstractions.Agent`.
+
+### `MigrationAgent` references Infrastructure projects
+
+`MigrationAgent` is a composition root — it wires up concrete implementations from
+`Infrastructure`, `Infrastructure.AzureDevOps`, and `Infrastructure.Simulated` at startup.
+This is the correct place for those references. The topology table shows this explicitly.
+
+### `ControlPlaneHost` vs `ControlPlane` — split responsibility
+
+`ControlPlane` is a library project containing controllers, services, and domain logic.
+It references only `Abstractions` + `Abstractions.ControlPlane`. It MUST NOT reference
+`Infrastructure` directly.
+
+`ControlPlaneHost` is the ASP.NET Core executable (composition root). It wires up
+concrete implementations from `Infrastructure` and registers them via DI. Infrastructure
+references belong here, not in `ControlPlane`.
+
+**Current violation:** `ControlPlane/Services/ControlPlaneServiceExtensions.cs` directly
+references `DevOpsMigrationPlatform.Infrastructure.Factories` and hard-codes
+`FileSystemPackageStoreFactory`. This registration must move to `ControlPlaneHost`.
+
+### Log file access — no package reads from ControlPlane
+
+The ControlPlane MUST NOT read from the package filesystem. The current
+`LogDownloadController` injects `IPackageStoreFactory` and `IArtefactStore` to serve
+log files — this is a topology violation (`ControlPlane` must not reference
+`Abstractions.Agent`).
+
+**Resolution:** Delete `LogDownloadController`. Replace with a log path resolver:
+- The Agent already knows the log file paths (they are inside the package working directory)
+- The Agent reports the log path to the CP as part of `JobSnapshot` or `JobDiagnostics`
+- The CP returns the path to the CLI in the job status response
+- The CLI displays the path to the operator: `"Logs available at: /path/to/package/.migration/Logs/"`
+- The operator retrieves logs directly from the well-known filesystem location
+
+This removes `IArtefactStore` and `IPackageStoreFactory` from the ControlPlane entirely,
+eliminating the last reason for the CP to reference `Abstractions.Agent`.
+
+### Test project boundary violations
+
+**`Infrastructure.Tests`** currently references `CLI.Migration`. This is a cross-boundary
+violation — infrastructure tests should not depend on the CLI. Any test that exercises
+CLI+Infrastructure integration belongs in `CLI.Migration.Tests` or a dedicated integration
+test project.
+
+**`CLI.Migration.Tests`** currently references `Infrastructure` and
+`Infrastructure.AzureDevOps`. After Phase 1 severs the CLI from Infrastructure, these
+test references must also be removed. Tests that need Infrastructure types should mock
+the abstraction layer interfaces instead.
+
+### Simulated config types
+
+`Infrastructure.Simulated/Options/` contains 5 files, not just 2. All must move to
+`Abstractions/Options/` because the CLI deserialises simulated config files:
+- `SimulatedEndpointOptions.cs` — endpoint connection settings
+- `SimulatedOrganisationEntry.cs` — org-level config
+- `SimulatedProjectConfig.cs` — per-project generation settings
+- `SimulatedWorkItemTypeConfig.cs` — work item type definitions
+- `SimulatedGeneratorConfig.cs` — data generation parameters

--- a/analysis/separation-of-concerns.md
+++ b/analysis/separation-of-concerns.md
@@ -80,11 +80,12 @@ IConfigurationService.cs
 
 #### `ControlPlane/`
 The HTTP contracts and payload types the CLI and Agent use to communicate with the
-ControlPlane. These live in base `Abstractions` so the CLI compiles against them
-without needing a reference to `Abstractions.ControlPlane`.
+ControlPlane. These live in base `Abstractions` so any component that talks to CP
+compiles against them without needing a reference to `Abstractions.ControlPlane`.
 ```
 IControlPlaneClient.cs            ← CLI reads jobs, streams logs, gets telemetry via HTTP
 IJobRunner.cs                     ← CLI submits jobs to CP via HTTP
+IControlPlaneTelemetryClient.cs   ← Agent pushes metrics + snapshots to CP via HTTP
 JobSummary.cs                     ← returned by GET /jobs
 JobMetrics.cs                     ← pushed by Agent, read by CLI via CP
 JobSnapshot.cs                    ← pushed by Agent, read by CLI via CP
@@ -171,22 +172,17 @@ IsExternalInit.cs
 
 ---
 
-### `DevOpsMigrationPlatform.Abstractions.ControlPlane` — CP-internal + Agent→CP push
+### `DevOpsMigrationPlatform.Abstractions.ControlPlane` — CP-internal only
 
-Contracts that only the ControlPlane itself implements or receives.
-Neither the CLI nor the TUI reference this project — they communicate with CP exclusively
-via the `IControlPlaneClient` / `IJobRunner` HTTP contracts in base `Abstractions`.
-
-#### `Contracts/`
-```
-IControlPlaneTelemetryClient.cs   ← Agent pushes metrics + snapshots to CP over HTTP
-```
+Contracts that only the ControlPlane itself implements internally.
+Neither the CLI, TUI, nor the Agent reference this project — all three communicate
+with CP exclusively via the HTTP contracts in base `Abstractions`.
 
 #### `Metrics/`
 ```
-IJobLifecycleMetrics.cs           ← OTel instruments on WellKnownMeterNames.ControlPlane
-IJobMetricsStore.cs               ← CP stores incoming agent metrics
-IJobSnapshotStore.cs              ← CP stores incoming agent snapshots
+IJobLifecycleMetrics.cs           ← OTel instruments emitted inside the CP process
+IJobMetricsStore.cs               ← CP persists incoming agent metrics
+IJobSnapshotStore.cs              ← CP persists incoming agent snapshots
 ```
 
 ---
@@ -337,14 +333,15 @@ EmbeddedImagesExtensionOptions.cs
 | `CLI.Migration` | ✅ | ❌ | ❌ |
 | `TUI` | ✅ | ❌ | ❌ |
 | `ControlPlane` / `ControlPlaneHost` | ✅ | ✅ | ❌ |
-| `MigrationAgent` | ✅ | ✅ | ✅ |
+| `MigrationAgent` | ✅ | ❌ | ✅ |
 | `CLI.TfsMigration` (.NET 4.8) | ✅ | ❌ | ✅ |
-| `Infrastructure` | ✅ | ❌ | ❌ |
+| `Infrastructure` | ✅ | ❌ | ✅ |
 
-The CLI communicates with ControlPlane exclusively via the HTTP contracts in base `Abstractions`
-(`IControlPlaneClient`, `IJobRunner`). It never compiles against `Abstractions.ControlPlane`.
-A CLI developer cannot accidentally call a CP-internal store or OTel instrument because
-those types are not in their reference graph.
+All three communicating components (CLI, Agent, TUI) talk to the ControlPlane exclusively
+via HTTP contracts in base `Abstractions` (`IControlPlaneClient`, `IJobRunner`,
+`IControlPlaneTelemetryClient`). No component other than `ControlPlane`/`ControlPlaneHost`
+needs `Abstractions.ControlPlane`. The CP-internal store and OTel interfaces are invisible
+to everything outside the CP process boundary.
 
 ---
 
@@ -419,6 +416,74 @@ be **removed from `CLI.Migration.csproj` entirely**.
 `CLI.TfsMigration` directly resolves `IWorkItemDiscoveryService` because it **is** the
 TFS Export Agent running inline — not a CLI submitting to ControlPlane. This reference
 is legitimate and is not a violation.
+
+---
+
+## Problem 3 — `CLI.Migration` is the composition root for ControlPlane and Agent
+
+### Current state
+
+`LocalStackHost` has two modes:
+1. **Process-per-component** (correct) — launches `ControlPlaneHost.exe` and `MigrationAgent.exe`
+   as child processes via `ChildProcessHost`. No assembly dependencies needed.
+2. **In-process fallback** (violation) — when published binaries are not found, `LocalStackHost`
+   calls `AddControlPlaneServices()`, `AddMigrationAgentServices()`, and hosts both components
+   inside the CLI process. This is why `CLI.Migration.csproj` references `ControlPlane`,
+   `MigrationAgent`, `Infrastructure`, `Infrastructure.AzureDevOps`, and `Infrastructure.Simulated`.
+
+### Why the in-process fallback must be deleted
+
+The fallback makes the CLI the composition root for CP and Agent. This:
+- **Breaks the three-channel topology.** The CLI holds `IArtefactStore`, `IModule`, every
+  Agent-internal contract. A developer can inject anything.
+- **Breaks telemetry isolation.** Multiple OTel pipelines in one process produce phantom
+  dependency arrows on Application Insights. The existing code already warns about this.
+- **Is unnecessary.** The TFS export pattern proves the CLI can launch child processes
+  without in-process hosting. `ChildProcessHost` and `ExternalToolRunner` already work.
+  The `dotnet run` case should build-then-launch rather than host in-process.
+
+### What the CLI should reference after remediation
+
+```xml
+<!-- CLI.Migration.csproj — target state -->
+<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\DevOpsMigrationPlatform.Abstractions.csproj" />
+```
+
+That is it. The CLI should compile against `Abstractions` only. Everything else is
+launched as a child process or accessed via HTTP.
+
+### Detailed dependency analysis for remaining usages
+
+| Current usage | File | What it touches | Fix |
+|---|---|---|---|
+| `AddControlPlaneServices()` | `LocalStackHost.cs` | `ControlPlane` | Delete in-process fallback |
+| `AddMigrationAgentServices()` | `LocalStackHost.cs` | `MigrationAgent` | Delete in-process fallback |
+| `ControlPlaneServiceExtensions.Assembly` | `LocalStackHost.cs` | `ControlPlane` | Delete in-process fallback |
+| `AddEndpointOptionsType("AzureDevOpsServices", ...)` | `LocalStackHost.cs`, `MigrationCliServiceCollectionExtensions.cs` | `Infrastructure.AzureDevOps` (endpoint types) | Move type registration to `Abstractions` or to a thin `Infrastructure.Configuration` package |
+| `AddSimulatedServices()` | `MigrationCliServiceCollectionExtensions.cs` | `Infrastructure.Simulated` (Agent factories) | Replace with `AddSimulatedConfigurationTypes()` in thin config package |
+| `AddMigrationPlatformPolymorphicSerializers()` | `LocalStackHost.cs`, `MigrationPlatformHost.cs` | `Infrastructure` (serialisation) | Move polymorphic serializer registration to `Abstractions` or thin `Infrastructure.Serialization` package |
+| `ConfigurationService` (concrete class) | `QueueCommand.cs`, `ConfigNewCommand.cs`, `ConfigureCommand.cs`, `PrepareCommand.cs` | `Infrastructure.Services` | Register via `IConfigurationService` from a CLI composition-root extension method; move `ConfigurationService` into a thin config package |
+| `AzureDevOpsEndpointOptions` | `QueueCommand.cs`, `LocalStackHost.cs`, `InteractiveConfigurationBuilder.cs` | `Infrastructure.AzureDevOps.Options` | Move endpoint option types to `Abstractions/Options/` — they are config schema, not execution |
+| `SimulatedEndpointOptions` | `LocalStackHost.cs` | `Infrastructure.Simulated.Options` | Same — move to `Abstractions/Options/` |
+| `AzureDevOpsValidation` | `QueueCommand.cs` | `Infrastructure.AzureDevOps.Validation` | Extract `IPreFlightValidator` interface to `Abstractions`; implementation stays in `Infrastructure.AzureDevOps` but is resolved by DI, not direct reference |
+| `AddDataClassificationFilter()` | `LocalStackHost.cs` | `Infrastructure.Telemetry` | Delete in-process fallback |
+| `PolymorphicEndpointOptionsConverter` | `LocalStackHost.cs` | `Infrastructure.Serialization` | Delete in-process fallback |
+| `IProgressSink` + `AnsiProgressSink` | `QueueCommand.cs` | `Abstractions` (interface) + CLI (impl) | Already correct — `IProgressSink` moves to `Abstractions.Agent`, and `QueueCommand` only uses it for TFS subprocess output. The CLI can hold its own `AnsiProgressSink` implementation since the TFS CLI IS an agent. |
+
+### Execution plan (ordered)
+
+1. **Delete `StartControlPlaneInProcessAsync()` and `StartAgentInProcessAsync()` from `LocalStackHost`.** 
+   Require published binaries. If not found, fail with an actionable error message telling the
+   developer to run `build.ps1 Install`.
+2. **Move `AzureDevOpsEndpointOptions`, `SimulatedEndpointOptions`, and related type-registration
+   extension methods to `Abstractions/Options/`** — they are config schema, not execution contracts.
+3. **Move `ConfigurationService` registration to a `AddMigrationCliConfiguration()` extension
+   method** in `Infrastructure` so the CLI resolves only the interface.
+4. **Extract `IPreFlightValidator` to `Abstractions`** and remove direct reference to
+   `AzureDevOpsValidation` from `QueueCommand`.
+5. **Move polymorphic serialiser setup to `Abstractions`** — `PolymorphicEndpointOptionsConverter`
+   is needed by anyone who deserialises the config file (CLI, CP, Agent).
+6. **Remove all five invalid project references from `CLI.Migration.csproj`.**
 
 ---
 

--- a/analysis/separation-of-concerns.md
+++ b/analysis/separation-of-concerns.md
@@ -53,15 +53,21 @@ export). The in-process fallback is unnecessary and must be deleted.
 
 ## Target state
 
-### `CLI.Migration.csproj` — single reference
+### `CLI.Migration.csproj` — two references
 
 ```xml
 <ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\DevOpsMigrationPlatform.Abstractions.csproj" />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure\DevOpsMigrationPlatform.Infrastructure.csproj" />
 ```
 
-The CLI compiles against `Abstractions` only. It launches ControlPlane and Agent as child
-processes via `ChildProcessHost`. All communication with CP is via HTTP using the contracts
-in `Abstractions/ControlPlaneApi/`.
+The CLI compiles against `Abstractions` (contracts) and base `Infrastructure` (config
+binding, options validation, and polymorphic serializer registration). It launches
+ControlPlane and Agent as child processes via `ChildProcessHost`. All communication with
+CP is via HTTP using the contracts in `Abstractions/ControlPlaneApi/`.
+
+The CLI MUST NOT reference `Infrastructure.Agent`, `Infrastructure.ControlPlane`,
+`Infrastructure.AzureDevOps`, `Infrastructure.Simulated`, `ControlPlane`, or
+`MigrationAgent`. Only cross-cutting infrastructure (config, serialization) is reachable.
 
 ### Project reference topology — enforced by compiler
 
@@ -500,7 +506,7 @@ Concrete implementations of `Abstractions.ControlPlane` interfaces. Only
 `ControlPlaneHost` references this project.
 
 ```xml
-<!-- Infrastructure.ControlPlane.csproj -->
+<!-- Infrastructure.ControlPlane.csproj — net10.0 only (no net481 consumers) -->
 <ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\..." />
 <ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions.ControlPlane\..." />
 <ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure\..." />
@@ -523,7 +529,7 @@ Concrete implementations of `Abstractions.Agent` interfaces. Only `MigrationAgen
 and `CLI.TfsMigration` reference this project.
 
 ```xml
-<!-- Infrastructure.Agent.csproj -->
+<!-- Infrastructure.Agent.csproj — MUST multi-target net481;net10.0 (CLI.TfsMigration is net481) -->
 <ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\..." />
 <ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions.Agent\..." />
 <ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure\..." />
@@ -641,7 +647,10 @@ Git tracks renames by content similarity. To maximise rename detection:
 1. **One move per file.** Every file moves ONCE to its final destination — never via an
    intermediate location. Phase 2 moves only files that stay in base `Abstractions`.
    Agent-targeted files skip Phase 2 and move directly to `Abstractions.Agent` in Phase 3.
-   Same pattern for Infrastructure in Phases 4–5.
+   Same pattern for Infrastructure in Phases 4–5. **Clarification:** files tagged
+   "stays temporarily" in Phase 2 tables are NOT moved — they stay at their current path
+   untouched. Their single move happens in Phase 3 (or Phase 5 for Infrastructure files)
+   directly to their final destination. "Staying in place" is not a move.
 
 2. **Separate rename from edit.** Each step is either a batch of `git mv` operations OR a
    batch of namespace/using edits — not both. Git's rename detection threshold (default 50%
@@ -658,6 +667,7 @@ Git tracks renames by content similarity. To maximise rename detection:
 
 | Phase | Description | Move type |
 |-------|-------------|-----------|
+| 0 | Pre-flight audit — record current state | No moves |
 | 1 | Code edits — sever CLI coupling | No moves |
 | 2 | Screaming architecture within base `Abstractions` | `git mv` within project |
 | 3 | Create `Abstractions.ControlPlane` + `Abstractions.Agent` | `git mv` across projects |
@@ -666,6 +676,22 @@ Git tracks renames by content similarity. To maximise rename detection:
 | 6 | Reference cleanup, test boundaries, verification | No moves |
 
 ---
+
+### Phase 0 — Pre-flight audit
+
+Before any restructuring, capture the current project reference graph and compare it
+against the target topology tables.
+
+| Action | Detail |
+|--------|--------|
+| Run | `dotnet list reference` for every project in the solution |
+| Record | Save output to `analysis/current-project-references.md` |
+| Compare | Diff current references against both topology tables (Abstractions layer + Implementation layer) in Target State |
+| Document | Any violation not already listed in Phase 1 steps — add new steps to Phase 1 for each |
+| Verify TFMs | Confirm `Abstractions` and `Infrastructure` multi-target `net481;net10.0` (required for `CLI.TfsMigration`) |
+
+This step produces no code changes. It ensures Phase 1 covers all violations, not just
+the known ones.
 
 ### Phase 1 — Sever the CLI ↔ Agent/CP compile-time coupling
 
@@ -703,9 +729,13 @@ Removing it makes Steps 1.2–1.5 possible.
 |--------|--------|
 | Update | `QueueCommand`, `ConfigNewCommand`, `ConfigureCommand`, `PrepareCommand` |
 | Change | Replace `new ConfigurationService(...)` → constructor-inject `IConfigurationService` |
-| Register | In `MigrationCliServiceCollectionExtensions`, add `services.AddSingleton<IConfigurationService, ConfigurationService>()` — but this still requires Infrastructure reference |
-| Split registration | Create `Abstractions/Configuration/ConfigurationServiceCollectionExtensions.cs` with `AddConfigurationService(this IServiceCollection)` method that takes a factory delegate |
-| Actual registration | Move to `Infrastructure` as an extension method that the CLI's composition root calls |
+| Create | `Abstractions/Configuration/ConfigurationServiceCollectionExtensions.cs` — defines `AddConfigurationService(this IServiceCollection, Func<IServiceProvider, IConfigurationService> factory)` accepting a factory delegate |
+| Implement | `Infrastructure/Config/ConfigurationServiceRegistration.cs` — extension method `AddFileSystemConfigurationService(this IServiceCollection)` that calls `AddConfigurationService(sp => new ConfigurationService(...))` |
+| Register | CLI composition root calls `services.AddFileSystemConfigurationService()` |
+
+**Why factory delegate:** Keeps `Abstractions` free of implementation references. If the
+CLI `Infrastructure` reference is ever removed, the registration still works via the
+factory delegate pattern in `Abstractions`.
 
 #### Step 1.4 — Move config-schema types to `Abstractions/Options/`
 
@@ -742,32 +772,46 @@ config and job payloads. Currently in `Infrastructure.Serialization`.
 Update namespace: `DevOpsMigrationPlatform.Infrastructure.Serialization` →
 `DevOpsMigrationPlatform.Abstractions.Serialization`.
 
-#### Step 1.6 — Remove all invalid project references
+#### Step 1.6 — Remove invalid project references
 
 Delete from `CLI.Migration.csproj`:
 ```xml
 <ProjectReference Include="..\DevOpsMigrationPlatform.ControlPlane\..." />
 <ProjectReference Include="..\DevOpsMigrationPlatform.MigrationAgent\..." />
-<ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure\..." />
 <ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure.AzureDevOps\..." />
 <ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure.Simulated\..." />
 ```
 
-**Build gate:** `CLI.Migration` must compile with only `Abstractions` as a project reference.
+The `Infrastructure` reference stays — the CLI needs it for `ConfigurationService`,
+`AddMigrationPlatformOptions()`, and `EndpointOptionsRegistrationExtensions`.
+
+**Build gate:** `CLI.Migration` must compile with `Abstractions` + `Infrastructure` only.
 Any remaining compile error means a dependency was missed in Steps 1.1–1.5.
 
 #### Step 1.7 — Remove `LogDownloadController` from ControlPlane
 
 **Why:** `LogDownloadController` injects `IPackageStoreFactory` and `IArtefactStore` to
-serve log files. This forces the ControlPlane to reference Agent-internal contracts.
-Operators can access logs directly from the well-known package directory.
+serve historical log files. This forces the ControlPlane to reference Agent-internal
+contracts. The CLI and TUI must NEVER access the package filesystem directly.
+
+**Current consumers:**
+- `ControlPlaneClient.DownloadDiagnosticsAsync()` → `GET /jobs/{id}/logs/download?type=diagnostics`
+- `ControlPlaneClient.DownloadProgressAsync()` → `GET /jobs/{id}/logs/download?type=progress`
+- `ManageDiagnosticsCommand` calls `DownloadDiagnosticsAsync()`
+- `TuiLogView` uses `IControlPlaneClient` (live streaming only — unaffected)
+
+**Resolution:** Live logs already stream via SSE through the CP (no `IArtefactStore`
+dependency). Historical log download is removed. The CP reports the log store location
+so operators can retrieve historical logs from the package store directly.
 
 | Action | Detail |
 |--------|--------|
 | Delete | `ControlPlane/Controllers/LogDownloadController.cs` |
-| Add field | `JobDiagnostics.LogPath` (string) — the Agent populates this with the absolute path to the package log directory |
+| Add field | `JobDiagnostics.LogPath` (string) — the Agent populates this with the store-relative path to the job's log directory |
 | Update Agent | Set `JobDiagnostics.LogPath` when reporting diagnostics to CP |
-| Update CLI | Display log path to operator: `"Logs available at: {logPath}"` |
+| Remove methods | `IControlPlaneClient.DownloadDiagnosticsAsync()`, `DownloadProgressAsync()` |
+| Update `ManageDiagnosticsCommand` | Display log path: `"Historical logs available at: {logPath}"` instead of downloading |
+| Update `TuiLogView` | Ensure it uses only live SSE streaming (no historical download calls) |
 
 After this step, ControlPlane has zero dependency on `IArtefactStore`, `IPackageStoreFactory`,
 or any other Agent-internal contract.
@@ -1032,7 +1076,7 @@ src/DevOpsMigrationPlatform.Abstractions.ControlPlane/
 ```
 
 ```xml
-<!-- Abstractions.ControlPlane.csproj -->
+<!-- Abstractions.ControlPlane.csproj — net10.0 only (no net481 consumers) -->
 <ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\DevOpsMigrationPlatform.Abstractions.csproj" />
 ```
 
@@ -1068,7 +1112,7 @@ src/DevOpsMigrationPlatform.Abstractions.Agent/
 ```
 
 ```xml
-<!-- Abstractions.Agent.csproj -->
+<!-- Abstractions.Agent.csproj — MUST multi-target net481;net10.0 (CLI.TfsMigration is net481) -->
 <ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\DevOpsMigrationPlatform.Abstractions.csproj" />
 ```
 
@@ -1095,7 +1139,7 @@ Move all files tagged "Phase 3" in Steps 2.1–2.7:
 | `IIdentityMappingService.cs` | `Identity/` |
 | 5 Checkpointing/PhaseTracking interfaces + factories | `Checkpointing/` |
 | 5 Package/IdMap interfaces + factories | `Storage/` |
-| `IProgressSink.cs` | `Lease/` |
+| `IProgressSink.cs` | `Telemetry/` |
 
 **From `Abstractions/Services/` → `Abstractions.Agent/Modules/`:**
 
@@ -1229,7 +1273,7 @@ src/DevOpsMigrationPlatform.Infrastructure.ControlPlane/
 ```
 
 ```xml
-<!-- Infrastructure.ControlPlane.csproj -->
+<!-- Infrastructure.ControlPlane.csproj — net10.0 only (no net481 consumers) -->
 <ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\..." />
 <ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions.ControlPlane\..." />
 <ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure\..." />
@@ -1257,13 +1301,17 @@ Update `ControlPlaneHost/Program.cs` to call `AddControlPlaneTelemetryServices()
 
 #### Step 5.2a — Create `Infrastructure.Agent` project
 
+**Note:** Source paths below assume Phases 1–4 are complete. Phase 1 moves serialization
+files out of `Infrastructure/` but does not relocate any files listed in Steps 5.2b–5.2d.
+If the Phase 0 audit reveals additional file moves, update these tables accordingly.
+
 ```
 src/DevOpsMigrationPlatform.Infrastructure.Agent/
   DevOpsMigrationPlatform.Infrastructure.Agent.csproj
 ```
 
 ```xml
-<!-- Infrastructure.Agent.csproj -->
+<!-- Infrastructure.Agent.csproj — MUST multi-target net481;net10.0 (CLI.TfsMigration is net481) -->
 <ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\..." />
 <ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions.Agent\..." />
 <ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure\..." />

--- a/analysis/separation-of-concerns.md
+++ b/analysis/separation-of-concerns.md
@@ -1,0 +1,432 @@
+# Separation of Concerns — Abstractions & Project Boundary Analysis
+
+## Context
+
+This document captures the boundary-violation analysis of `DevOpsMigrationPlatform.Abstractions`
+and `CLI.Migration` project references, and the proposed structural remediation.
+
+The system enforces a strict communication topology:
+
+```
+CLI  ←→  ControlPlane  ←→  Agent
+```
+
+CLI and TUI must not hold Agent-internal contracts. The compiler should enforce this via
+project reference topology, not developer discipline.
+
+---
+
+## Problem 1 — `Abstractions` is a technical bucket, not a boundary map
+
+### Current structure
+
+| Folder | Files | Problem |
+|--------|-------|---------|
+| `Models/` | 70+ files | CLI contracts, Agent domain objects, and shared types all mixed together |
+| `Services/` | 40+ files | CLI-side interfaces mixed with Agent-execution interfaces |
+| `Telemetry/` | 18 files | Constants (cross-cutting) and OTel interfaces (Agent/CP-specific) mixed together |
+| `Checkpointing/` | 3 files | Agent-only — `CursorEntry` is only written by the Agent |
+| `Storage/` | 2 files | Agent-only — `IArtefactStore`/`IStateStore` have data residency restriction |
+| `Utilities/` | 2 files | Generic bucket name — screaming architecture violation |
+| `Options/` | 24 files | ✅ Cross-cutting — config schema only |
+| `Errors/` | 3 files | ✅ Cross-cutting |
+| `Validation/` | 2 files | ✅ Cross-cutting |
+
+### Impact
+
+`IArtefactStore` and `IControlPlaneClient` sit in the same project. A CLI command can
+accidentally inject `IArtefactStore` and the compiler will not object. The data residency
+guardrail (agents.md rule 23 — only the Migration Agent and TFS Export Agent may write
+to the package) relies entirely on code review.
+
+---
+
+## Proposed fix — split into three projects
+
+### `DevOpsMigrationPlatform.Abstractions` — truly cross-cutting
+
+Shared types that all three components (CLI, ControlPlane, Agent) legitimately depend on.
+
+#### `Domain/`
+```
+Job.cs
+MigrationJob.cs
+DiscoveryJob.cs
+DiscoveryJobType.cs
+JobModule.cs
+JobModuleScope.cs
+JobPackage.cs
+JobResume.cs
+JobGuardrails.cs
+JobPolicies.cs
+ProgressEvent.cs                  ← flows CLI → CP → Agent → CLI
+DiagnosticLogRecord.cs            ← flows CLI → CP → Agent → CLI
+OrganisationEndpoint.cs
+OrganisationEndpointAuthentication.cs
+ScopedOrganisationEndpoint.cs
+ResumeDecision.cs
+ResumeDecisionStatus.cs
+ResumeRejectedException.cs
+ValidationContext.cs
+FilterOperator.cs
+```
+
+#### `Configuration/`
+CLI-facing service for loading and validating config files on disk before job submission.
+The CLI calls this directly; the Agent never touches it.
+```
+IConfigurationService.cs
+```
+
+#### `ControlPlane/`
+The HTTP contracts and payload types the CLI and Agent use to communicate with the
+ControlPlane. These live in base `Abstractions` so the CLI compiles against them
+without needing a reference to `Abstractions.ControlPlane`.
+```
+IControlPlaneClient.cs            ← CLI reads jobs, streams logs, gets telemetry via HTTP
+IJobRunner.cs                     ← CLI submits jobs to CP via HTTP
+JobSummary.cs                     ← returned by GET /jobs
+JobMetrics.cs                     ← pushed by Agent, read by CLI via CP
+JobSnapshot.cs                    ← pushed by Agent, read by CLI via CP
+JobBootstrap.cs                   ← returned by GET /jobs/{id}/bootstrap
+JobScopeCounters.cs               ← embedded in JobMetrics
+JobDiagnostics.cs
+MigrationCounters.cs              ← embedded in JobMetrics
+MigrationDiagnostics.cs
+OrgSnapshot.cs                    ← embedded in JobSnapshot
+ProjectSnapshot.cs                ← embedded in JobSnapshot
+ProjectStatus.cs
+TargetStatus.cs
+DiscoveryCounters.cs              ← embedded in JobMetrics.Discovery and ProjectSnapshot.Discovery
+InventoryCounters.cs              ← embedded in DiscoveryCounters
+DependencyCounters.cs             ← embedded in DiscoveryCounters
+```
+
+#### `Options/`
+All existing `Options/` files unchanged — config schema is cross-cutting.
+```
+AuthenticationType.cs
+CommentsExtensionOptionsConfig.cs
+DiscoveryOptions.cs
+EmbeddedImagesExtensionOptionsConfig.cs
+EnabledExtensionOptions.cs
+EndpointAuthenticationOptions.cs
+FilterMode.cs
+IModuleOptions.cs
+MigrationCheckpointsOptions.cs
+MigrationEndpointOptions.cs
+MigrationModulesOptions.cs
+MigrationOptions.cs
+MigrationOptionsScope.cs
+MigrationPackageOptions.cs
+MigrationPlatformRoot.cs
+MigrationPoliciesOptions.cs
+MigrationRetriesOptions.cs
+MigrationThrottleOptions.cs
+OrganisationEntry.cs
+WorkItemFilterOptions.cs
+WorkItemResolutionStrategyOptionsConfig.cs
+WorkItemsExtensionsOptions.cs
+WorkItemsModuleOptions.cs
+WorkItemsScopeOptions.cs
+```
+
+#### `Errors/`
+```
+MigrationErrorCategory.cs
+MigrationException.cs
+PackageLockConflictException.cs
+```
+
+#### `Validation/`
+```
+ValidationError.cs
+ValidationResult.cs
+```
+
+#### `Telemetry/`
+Constants and classification only — **no interfaces**.
+```
+DataClassification.cs
+DataClassificationScope.cs
+MigrationTagList.cs
+TelemetryOptions.cs
+WellKnownActivitySourceNames.cs
+WellKnownDiscoveryMetricNames.cs
+WellKnownJobMetricNames.cs
+WellKnownMeterNames.cs
+WellKnownMetricNames.cs
+WellKnownServiceNames.cs
+```
+
+#### `Diagnostics/`
+```
+DiagnosticLogOptions.cs
+```
+
+#### `Polyfills/`
+```
+IsExternalInit.cs
+```
+
+---
+
+### `DevOpsMigrationPlatform.Abstractions.ControlPlane` — CP-internal + Agent→CP push
+
+Contracts that only the ControlPlane itself implements or receives.
+Neither the CLI nor the TUI reference this project — they communicate with CP exclusively
+via the `IControlPlaneClient` / `IJobRunner` HTTP contracts in base `Abstractions`.
+
+#### `Contracts/`
+```
+IControlPlaneTelemetryClient.cs   ← Agent pushes metrics + snapshots to CP over HTTP
+```
+
+#### `Metrics/`
+```
+IJobLifecycleMetrics.cs           ← OTel instruments on WellKnownMeterNames.ControlPlane
+IJobMetricsStore.cs               ← CP stores incoming agent metrics
+IJobSnapshotStore.cs              ← CP stores incoming agent snapshots
+```
+
+---
+
+### `DevOpsMigrationPlatform.Abstractions.Agent` — Agent-internal only
+
+Contracts used exclusively inside the Migration Agent (and `CLI.TfsMigration` which
+is the TFS Export Agent running inline).
+
+#### `Storage/`
+```
+IArtefactStore.cs
+IStateStore.cs
+```
+
+#### `Checkpointing/`
+```
+CursorEntry.cs
+CursorStage.cs
+JobPhaseRecord.cs
+```
+
+#### `Runtime/`
+Agent lifecycle singletons — set when a lease is acquired, cleared on release.
+```
+ActiveLeaseState.cs
+ActivePackageState.cs
+PackagePaths.cs                   ← package path constants (IArtefactStore paths)
+```
+
+#### `WorkItems/`
+```
+WorkItemRevision.cs
+WorkItemField.cs
+WorkItemComment.cs
+WorkItemIdentityRef.cs
+WorkItemRelations.cs
+WorkItemCounters.cs
+WorkItemFetchScope.cs
+WorkItemFieldFilterEvaluator.cs
+WorkItemFieldFilterOptions.cs
+WorkItemQueryChunk.cs
+WorkItemQueryCountChunk.cs
+ExternalWorkItemLink.cs
+HyperlinkWorkItemLink.cs
+RelatedWorkItemLink.cs
+LinkScope.cs
+FetchedWorkItem.cs
+IdMapEntry.cs
+```
+
+#### `Attachments/`
+```
+AttachmentMetadata.cs
+AttachmentCounters.cs
+AttachmentDownloadResult.cs
+AttachmentMapEntry.cs
+EmbeddedImageMetadata.cs
+EmbeddedImageDownloadResult.cs
+```
+
+#### `Export/`
+```
+ExportContext.cs
+BatchContinuationToken.cs
+RevisionProcessResult.cs
+DiscoveryContext.cs
+InventoryReport.cs                ← written by Agent to inventory.json; CLI never compiles against this
+InventorySummary.cs
+InventoryProgressEvent.cs         ← internal Agent progress signal; CLI receives ProgressEvent from CP instead
+ProjectDiscoverySummary.cs
+DependencyRecord.cs
+DependencySummary.cs
+DependencyProgressEvent.cs
+```
+
+#### `Import/`
+```
+ImportContext.cs
+ImportedWorkItemResult.cs
+```
+
+#### `Services/`
+```
+ICatalogService.cs                ← queries source systems for project/count data; Agent-execution concern
+IInventoryService.cs
+IInventoryServiceFactory.cs
+IProjectDiscoveryService.cs
+IRepoDiscoveryService.cs
+IWorkItemDiscoveryService.cs
+IDependencyDiscoveryService.cs
+IDependencyDiscoveryServiceFactory.cs
+IAttachmentBinarySource.cs
+ICheckpointingService.cs
+ICheckpointingServiceFactory.cs
+IEmbeddedImageDownloader.cs
+IEmbeddedImageExportService.cs
+IIdentityMappingService.cs
+IIdMapStore.cs
+IIdMapStoreFactory.cs
+IPackageLockService.cs
+IPackageStoreFactory.cs
+IPackageValidator.cs
+IPhaseTrackingService.cs
+IPhaseTrackingServiceFactory.cs
+IProgressSink.cs                  ← also used by CLI.TfsMigration (legitimate — it IS the TFS agent)
+IQueryFingerprintService.cs
+IRevisionFolderProcessor.cs
+IRevisionFolderProcessorFactory.cs
+IWorkItemCommentSource.cs
+IWorkItemCommentSourceFactory.cs
+IWorkItemFetchService.cs
+IWorkItemImportTarget.cs
+IWorkItemImportTargetFactory.cs
+IWorkItemLinkAnalysisService.cs
+IWorkItemQueryWindowStrategy.cs
+WorkItemQueryWindow.cs
+IWorkItemResolutionStrategy.cs
+IWorkItemResolutionStrategyFactory.cs
+IWorkItemRevisionSource.cs
+IWorkItemRevisionSourceFactory.cs
+```
+
+#### `Telemetry/`
+OTel metric interfaces — only emitted from within Agent execution.
+```
+IDiscoveryMetrics.cs
+IWorkItemExportMetrics.cs
+IAttachmentDownloadMetrics.cs
+IMigrationMetrics.cs
+```
+
+#### `Modules/`
+```
+IModule.cs
+IDiscoveryModule.cs
+WorkItemsModuleExtensions.cs
+CommentsExtensionOptions.cs
+EmbeddedImagesExtensionOptions.cs
+```
+
+---
+
+## Project reference topology — enforced by compiler
+
+| Project | Abstractions | Abstractions.ControlPlane | Abstractions.Agent |
+|---------|:---:|:---:|:---:|
+| `CLI.Migration` | ✅ | ❌ | ❌ |
+| `TUI` | ✅ | ❌ | ❌ |
+| `ControlPlane` / `ControlPlaneHost` | ✅ | ✅ | ❌ |
+| `MigrationAgent` | ✅ | ✅ | ✅ |
+| `CLI.TfsMigration` (.NET 4.8) | ✅ | ❌ | ✅ |
+| `Infrastructure` | ✅ | ❌ | ❌ |
+
+The CLI communicates with ControlPlane exclusively via the HTTP contracts in base `Abstractions`
+(`IControlPlaneClient`, `IJobRunner`). It never compiles against `Abstractions.ControlPlane`.
+A CLI developer cannot accidentally call a CP-internal store or OTel instrument because
+those types are not in their reference graph.
+
+---
+
+## Problem 2 — `CLI.Migration` pulls in unused Agent-side execution services
+
+### Current `CLI.Migration.csproj` references (problematic lines)
+
+```xml
+<ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure.AzureDevOps\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure.Simulated\..." />
+```
+
+### What the CLI actually needs from these
+
+`InventoryCommand` calls `AddAzureDevOpsInventory(config)`.
+`DependencyCommand` calls `AddAzureDevOpsDependencyAnalysis(config)`.
+
+Both commands then resolve **only**:
+- `IAnsiConsole`
+- `IOptions<DiscoveryOptions>` — config binding
+- `ControlPlaneClient` — HTTP submission
+
+They build a `DiscoveryJob` and submit it via HTTP. They **never** resolve the
+execution services from the CLI DI container.
+
+### Services registered in the CLI process but never resolved
+
+```
+IWorkItemDiscoveryService
+IProjectDiscoveryService
+IRepoDiscoveryService
+IWorkItemFetchService
+IWiqlQueryClientFactory
+IAzureDevOpsClientFactory
+IWorkItemQueryWindowStrategy
+IInventoryService
+IInventoryServiceFactory
+```
+
+`AddSimulatedServices()` (called unconditionally from `MigrationCliServiceCollectionExtensions`)
+also registers:
+```
+IWorkItemRevisionSourceFactory    ← Agent-only
+IWorkItemImportTargetFactory      ← Agent-only
+```
+
+### Root cause
+
+The `AddAzureDevOpsInventory()` and `AddSimulatedServices()` extension methods bundle
+CLI config concerns and Agent execution concerns into a single call. The CLI has no way
+to take only config binding without pulling in execution services.
+
+### Proposed fix — split infrastructure registration by audience
+
+```csharp
+// CLI-safe — config binding and endpoint type registration only
+services.AddAzureDevOpsDiscoveryConfiguration(config);
+services.AddSimulatedEndpointTypes();
+
+// Agent-only — execution services (registered only inside MigrationAgent DI setup)
+services.AddAzureDevOpsInventoryExecution();
+services.AddSimulatedWorkItemExecution();
+```
+
+Once split, `CLI.Migration` calls only `*Configuration` / `*EndpointTypes` variants.
+Config binding can then move to `Infrastructure` (already referenced by CLI), allowing
+the `Infrastructure.AzureDevOps` and `Infrastructure.Simulated` project references to
+be **removed from `CLI.Migration.csproj` entirely**.
+
+### Exception — `CLI.TfsMigration` is correct
+
+`CLI.TfsMigration` directly resolves `IWorkItemDiscoveryService` because it **is** the
+TFS Export Agent running inline — not a CLI submitting to ControlPlane. This reference
+is legitimate and is not a violation.
+
+---
+
+## `Utilities/` — screaming architecture violation
+
+`PathUtilities` is a package-path helper (Agent concern).
+`TokenResolver` resolves config tokens (cross-cutting / CLI concern).
+
+Neither belongs in a folder named `Utilities`. Resolution:
+- `PathUtilities` → inline into `PackagePaths` or move to `Abstractions.Agent/Runtime/`
+- `TokenResolver` → move to `Abstractions/Options/` or keep at root as `ConfigTokenResolver`

--- a/analysis/separation-of-concerns.md
+++ b/analysis/separation-of-concerns.md
@@ -625,6 +625,37 @@ FactoryRegistrationExtensions.cs  ← moved from Extensions/
 Each step is independently buildable. Run `dotnet clean && dotnet build --no-incremental`
 after each step. Do not combine steps — a broken intermediate state is harder to diagnose.
 
+### Rename-preservation strategy
+
+Git tracks renames by content similarity. To maximise rename detection:
+
+1. **One move per file.** Every file moves ONCE to its final destination — never via an
+   intermediate location. Phase 2 moves only files that stay in base `Abstractions`.
+   Agent-targeted files skip Phase 2 and move directly to `Abstractions.Agent` in Phase 3.
+   Same pattern for Infrastructure in Phases 4–5.
+
+2. **Separate rename from edit.** Each step is either a batch of `git mv` operations OR a
+   batch of namespace/using edits — not both. Git's rename detection threshold (default 50%
+   similarity) breaks when you move AND rewrite in the same commit.
+
+3. **Commit after each step.** Phase 2 Step 2.1a is all `git mv` operations for the
+   Models/ dissolution. Step 2.1b is all namespace updates for those files. Each is one commit.
+
+4. **Use `git mv`, not delete+create.** Even though the end result is the same, `git mv`
+   records intent and avoids `git add -A` guessing games.
+
+5. **Batch by destination.** Move all files going to the same target folder in one commit.
+   This keeps the diff coherent and reviewable.
+
+| Phase | Description | Move type |
+|-------|-------------|-----------|
+| 1 | Code edits — sever CLI coupling | No moves |
+| 2 | Screaming architecture within base `Abstractions` | `git mv` within project |
+| 3 | Create `Abstractions.ControlPlane` + `Abstractions.Agent` | `git mv` across projects |
+| 4 | Screaming architecture within base `Infrastructure` | `git mv` within project |
+| 5 | Create `Infrastructure.ControlPlane` + `Infrastructure.Agent` | `git mv` across projects |
+| 6 | Reference cleanup, test boundaries, verification | No moves |
+
 ---
 
 ### Phase 1 — Sever the CLI ↔ Agent/CP compile-time coupling
@@ -1120,11 +1151,16 @@ Update root namespace: `DevOpsMigrationPlatform.Abstractions.*` →
 
 #### Step 3.3 — Add project references to consumers
 
+**Temporary state:** `Infrastructure.csproj` references `Abstractions.Agent` because
+it still contains Agent-specific implementations (modules, orchestrators, stores).
+This reference moves to `Infrastructure.Agent.csproj` in Phase 5 and is removed from
+base `Infrastructure.csproj`.
+
 | Project | Add reference to |
 |---------|-----------------|
 | `MigrationAgent.csproj` | `Abstractions.Agent` |
 | `CLI.TfsMigration.csproj` | `Abstractions.Agent` |
-| `Infrastructure.csproj` | `Abstractions.Agent` |
+| `Infrastructure.csproj` | `Abstractions.Agent` ← **temporary**, moves to `Infrastructure.Agent` in Phase 5 |
 | `Infrastructure.AzureDevOps.csproj` | `Abstractions.Agent` |
 | `Infrastructure.Simulated.csproj` | `Abstractions.Agent` |
 | `Infrastructure.TfsObjectModel.csproj` | `Abstractions.Agent` |
@@ -1148,9 +1184,265 @@ Add both new projects to the solution file.
 
 ---
 
-### Phase 4 — Verification
+### Phase 4 — Restructure `Infrastructure` folders (screaming architecture, cross-cutting only)
 
-#### Step 4.1 — Build gate
+Same pattern as Phase 2. Move only files that STAY in base `Infrastructure` to their
+screaming-architecture folders. Agent-targeted and CP-targeted files skip this phase and
+move directly to `Infrastructure.Agent` / `Infrastructure.ControlPlane` in Phase 5.
+
+#### Step 4.1a — `git mv` cross-cutting files to screaming folders
+
+| Source | Destination | Notes |
+|--------|-------------|-------|
+| `Infrastructure/Config/MigrationPlatformServiceExtensions.cs` | stays — already in `Config/` | no move |
+| `Infrastructure/Config/MigrationOptionsValidator.cs` | stays — already in `Config/` | no move |
+| `Infrastructure/Config/DiscoveryOptionsOrganisationsBinder.cs` | stays — already in `Config/` | no move |
+| `Infrastructure/Telemetry/DataClassificationLogProcessor.cs` | stays — already in `Telemetry/` | no move |
+| `Infrastructure/Telemetry/DataClassificationExtensions.cs` | stays — already in `Telemetry/` | no move |
+| `Infrastructure/Polyfills/IsExternalInit.cs` | stays — already in `Polyfills/` | no move |
+
+Most cross-cutting files are already in correctly-named folders. The only structural
+change is removing files that leave in Phase 5. No `git mv` operations needed here unless
+renaming the `Config/` folder (it's already descriptive enough).
+
+#### Step 4.1b — Namespace updates for any moved files
+
+Update `namespace` and `using` statements for any files moved in 4.1a.
+
+---
+
+### Phase 5 — Extract `Infrastructure.ControlPlane` and `Infrastructure.Agent` projects
+
+#### Step 5.1a — Create `Infrastructure.ControlPlane` project
+
+```
+src/DevOpsMigrationPlatform.Infrastructure.ControlPlane/
+  DevOpsMigrationPlatform.Infrastructure.ControlPlane.csproj
+```
+
+```xml
+<!-- Infrastructure.ControlPlane.csproj -->
+<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions.ControlPlane\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure\..." />
+```
+
+#### Step 5.1b — `git mv` CP telemetry files to `Infrastructure.ControlPlane/Metrics/`
+
+| Source | Destination |
+|--------|-------------|
+| `Infrastructure/Telemetry/InMemoryJobMetricsStore.cs` | `Infrastructure.ControlPlane/Metrics/InMemoryJobMetricsStore.cs` |
+| `Infrastructure/Telemetry/InMemoryJobSnapshotStore.cs` | `Infrastructure.ControlPlane/Metrics/InMemoryJobSnapshotStore.cs` |
+| `Infrastructure/Telemetry/JobLifecycleMetrics.cs` | `Infrastructure.ControlPlane/Metrics/JobLifecycleMetrics.cs` |
+| `Infrastructure/Telemetry/SnapshotMetricExporter.cs` | `Infrastructure.ControlPlane/Metrics/SnapshotMetricExporter.cs` |
+
+#### Step 5.1c — Namespace updates for CP files
+
+Update `namespace` → `DevOpsMigrationPlatform.Infrastructure.ControlPlane.Metrics`
+
+#### Step 5.1d — Create `AddControlPlaneTelemetryServices()` registration
+
+Extract CP-specific registrations from the current `AddTelemetryServices()` into a new
+extension method in `Infrastructure.ControlPlane/Metrics/TelemetryServiceExtensions.cs`.
+
+Update `ControlPlaneHost/Program.cs` to call `AddControlPlaneTelemetryServices()`.
+
+#### Step 5.2a — Create `Infrastructure.Agent` project
+
+```
+src/DevOpsMigrationPlatform.Infrastructure.Agent/
+  DevOpsMigrationPlatform.Infrastructure.Agent.csproj
+```
+
+```xml
+<!-- Infrastructure.Agent.csproj -->
+<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions.Agent\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure\..." />
+```
+
+#### Step 5.2b — `git mv` Agent files to `Infrastructure.Agent/` with screaming architecture
+
+All files move directly from their current `Infrastructure/` location to their final
+screaming-architecture folder in `Infrastructure.Agent/`. One move per file.
+
+**Storage/** (from `Infrastructure/Storage/` + `Infrastructure/Factories/`):
+
+| Source | Destination |
+|--------|-------------|
+| `Infrastructure/Storage/FileSystemArtefactStore.cs` | `Infrastructure.Agent/Storage/FileSystemArtefactStore.cs` |
+| `Infrastructure/Storage/AzureBlobArtefactStore.cs` | `Infrastructure.Agent/Storage/AzureBlobArtefactStore.cs` |
+| `Infrastructure/Factories/FileSystemPackageStoreFactory.cs` | `Infrastructure.Agent/Storage/FileSystemPackageStoreFactory.cs` |
+
+**Checkpointing/** (from `Infrastructure/Checkpointing/` + `Infrastructure/JobEngine/`):
+
+| Source | Destination |
+|--------|-------------|
+| `Infrastructure/Checkpointing/CheckpointingService.cs` | `Infrastructure.Agent/Checkpointing/CheckpointingService.cs` |
+| `Infrastructure/Checkpointing/CheckpointingServiceFactory.cs` | `Infrastructure.Agent/Checkpointing/CheckpointingServiceFactory.cs` |
+| `Infrastructure/Checkpointing/FileSystemStateStore.cs` | `Infrastructure.Agent/Checkpointing/FileSystemStateStore.cs` |
+| `Infrastructure/JobEngine/PhaseTrackingService.cs` | `Infrastructure.Agent/Checkpointing/PhaseTrackingService.cs` |
+| `Infrastructure/JobEngine/PhaseTrackingServiceFactory.cs` | `Infrastructure.Agent/Checkpointing/PhaseTrackingServiceFactory.cs` |
+
+**Export/** (from `Infrastructure/Export/`):
+
+| Source | Destination |
+|--------|-------------|
+| `Infrastructure/Export/WorkItemExportOrchestrator.cs` | `Infrastructure.Agent/Export/WorkItemExportOrchestrator.cs` |
+| `Infrastructure/Export/EmbeddedImageExportService.cs` | `Infrastructure.Agent/Export/EmbeddedImageExportService.cs` |
+| `Infrastructure/Export/CompositeWorkItemRevisionSourceFactory.cs` | `Infrastructure.Agent/Export/CompositeWorkItemRevisionSourceFactory.cs` |
+
+**Import/** (from `Infrastructure/Import/`):
+
+| Source | Destination |
+|--------|-------------|
+| `Infrastructure/Import/WorkItemImportOrchestrator.cs` | `Infrastructure.Agent/Import/WorkItemImportOrchestrator.cs` |
+| `Infrastructure/Import/CompositeWorkItemImportTargetFactory.cs` | `Infrastructure.Agent/Import/CompositeWorkItemImportTargetFactory.cs` |
+| `Infrastructure/Import/CompositeWorkItemResolutionStrategyFactory.cs` | `Infrastructure.Agent/Import/CompositeWorkItemResolutionStrategyFactory.cs` |
+| `Infrastructure/Import/RevisionFolderProcessor.cs` | `Infrastructure.Agent/Import/RevisionFolderProcessor.cs` |
+| `Infrastructure/Import/RevisionFolderProcessorFactory.cs` | `Infrastructure.Agent/Import/RevisionFolderProcessorFactory.cs` |
+| `Infrastructure/Import/WorkItemRevisionFolderParser.cs` | `Infrastructure.Agent/Import/WorkItemRevisionFolderParser.cs` |
+| `Infrastructure/Import/SqliteIdMapStore.cs` | `Infrastructure.Agent/Import/SqliteIdMapStore.cs` |
+| `Infrastructure/Import/IdMapStoreFactory.cs` | `Infrastructure.Agent/Import/IdMapStoreFactory.cs` |
+| `Infrastructure/Import/PassThroughIdentityMappingService.cs` | `Infrastructure.Agent/Import/PassThroughIdentityMappingService.cs` |
+| `Infrastructure/Import/NullResolutionStrategy.cs` | `Infrastructure.Agent/Import/NullResolutionStrategy.cs` |
+
+**Discovery/** (from `Infrastructure/Services/` + `Infrastructure/Modules/Discovery/`):
+
+| Source | Destination |
+|--------|-------------|
+| `Infrastructure/Services/CatalogService.cs` | `Infrastructure.Agent/Discovery/CatalogService.cs` |
+| `Infrastructure/Services/InventoryService.cs` | `Infrastructure.Agent/Discovery/InventoryService.cs` |
+| `Infrastructure/Services/DependencyDiscoveryService.cs` | `Infrastructure.Agent/Discovery/DependencyDiscoveryService.cs` |
+| `Infrastructure/Services/QueryFingerprintService.cs` | `Infrastructure.Agent/Discovery/QueryFingerprintService.cs` |
+| `Infrastructure/Services/PackageLockFileService.cs` | `Infrastructure.Agent/Discovery/PackageLockFileService.cs` |
+| `Infrastructure/Services/FileSystemIdentityMappingService.cs` | `Infrastructure.Agent/Discovery/FileSystemIdentityMappingService.cs` |
+| `Infrastructure/Services/ConfigurationService.cs` | `Infrastructure.Agent/Discovery/ConfigurationService.cs` |
+| `Infrastructure/Modules/Discovery/ProjectDependencyRecord.cs` | `Infrastructure.Agent/Discovery/ProjectDependencyRecord.cs` |
+| `Infrastructure/Modules/Discovery/MermaidUtilities.cs` | `Infrastructure.Agent/Discovery/MermaidUtilities.cs` |
+| `Infrastructure/Modules/Discovery/MermaidDiagramBuilder.cs` | `Infrastructure.Agent/Discovery/MermaidDiagramBuilder.cs` |
+| `Infrastructure/Modules/Discovery/TransitiveDependencyEdge.cs` | `Infrastructure.Agent/Discovery/TransitiveDependencyEdge.cs` |
+| `Infrastructure/Modules/Discovery/ProjectPairKey.cs` | `Infrastructure.Agent/Discovery/ProjectPairKey.cs` |
+| `Infrastructure/Modules/Discovery/TransitiveDependencyWalker.cs` | `Infrastructure.Agent/Discovery/TransitiveDependencyWalker.cs` |
+| `Infrastructure/Modules/Discovery/TransitiveMermaidBuilder.cs` | `Infrastructure.Agent/Discovery/TransitiveMermaidBuilder.cs` |
+| `Infrastructure/Modules/Discovery/UnionFindComponentLabeler.cs` | `Infrastructure.Agent/Discovery/UnionFindComponentLabeler.cs` |
+
+**Modules/** (from `Infrastructure/Modules/`):
+
+| Source | Destination |
+|--------|-------------|
+| `Infrastructure/Modules/WorkItemsModule.cs` | `Infrastructure.Agent/Modules/WorkItemsModule.cs` |
+| `Infrastructure/Modules/InventoryDiscoveryModule.cs` | `Infrastructure.Agent/Modules/InventoryDiscoveryModule.cs` |
+| `Infrastructure/Modules/DependencyDiscoveryModule.cs` | `Infrastructure.Agent/Modules/DependencyDiscoveryModule.cs` |
+| `Infrastructure/ModuleServiceCollectionExtensions.cs` | `Infrastructure.Agent/Modules/ModuleServiceCollectionExtensions.cs` |
+
+**Telemetry/** (from `Infrastructure/Telemetry/` — Agent-specific only):
+
+| Source | Destination |
+|--------|-------------|
+| `Infrastructure/Telemetry/DiscoveryMetrics.cs` | `Infrastructure.Agent/Telemetry/DiscoveryMetrics.cs` |
+| `Infrastructure/Telemetry/MigrationMetrics.cs` | `Infrastructure.Agent/Telemetry/MigrationMetrics.cs` |
+| `Infrastructure/Telemetry/AnsiProgressSink.cs` | `Infrastructure.Agent/Telemetry/AnsiProgressSink.cs` |
+| `Infrastructure/Telemetry/CompositeProgressSink.cs` | `Infrastructure.Agent/Telemetry/CompositeProgressSink.cs` |
+| `Infrastructure/Telemetry/ControlPlaneProgressSink.cs` | `Infrastructure.Agent/Telemetry/ControlPlaneProgressSink.cs` |
+| `Infrastructure/Telemetry/PackageProgressSink.cs` | `Infrastructure.Agent/Telemetry/PackageProgressSink.cs` |
+| `Infrastructure/Telemetry/ControlPlaneTelemetryClient.cs` | `Infrastructure.Agent/Telemetry/ControlPlaneTelemetryClient.cs` |
+| `Infrastructure/Telemetry/ControlPlaneLoggerProvider.cs` | `Infrastructure.Agent/Telemetry/ControlPlaneLoggerProvider.cs` |
+| `Infrastructure/Telemetry/PackageLoggerProvider.cs` | `Infrastructure.Agent/Telemetry/PackageLoggerProvider.cs` |
+
+**DI/** (from `Infrastructure/Extensions/`):
+
+| Source | Destination |
+|--------|-------------|
+| `Infrastructure/Extensions/FactoryRegistrationExtensions.cs` | `Infrastructure.Agent/DI/FactoryRegistrationExtensions.cs` |
+
+**Validation/** (from `Infrastructure/Validation/`):
+
+| Source | Destination |
+|--------|-------------|
+| `Infrastructure/Validation/PackageValidator.cs` | `Infrastructure.Agent/Validation/PackageValidator.cs` |
+
+#### Step 5.2c — Namespace updates for Agent files
+
+Update all moved files: `namespace` → `DevOpsMigrationPlatform.Infrastructure.Agent.*`
+
+#### Step 5.2d — Create `AddAgentTelemetryServices()` registration
+
+Extract Agent-specific registrations from the current `AddTelemetryServices()` into a new
+extension method in `Infrastructure.Agent/Telemetry/TelemetryServiceExtensions.cs`.
+
+The original `AddTelemetryServices()` in base `Infrastructure/Telemetry/` retains only
+cross-cutting registrations (data classification log processor). Rename to
+`AddCoreTelemetryServices()` to make intent explicit.
+
+Update `MigrationAgent/Program.cs` to call `AddAgentTelemetryServices()`.
+Update `CLI.TfsMigration` to call `AddAgentTelemetryServices()`.
+
+#### Step 5.3 — Update project references
+
+**Remove from `Infrastructure.csproj`:**
+```xml
+<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions.Agent\..." />
+```
+Base `Infrastructure` no longer contains Agent-specific implementations.
+
+**Add to consumers:**
+
+| Project | Add reference |
+|---------|-------------|
+| `MigrationAgent.csproj` | `Infrastructure.Agent` |
+| `CLI.TfsMigration.csproj` | `Infrastructure.Agent` |
+| `ControlPlaneHost.csproj` | `Infrastructure.ControlPlane` |
+| `Infrastructure.AzureDevOps.csproj` | `Infrastructure.Agent` |
+| `Infrastructure.Simulated.csproj` | `Infrastructure.Agent` |
+| `Infrastructure.TfsObjectModel.csproj` | `Infrastructure.Agent` |
+
+**Remove from consumers (previously referenced base `Infrastructure` for Agent types):**
+
+| Project | Remove reference | Reason |
+|---------|-----------------|--------|
+| `MigrationAgent.csproj` | — | Still needs base `Infrastructure` for config binding |
+| `ControlPlaneHost.csproj` | — | Still needs base `Infrastructure` for config binding + serialization |
+
+#### Step 5.4 — Update `DevOpsMigrationPlatform.slnx`
+
+Add both new projects to the solution file.
+
+#### Step 5.5 — Delete empty folders from base `Infrastructure`
+
+After all moves, delete empty folders:
+- `Storage/`, `Factories/`, `Checkpointing/`, `JobEngine/`, `Export/`, `Import/`
+- `Modules/` (including `Discovery/` subfolder)
+- `Services/`, `Extensions/`, `Validation/`
+
+Base `Infrastructure/` retains only:
+- `Config/` (3 files)
+- `Telemetry/` (2–3 cross-cutting files)
+- `Serialization/` (types not moved to Abstractions in Phase 1)
+- `Polyfills/` (1 file)
+
+---
+
+### Phase 6 — Reference topology cleanup and verification
+
+#### Step 6.1 — Fix test project references
+
+| Test project | Remove reference | Reason |
+|---|---|---|
+| `Infrastructure.Tests` | `CLI.Migration` | Infrastructure tests must not depend on CLI |
+| `CLI.Migration.Tests` | `Infrastructure` | CLI tests must mock abstractions, not use concrete infra |
+| `CLI.Migration.Tests` | `Infrastructure.AzureDevOps` | CLI tests must mock abstractions, not use concrete infra |
+
+For any test that currently depends on the removed reference:
+- If it tests CLI+Infrastructure integration → move to a dedicated integration test project
+- If it uses concrete types for test setup → replace with mocks of the abstraction interfaces
+- If it only uses config types → those are now in `Abstractions/Options/` (no reference needed)
+
+`Infrastructure.Tests` may need splitting into `Infrastructure.Tests`,
+`Infrastructure.Agent.Tests`, and `Infrastructure.ControlPlane.Tests` to match the
+production project boundaries. Each test project references only its system-under-test.
+
+#### Step 6.2 — Build gate
 
 ```powershell
 dotnet clean && dotnet build --no-incremental
@@ -1158,7 +1450,7 @@ dotnet clean && dotnet build --no-incremental
 
 All projects must compile. Zero warnings from missing types.
 
-#### Step 4.2 — Test gate
+#### Step 6.3 — Test gate
 
 ```powershell
 dotnet test
@@ -1166,20 +1458,34 @@ dotnet test
 
 All existing tests must pass. The refactoring is purely structural — no behaviour changes.
 
-#### Step 4.3 — Reference topology audit
+#### Step 6.4 — Reference topology audit
 
 Verify that the compiler-enforced topology matches BOTH tables in the Target State section.
 Any ❌ cell that has a reference is a violation. Fix before declaring done.
 
-Specifically verify:
-- `CLI.Migration` → only `Abstractions`
-- `ControlPlane` → only `Abstractions` + `Abstractions.ControlPlane` (no `Infrastructure`, no `Abstractions.Agent`)
-- `ControlPlaneHost` → `Abstractions` + `Abstractions.ControlPlane` + `Infrastructure` + `ServiceDefaults`
-- `MigrationAgent` → `Abstractions` + `Abstractions.Agent` + `Infrastructure` + `Infrastructure.AzureDevOps` + `Infrastructure.Simulated` + `ServiceDefaults`
-- `Infrastructure.Tests` does NOT reference `CLI.Migration`
-- `CLI.Migration.Tests` does NOT reference `Infrastructure` or `Infrastructure.AzureDevOps`
+**Abstractions layer:**
+- `CLI.Migration` → only `Abstractions` (no `Abstractions.Agent`, no `Abstractions.ControlPlane`)
+- `ControlPlane` → `Abstractions` + `Abstractions.ControlPlane` (no `Abstractions.Agent`)
+- `ControlPlaneHost` → `Abstractions` + `Abstractions.ControlPlane`
+- `MigrationAgent` → `Abstractions` + `Abstractions.Agent` (no `Abstractions.ControlPlane`)
+- `Infrastructure` → `Abstractions` only (no `Abstractions.Agent`, no `Abstractions.ControlPlane`)
+- `Infrastructure.ControlPlane` → `Abstractions` + `Abstractions.ControlPlane`
+- `Infrastructure.Agent` → `Abstractions` + `Abstractions.Agent`
 
-#### Step 4.4 — Scenario smoke test
+**Implementation layer:**
+- `CLI.Migration` → `Infrastructure` only (config binding, serialization — no `Infrastructure.Agent`, no `Infrastructure.ControlPlane`)
+- `ControlPlane` → NO Infrastructure references (library project; registrations in Host)
+- `ControlPlaneHost` → `Infrastructure` + `Infrastructure.ControlPlane` (no `Infrastructure.Agent`)
+- `MigrationAgent` → `Infrastructure` + `Infrastructure.Agent` + `Infrastructure.AzureDevOps` + `Infrastructure.Simulated` (no `Infrastructure.ControlPlane`)
+- `Infrastructure.AzureDevOps` → `Infrastructure` + `Infrastructure.Agent`
+- `Infrastructure.Simulated` → `Infrastructure` + `Infrastructure.Agent`
+- `Infrastructure.TfsObjectModel` → `Infrastructure` + `Infrastructure.Agent`
+
+**Test projects:**
+- `Infrastructure.Tests` does NOT reference `CLI.Migration`
+- `CLI.Migration.Tests` does NOT reference `Infrastructure`, `Infrastructure.Agent`, or `Infrastructure.AzureDevOps`
+
+#### Step 6.5 — Scenario smoke test
 
 Run at least one scenario config via `launch.json` debug profile and verify observable output.
 
@@ -1193,17 +1499,19 @@ Run at least one scenario config via `launch.json` debug profile and verify obse
 ControlPlane. It correctly references `Abstractions` + `Abstractions.Agent` and directly
 resolves `IWorkItemDiscoveryService`, `IProgressSink`, etc. This is by design.
 
-### `Infrastructure` references `Abstractions.Agent`
+### `Infrastructure` references `Abstractions.Agent` — temporary
 
-`Infrastructure` implements Agent modules (`InventoryDiscoveryModule`,
-`WorkItemExportOrchestrator`, etc.) and uses `IArtefactStore`, `ICheckpointingService`,
-and other Agent-internal contracts. It correctly references `Abstractions` +
-`Abstractions.Agent`.
+During Phase 3, base `Infrastructure` gains a temporary `Abstractions.Agent` reference
+because it still contains Agent-specific implementations. Phase 5 moves those
+implementations to `Infrastructure.Agent` and removes the reference from base
+`Infrastructure`. After Phase 5, base `Infrastructure` references only `Abstractions`
+(cross-cutting config, serialization, telemetry utilities).
 
 ### `MigrationAgent` references Infrastructure projects
 
 `MigrationAgent` is a composition root — it wires up concrete implementations from
-`Infrastructure`, `Infrastructure.AzureDevOps`, and `Infrastructure.Simulated` at startup.
+`Infrastructure` (config binding), `Infrastructure.Agent` (stores, orchestrators, modules),
+`Infrastructure.AzureDevOps`, and `Infrastructure.Simulated` at startup.
 This is the correct place for those references. The topology table shows this explicitly.
 
 ### `ControlPlaneHost` vs `ControlPlane` — split responsibility
@@ -1213,8 +1521,9 @@ It references only `Abstractions` + `Abstractions.ControlPlane`. It MUST NOT ref
 `Infrastructure` directly.
 
 `ControlPlaneHost` is the ASP.NET Core executable (composition root). It wires up
-concrete implementations from `Infrastructure` and registers them via DI. Infrastructure
-references belong here, not in `ControlPlane`.
+concrete implementations from `Infrastructure` (config binding) and
+`Infrastructure.ControlPlane` (metric stores, lifecycle metrics) via DI. It MUST NOT
+reference `Infrastructure.Agent`.
 
 **Current violation:** `ControlPlane/Services/ControlPlaneServiceExtensions.cs` directly
 references `DevOpsMigrationPlatform.Infrastructure.Factories` and hard-codes

--- a/analysis/separation-of-concerns.md
+++ b/analysis/separation-of-concerns.md
@@ -61,7 +61,7 @@ export). The in-process fallback is unnecessary and must be deleted.
 
 The CLI compiles against `Abstractions` only. It launches ControlPlane and Agent as child
 processes via `ChildProcessHost`. All communication with CP is via HTTP using the contracts
-in `Abstractions/ControlPlane/`.
+in `Abstractions/ControlPlaneApi/`.
 
 ### Project reference topology — enforced by compiler
 
@@ -119,7 +119,9 @@ The CP-internal store and OTel interfaces are invisible to everything outside th
 
 | Test project | References (beyond test frameworks) |
 |---|---|
-| `Infrastructure.Tests` | `Abstractions`, `Abstractions.Agent`, `Infrastructure`, `Infrastructure.AzureDevOps`, `Infrastructure.Simulated` |
+| `Infrastructure.Tests` | `Abstractions`, `Infrastructure` |
+| `Infrastructure.Agent.Tests` | `Abstractions`, `Abstractions.Agent`, `Infrastructure`, `Infrastructure.Agent`, `Infrastructure.AzureDevOps`, `Infrastructure.Simulated` |
+| `Infrastructure.ControlPlane.Tests` | `Abstractions`, `Abstractions.ControlPlane`, `Infrastructure`, `Infrastructure.ControlPlane` |
 | `Infrastructure.Simulated.Tests` | `Abstractions`, `Abstractions.Agent`, `Infrastructure`, `Infrastructure.Simulated` |
 | `CLI.Migration.Tests` | `Abstractions`, `CLI.Migration` |
 | `ControlPlane.Tests` | `Abstractions`, `Abstractions.ControlPlane`, `ControlPlane` |
@@ -154,6 +156,7 @@ ResumeDecisionStatus.cs
 ResumeRejectedException.cs
 MigrationErrorCategory.cs         ← moved from Errors/
 MigrationException.cs             ← moved from Errors/
+IJobSubmissionClient.cs           ← renamed from IJobRunner; submits job to CP + streams progress
 ```
 
 ### `Streaming/`
@@ -178,12 +181,13 @@ IConfigurationService.cs
 IPreFlightValidator.cs            ← Tier 0/1 validation before job submission
 ```
 
-### `ControlPlane/`
+### `ControlPlaneApi/`
 HTTP contracts and payload types for communicating with the ControlPlane.
 All components that talk to CP compile against these — no separate assembly needed.
+The folder name distinguishes this from the `Abstractions.ControlPlane` project
+(which contains CP-internal contracts like metric stores).
 ```
 IControlPlaneClient.cs            ← CLI reads jobs, streams logs, gets telemetry via HTTP
-IJobRunner.cs                     ← CLI submits jobs to CP via HTTP
 IControlPlaneTelemetryClient.cs   ← Agent pushes metrics + snapshots to CP via HTTP
 JobSummary.cs                     ← returned by GET /jobs
 JobMetrics.cs                     ← pushed by Agent, read by CLI via CP
@@ -429,16 +433,16 @@ ActiveLeaseState.cs
 ActivePackageState.cs
 PackagePaths.cs
 PackagePathUtilities.cs
-IProgressSink.cs                  ← agent lifecycle progress reporting
 ```
 
 ### `Telemetry/`
-OTel metric interfaces — only emitted from within Agent execution.
+OTel metric interfaces and progress reporting — only emitted from within Agent execution.
 ```
 IDiscoveryMetrics.cs
 IWorkItemExportMetrics.cs
 IAttachmentDownloadMetrics.cs
 IMigrationMetrics.cs
+IProgressSink.cs                  ← agent progress reporting (console, package, CP)
 ```
 
 ### `Modules/`
@@ -457,11 +461,12 @@ Config binding, serialization, options validation, and DI extension methods that
 composition roots need. No Agent-specific or CP-specific implementations.
 
 ### `Config/`
-Options binding and validation.
+Options binding, validation, and config file services.
 ```
 MigrationPlatformServiceExtensions.cs   ← AddMigrationPlatformOptions(), AddMigrationPlatformPolymorphicSerializers()
 MigrationOptionsValidator.cs
 DiscoveryOptionsOrganisationsBinder.cs
+ConfigurationService.cs                 ← implements IConfigurationService (CLI registers this directly)
 ```
 
 ### `Serialization/`
@@ -471,6 +476,7 @@ What remains here are internal helpers:
 ```
 EndpointOptionsTypeRegistry.cs
 EndpointOptionsRegistration.cs
+EndpointOptionsRegistrationExtensions.cs  ← stays here (depends on serialization + DI)
 PolymorphicOrganisationEntryConverter.cs  ← if not also moved to Abstractions
 ```
 
@@ -570,16 +576,11 @@ PackageLockFileService.cs         ← implements IPackageLockService (moved from
 FileSystemIdentityMappingService.cs ← implements IIdentityMappingService (moved from Services/)
 ```
 
-### `Modules/`
-```
-WorkItemsModule.cs                ← implements IModule
-InventoryDiscoveryModule.cs       ← implements IDiscoveryModule
-DependencyDiscoveryModule.cs      ← implements IDiscoveryModule
-ModuleServiceCollectionExtensions.cs ← AddWorkItemsModule(), AddInventoryDiscoveryModule(), AddDependencyDiscoveryModule()
-```
+Note: `ConfigurationService` stays in base `Infrastructure/Config/` — it is CLI-facing
+(registered by CLI commands directly) and must remain reachable without `Infrastructure.Agent`.
 
-### `Modules/Discovery/`
-Internal utilities for dependency analysis:
+### `Discovery/DependencyGraph/`
+Internal graph analysis utilities used only by `DependencyDiscoveryModule`:
 ```
 ProjectDependencyRecord.cs
 MermaidUtilities.cs
@@ -589,6 +590,14 @@ ProjectPairKey.cs
 TransitiveDependencyWalker.cs
 TransitiveMermaidBuilder.cs
 UnionFindComponentLabeler.cs
+```
+
+### `Modules/`
+```
+WorkItemsModule.cs                ← implements IModule
+InventoryDiscoveryModule.cs       ← implements IDiscoveryModule
+DependencyDiscoveryModule.cs      ← implements IDiscoveryModule
+ModuleServiceCollectionExtensions.cs ← AddWorkItemsModule(), AddInventoryDiscoveryModule(), AddDependencyDiscoveryModule()
 ```
 
 ### `Telemetry/`
@@ -612,8 +621,8 @@ DiagnosticsServiceExtensions.cs   ← AddDiagnosticsServices() — Agent diagnos
 PackageValidator.cs               ← implements IPackageValidator
 ```
 
-### `DI/`
-Factory dispatcher registration — used by `Infrastructure.AzureDevOps` and `Infrastructure.Simulated`:
+### `Connectors/`
+Connector factory registration — used by `Infrastructure.AzureDevOps` and `Infrastructure.Simulated`:
 ```
 FactoryRegistrationExtensions.cs  ← moved from Extensions/
 ```
@@ -716,10 +725,9 @@ Removing it makes Steps 1.2–1.5 possible.
 Update namespaces from `DevOpsMigrationPlatform.Infrastructure.*.Options` →
 `DevOpsMigrationPlatform.Abstractions.Options`.
 
-Also move:
-| Source | Destination |
-|--------|-------------|
-| `Infrastructure/Extensions/EndpointOptionsRegistrationExtensions.cs` | `Abstractions/Options/EndpointOptionsRegistrationExtensions.cs` |
+Note: `EndpointOptionsRegistrationExtensions.cs` stays in base `Infrastructure` — it
+depends on `EndpointOptionsTypeRegistry` (serialization) and `IServiceCollection` (DI
+framework), which would invert the dependency rule if placed in `Abstractions`.
 
 #### Step 1.5 — Move serialization to `Abstractions/Serialization/`
 
@@ -809,8 +817,8 @@ namespace update + file move. Run build after each step.
 `Models/` is the largest technical bucket (70 files). Every file moves to a folder
 named after the business concept it represents.
 
-**Create new folders:** `Jobs/`, `Streaming/`, `Organisations/`, `ControlPlane/`
-(ControlPlane/ may already exist for `IControlPlaneClient.cs`).
+**Create new folders:** `Jobs/`, `Streaming/`, `Organisations/`, `ControlPlaneApi/`
+(`ControlPlaneApi/` may already exist for `IControlPlaneClient.cs`).
 
 | Source file in `Models/` | Destination folder | Notes |
 |--------------------------|-------------------|-------|
@@ -834,21 +842,21 @@ named after the business concept it represents.
 | `ScopedOrganisationEndpoint.cs` | `Organisations/` | |
 | `ValidationContext.cs` | `Validation/` | merge with existing |
 | `FilterOperator.cs` | `Options/` | config filter concern |
-| `JobSummary.cs` | `ControlPlane/` | |
-| `JobMetrics.cs` | `ControlPlane/` | |
-| `JobSnapshot.cs` | `ControlPlane/` | |
-| `JobBootstrap.cs` | `ControlPlane/` | |
-| `JobScopeCounters.cs` | `ControlPlane/` | |
-| `JobDiagnostics.cs` | `ControlPlane/` | |
-| `MigrationCounters.cs` | `ControlPlane/` | |
-| `MigrationDiagnostics.cs` | `ControlPlane/` | |
-| `OrgSnapshot.cs` | `ControlPlane/` | |
-| `ProjectSnapshot.cs` | `ControlPlane/` | |
-| `ProjectStatus.cs` | `ControlPlane/` | |
-| `TargetStatus.cs` | `ControlPlane/` | |
-| `DiscoveryCounters.cs` | `ControlPlane/` | |
-| `InventoryCounters.cs` | `ControlPlane/` | |
-| `DependencyCounters.cs` | `ControlPlane/` | |
+| `JobSummary.cs` | `ControlPlaneApi/` | |
+| `JobMetrics.cs` | `ControlPlaneApi/` | |
+| `JobSnapshot.cs` | `ControlPlaneApi/` | |
+| `JobBootstrap.cs` | `ControlPlaneApi/` | |
+| `JobScopeCounters.cs` | `ControlPlaneApi/` | |
+| `JobDiagnostics.cs` | `ControlPlaneApi/` | |
+| `MigrationCounters.cs` | `ControlPlaneApi/` | |
+| `MigrationDiagnostics.cs` | `ControlPlaneApi/` | |
+| `OrgSnapshot.cs` | `ControlPlaneApi/` | |
+| `ProjectSnapshot.cs` | `ControlPlaneApi/` | |
+| `ProjectStatus.cs` | `ControlPlaneApi/` | |
+| `TargetStatus.cs` | `ControlPlaneApi/` | |
+| `DiscoveryCounters.cs` | `ControlPlaneApi/` | |
+| `InventoryCounters.cs` | `ControlPlaneApi/` | |
+| `DependencyCounters.cs` | `ControlPlaneApi/` | |
 
 **Remaining `Models/` files are Agent-internal.** They stay in `Models/` temporarily —
 they move to `Abstractions.Agent` in Phase 3:
@@ -902,7 +910,7 @@ Delete `Models/` after Phase 3.
 | Source file in `Services/` | Destination folder | Notes |
 |----------------------------|-------------------|-------|
 | `IConfigurationService.cs` | `Configuration/` | stays in Abstractions |
-| `IJobRunner.cs` | `ControlPlane/` | HTTP contract — stays in Abstractions |
+| `IJobRunner.cs` | `Jobs/IJobSubmissionClient.cs` | rename: IJobRunner → IJobSubmissionClient |
 
 **Remaining 39 files are Agent-internal.** They stay in `Services/` temporarily —
 they move to `Abstractions.Agent` in Phase 3:
@@ -945,7 +953,7 @@ they move to `Abstractions.Agent` in Phase 3:
 | `IPackageValidator.cs` | `Agent/Storage/` |
 | `IIdMapStore.cs` | `Agent/Storage/` |
 | `IIdMapStoreFactory.cs` | `Agent/Storage/` |
-| `IProgressSink.cs` | `Agent/Lease/` |
+| `IProgressSink.cs` | `Agent/Telemetry/` |
 | `IModule.cs` | `Agent/Modules/` |
 | `IDiscoveryModule.cs` | `Agent/Modules/` |
 
@@ -966,7 +974,7 @@ Delete `Errors/` after Phase 3.
 
 | Source | Destination | Notes |
 |--------|-------------|-------|
-| `Abstractions/IControlPlaneClient.cs` | `Abstractions/ControlPlane/IControlPlaneClient.cs` | HTTP contract |
+| `Abstractions/IControlPlaneClient.cs` | `Abstractions/ControlPlaneApi/IControlPlaneClient.cs` | HTTP contract |
 | `Abstractions/ActiveLeaseState.cs` | stays at root temporarily | moves to `Agent/Lease/` in Phase 3 |
 | `Abstractions/ActivePackageState.cs` | stays at root temporarily | moves to `Agent/Lease/` in Phase 3 |
 | `Abstractions/PackagePaths.cs` | stays at root temporarily | moves to `Agent/Lease/` in Phase 3 |
@@ -999,7 +1007,7 @@ Delete `CLI.Migration/Utilities/` after this step.
 | `Telemetry/IJobLifecycleMetrics.cs` | stays temporarily | Phase 3: `Abstractions.ControlPlane/Metrics/` |
 | `Telemetry/IJobMetricsStore.cs` | stays temporarily | Phase 3: `Abstractions.ControlPlane/Metrics/` |
 | `Telemetry/IJobSnapshotStore.cs` | stays temporarily | Phase 3: `Abstractions.ControlPlane/Metrics/` |
-| `Telemetry/IControlPlaneTelemetryClient.cs` | `ControlPlane/IControlPlaneTelemetryClient.cs` | HTTP contract — cross-cutting |
+| `Telemetry/IControlPlaneTelemetryClient.cs` | `ControlPlaneApi/IControlPlaneTelemetryClient.cs` | HTTP contract — cross-cutting |
 | `Telemetry/IDiscoveryMetrics.cs` | stays temporarily | Phase 3: `Abstractions.Agent/Telemetry/` |
 | `Telemetry/IWorkItemExportMetrics.cs` | stays temporarily | Phase 3: `Abstractions.Agent/Telemetry/` |
 | `Telemetry/IAttachmentDownloadMetrics.cs` | stays temporarily | Phase 3: `Abstractions.Agent/Telemetry/` |
@@ -1317,15 +1325,15 @@ screaming-architecture folder in `Infrastructure.Agent/`. One move per file.
 | `Infrastructure/Services/QueryFingerprintService.cs` | `Infrastructure.Agent/Discovery/QueryFingerprintService.cs` |
 | `Infrastructure/Services/PackageLockFileService.cs` | `Infrastructure.Agent/Discovery/PackageLockFileService.cs` |
 | `Infrastructure/Services/FileSystemIdentityMappingService.cs` | `Infrastructure.Agent/Discovery/FileSystemIdentityMappingService.cs` |
-| `Infrastructure/Services/ConfigurationService.cs` | `Infrastructure.Agent/Discovery/ConfigurationService.cs` |
-| `Infrastructure/Modules/Discovery/ProjectDependencyRecord.cs` | `Infrastructure.Agent/Discovery/ProjectDependencyRecord.cs` |
-| `Infrastructure/Modules/Discovery/MermaidUtilities.cs` | `Infrastructure.Agent/Discovery/MermaidUtilities.cs` |
-| `Infrastructure/Modules/Discovery/MermaidDiagramBuilder.cs` | `Infrastructure.Agent/Discovery/MermaidDiagramBuilder.cs` |
-| `Infrastructure/Modules/Discovery/TransitiveDependencyEdge.cs` | `Infrastructure.Agent/Discovery/TransitiveDependencyEdge.cs` |
-| `Infrastructure/Modules/Discovery/ProjectPairKey.cs` | `Infrastructure.Agent/Discovery/ProjectPairKey.cs` |
-| `Infrastructure/Modules/Discovery/TransitiveDependencyWalker.cs` | `Infrastructure.Agent/Discovery/TransitiveDependencyWalker.cs` |
-| `Infrastructure/Modules/Discovery/TransitiveMermaidBuilder.cs` | `Infrastructure.Agent/Discovery/TransitiveMermaidBuilder.cs` |
-| `Infrastructure/Modules/Discovery/UnionFindComponentLabeler.cs` | `Infrastructure.Agent/Discovery/UnionFindComponentLabeler.cs` |
+| `Infrastructure/Services/ConfigurationService.cs` | `Infrastructure/Config/ConfigurationService.cs` ← stays in base (CLI-facing) |
+| `Infrastructure/Modules/Discovery/ProjectDependencyRecord.cs` | `Infrastructure.Agent/Discovery/DependencyGraph/ProjectDependencyRecord.cs` |
+| `Infrastructure/Modules/Discovery/MermaidUtilities.cs` | `Infrastructure.Agent/Discovery/DependencyGraph/MermaidUtilities.cs` |
+| `Infrastructure/Modules/Discovery/MermaidDiagramBuilder.cs` | `Infrastructure.Agent/Discovery/DependencyGraph/MermaidDiagramBuilder.cs` |
+| `Infrastructure/Modules/Discovery/TransitiveDependencyEdge.cs` | `Infrastructure.Agent/Discovery/DependencyGraph/TransitiveDependencyEdge.cs` |
+| `Infrastructure/Modules/Discovery/ProjectPairKey.cs` | `Infrastructure.Agent/Discovery/DependencyGraph/ProjectPairKey.cs` |
+| `Infrastructure/Modules/Discovery/TransitiveDependencyWalker.cs` | `Infrastructure.Agent/Discovery/DependencyGraph/TransitiveDependencyWalker.cs` |
+| `Infrastructure/Modules/Discovery/TransitiveMermaidBuilder.cs` | `Infrastructure.Agent/Discovery/DependencyGraph/TransitiveMermaidBuilder.cs` |
+| `Infrastructure/Modules/Discovery/UnionFindComponentLabeler.cs` | `Infrastructure.Agent/Discovery/DependencyGraph/UnionFindComponentLabeler.cs` |
 
 **Modules/** (from `Infrastructure/Modules/`):
 
@@ -1354,7 +1362,7 @@ screaming-architecture folder in `Infrastructure.Agent/`. One move per file.
 
 | Source | Destination |
 |--------|-------------|
-| `Infrastructure/Extensions/FactoryRegistrationExtensions.cs` | `Infrastructure.Agent/DI/FactoryRegistrationExtensions.cs` |
+| `Infrastructure/Extensions/FactoryRegistrationExtensions.cs` | `Infrastructure.Agent/Connectors/FactoryRegistrationExtensions.cs` |
 
 **Validation/** (from `Infrastructure/Validation/`):
 
@@ -1425,7 +1433,9 @@ Base `Infrastructure/` retains only:
 
 ### Phase 6 — Reference topology cleanup and verification
 
-#### Step 6.1 — Fix test project references
+#### Step 6.1 — Fix test project references and split Infrastructure.Tests
+
+**Test boundary cleanup:**
 
 | Test project | Remove reference | Reason |
 |---|---|---|
@@ -1433,14 +1443,29 @@ Base `Infrastructure/` retains only:
 | `CLI.Migration.Tests` | `Infrastructure` | CLI tests must mock abstractions, not use concrete infra |
 | `CLI.Migration.Tests` | `Infrastructure.AzureDevOps` | CLI tests must mock abstractions, not use concrete infra |
 
-For any test that currently depends on the removed reference:
+**Mandatory test project split:**
+
+Create `Infrastructure.Agent.Tests` and `Infrastructure.ControlPlane.Tests` to match
+the production project boundaries. Move existing tests from `Infrastructure.Tests` to
+the appropriate new project based on the system-under-test:
+
+| Test subject | Move to |
+|---|---|
+| Tests for `Infrastructure.Agent/` types (stores, orchestrators, modules) | `Infrastructure.Agent.Tests` |
+| Tests for `Infrastructure.ControlPlane/` types (metric stores, exporters) | `Infrastructure.ControlPlane.Tests` |
+| Tests for base `Infrastructure/` types (config binding, serialization) | Keep in `Infrastructure.Tests` |
+
+Each test project references only its system-under-test and the abstraction layers it
+needs — matching the topology table in the Target State section.
+
+For any test that currently depends on a removed reference:
 - If it tests CLI+Infrastructure integration → move to a dedicated integration test project
 - If it uses concrete types for test setup → replace with mocks of the abstraction interfaces
 - If it only uses config types → those are now in `Abstractions/Options/` (no reference needed)
 
-`Infrastructure.Tests` may need splitting into `Infrastructure.Tests`,
-`Infrastructure.Agent.Tests`, and `Infrastructure.ControlPlane.Tests` to match the
-production project boundaries. Each test project references only its system-under-test.
+`Infrastructure.Tests` may NOT reference `Abstractions.Agent` — only the split
+`Infrastructure.Agent.Tests` project can. This prevents Agent test types from leaking
+into base infrastructure tests.
 
 #### Step 6.2 — Build gate
 
@@ -1498,6 +1523,15 @@ Run at least one scenario config via `launch.json` debug profile and verify obse
 `CLI.TfsMigration` IS the TFS Export Agent — it runs work item export inline, not via
 ControlPlane. It correctly references `Abstractions` + `Abstractions.Agent` and directly
 resolves `IWorkItemDiscoveryService`, `IProgressSink`, etc. This is by design.
+
+### Agent activity tracking does not require `Abstractions.Agent`
+
+`IControlPlaneClient.IsAgentActiveAsync(string agentInstanceId)` needs the CP to know
+whether an agent is alive. The CP implements the server side of this endpoint using only
+primitive types (`string` agent ID, `bool` return). The agent registers/deregisters via
+heartbeat HTTP calls (`POST /agents/{id}/heartbeat`). The CP tracks active agents in its
+own in-memory or persistent store (e.g. `IAgentRegistryStore` in `Abstractions.ControlPlane`).
+No Agent-specific types (`IArtefactStore`, `ICheckpointingService`, etc.) cross the boundary.
 
 ### `Infrastructure` references `Abstractions.Agent` — temporary
 

--- a/analysis/separation-of-concerns.md
+++ b/analysis/separation-of-concerns.md
@@ -1,53 +1,90 @@
-# Separation of Concerns — Abstractions & Project Boundary Analysis
+# Separation of Concerns — Abstractions & Project Boundary Specification
 
-## Context
+## Governing principle
 
-This document captures the boundary-violation analysis of `DevOpsMigrationPlatform.Abstractions`
-and `CLI.Migration` project references, and the proposed structural remediation.
-
-The system enforces a strict communication topology:
+The system enforces a strict three-channel communication topology:
 
 ```
-CLI  ←→  ControlPlane  ←→  Agent
+CLI  ←HTTP→  ControlPlane  ←HTTP→  Agent
 ```
 
-CLI and TUI must not hold Agent-internal contracts. The compiler should enforce this via
-project reference topology, not developer discipline.
+Each component runs in its own process. No component may compile against another
+component's internal contracts. The compiler enforces this via project reference
+topology — boundary violations are build errors, not code review findings.
 
 ---
 
-## Problem 1 — `Abstractions` is a technical bucket, not a boundary map
+## Current state — what is wrong
 
-### Current structure
+### `DevOpsMigrationPlatform.Abstractions` is a flat technical bucket
 
-| Folder | Files | Problem |
-|--------|-------|---------|
-| `Models/` | 70+ files | CLI contracts, Agent domain objects, and shared types all mixed together |
-| `Services/` | 40+ files | CLI-side interfaces mixed with Agent-execution interfaces |
-| `Telemetry/` | 18 files | Constants (cross-cutting) and OTel interfaces (Agent/CP-specific) mixed together |
-| `Checkpointing/` | 3 files | Agent-only — `CursorEntry` is only written by the Agent |
-| `Storage/` | 2 files | Agent-only — `IArtefactStore`/`IStateStore` have data residency restriction |
-| `Utilities/` | 2 files | Generic bucket name — screaming architecture violation |
-| `Options/` | 24 files | ✅ Cross-cutting — config schema only |
-| `Errors/` | 3 files | ✅ Cross-cutting |
-| `Validation/` | 2 files | ✅ Cross-cutting |
+| Folder | Problem |
+|--------|---------|
+| `Models/` (70+ files) | CLI contracts, Agent domain objects, and CP HTTP payloads all mixed together |
+| `Services/` (40+ files) | CLI config interfaces next to Agent execution interfaces |
+| `Telemetry/` (18 files) | Cross-cutting constants mixed with Agent/CP-specific OTel metric interfaces |
+| `Checkpointing/` (3 files) | Agent-only — only the Agent writes cursors |
+| `Storage/` (2 files) | Agent-only — `IArtefactStore`/`IStateStore` have a data residency restriction |
+| `Utilities/` (2 files) | Generic bucket name — screaming architecture violation |
 
-### Impact
+**Impact:** `IArtefactStore` and `IControlPlaneClient` are in the same assembly. A CLI
+command can accidentally inject `IArtefactStore` and the compiler will not object.
 
-`IArtefactStore` and `IControlPlaneClient` sit in the same project. A CLI command can
-accidentally inject `IArtefactStore` and the compiler will not object. The data residency
-guardrail (agents.md rule 23 — only the Migration Agent and TFS Export Agent may write
-to the package) relies entirely on code review.
+### `CLI.Migration` references five projects it should never touch
+
+```xml
+<ProjectReference Include="..\DevOpsMigrationPlatform.ControlPlane\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.MigrationAgent\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure.AzureDevOps\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure.Simulated\..." />
+```
+
+**Root cause:** `LocalStackHost` has an in-process fallback that hosts the ControlPlane
+and MigrationAgent inside the CLI process when published binaries are not found. This
+makes the CLI the composition root for both CP and Agent — pulling in every Agent-internal
+contract, every Infrastructure implementation, and every backend-specific package.
+
+The correct pattern already exists: `ChildProcessHost` launches CP and Agent as separate
+OS processes (identical to how `ExternalToolRunner` launches `CLI.TfsMigration` for TFS
+export). The in-process fallback is unnecessary and must be deleted.
 
 ---
 
-## Proposed fix — split into three projects
+## Target state
 
-### `DevOpsMigrationPlatform.Abstractions` — truly cross-cutting
+### `CLI.Migration.csproj` — single reference
+
+```xml
+<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\DevOpsMigrationPlatform.Abstractions.csproj" />
+```
+
+The CLI compiles against `Abstractions` only. It launches ControlPlane and Agent as child
+processes via `ChildProcessHost`. All communication with CP is via HTTP using the contracts
+in `Abstractions/ControlPlane/`.
+
+### Project reference topology — enforced by compiler
+
+| Project | Abstractions | Abstractions.ControlPlane | Abstractions.Agent |
+|---------|:---:|:---:|:---:|
+| `CLI.Migration` | ✅ | ❌ | ❌ |
+| `TUI` | ✅ | ❌ | ❌ |
+| `ControlPlane` / `ControlPlaneHost` | ✅ | ✅ | ❌ |
+| `MigrationAgent` | ✅ | ❌ | ✅ |
+| `CLI.TfsMigration` (.NET 4.8) | ✅ | ❌ | ✅ |
+| `Infrastructure` | ✅ | ❌ | ✅ |
+
+Every component talks to the ControlPlane exclusively via HTTP contracts in base
+`Abstractions`. Only `ControlPlane`/`ControlPlaneHost` references `Abstractions.ControlPlane`.
+The CP-internal store and OTel interfaces are invisible to everything outside the CP process.
+
+---
+
+## `DevOpsMigrationPlatform.Abstractions` — truly cross-cutting
 
 Shared types that all three components (CLI, ControlPlane, Agent) legitimately depend on.
 
-#### `Domain/`
+### `Domain/`
 ```
 Job.cs
 MigrationJob.cs
@@ -71,17 +108,16 @@ ValidationContext.cs
 FilterOperator.cs
 ```
 
-#### `Configuration/`
+### `Configuration/`
 CLI-facing service for loading and validating config files on disk before job submission.
-The CLI calls this directly; the Agent never touches it.
 ```
 IConfigurationService.cs
+IPreFlightValidator.cs            ← Tier 0/1 validation before job submission
 ```
 
-#### `ControlPlane/`
-The HTTP contracts and payload types the CLI and Agent use to communicate with the
-ControlPlane. These live in base `Abstractions` so any component that talks to CP
-compiles against them without needing a reference to `Abstractions.ControlPlane`.
+### `ControlPlane/`
+HTTP contracts and payload types for communicating with the ControlPlane.
+All components that talk to CP compile against these — no separate assembly needed.
 ```
 IControlPlaneClient.cs            ← CLI reads jobs, streams logs, gets telemetry via HTTP
 IJobRunner.cs                     ← CLI submits jobs to CP via HTTP
@@ -103,10 +139,16 @@ InventoryCounters.cs              ← embedded in DiscoveryCounters
 DependencyCounters.cs             ← embedded in DiscoveryCounters
 ```
 
-#### `Options/`
-All existing `Options/` files unchanged — config schema is cross-cutting.
+### `Options/`
+Config schema — cross-cutting. Includes backend-specific endpoint option types
+(currently in `Infrastructure.AzureDevOps.Options` and `Infrastructure.Simulated.Options`)
+because they are config schema, not execution contracts.
 ```
 AuthenticationType.cs
+AzureDevOpsEndpointOptions.cs     ← moved from Infrastructure.AzureDevOps.Options
+AzureDevOpsOrganisationEntry.cs   ← moved from Infrastructure.AzureDevOps.Options
+SimulatedEndpointOptions.cs       ← moved from Infrastructure.Simulated.Options
+SimulatedOrganisationEntry.cs     ← moved from Infrastructure.Simulated.Options
 CommentsExtensionOptionsConfig.cs
 DiscoveryOptions.cs
 EmbeddedImagesExtensionOptionsConfig.cs
@@ -132,20 +174,29 @@ WorkItemsModuleOptions.cs
 WorkItemsScopeOptions.cs
 ```
 
-#### `Errors/`
+### `Serialization/`
+Polymorphic JSON converters needed by anyone who deserialises config files or job payloads.
+Currently in `Infrastructure.Serialization` — must move here so CLI, CP, and Agent all
+have access without referencing `Infrastructure`.
+```
+PolymorphicEndpointOptionsConverter.cs
+MigrationPlatformJsonContext.cs   ← (or equivalent serializer setup)
+```
+
+### `Errors/`
 ```
 MigrationErrorCategory.cs
 MigrationException.cs
 PackageLockConflictException.cs
 ```
 
-#### `Validation/`
+### `Validation/`
 ```
 ValidationError.cs
 ValidationResult.cs
 ```
 
-#### `Telemetry/`
+### `Telemetry/`
 Constants and classification only — **no interfaces**.
 ```
 DataClassification.cs
@@ -160,25 +211,24 @@ WellKnownMetricNames.cs
 WellKnownServiceNames.cs
 ```
 
-#### `Diagnostics/`
+### `Diagnostics/`
 ```
 DiagnosticLogOptions.cs
 ```
 
-#### `Polyfills/`
+### `Polyfills/`
 ```
 IsExternalInit.cs
 ```
 
 ---
 
-### `DevOpsMigrationPlatform.Abstractions.ControlPlane` — CP-internal only
+## `DevOpsMigrationPlatform.Abstractions.ControlPlane` — CP-internal only
 
-Contracts that only the ControlPlane itself implements internally.
-Neither the CLI, TUI, nor the Agent reference this project — all three communicate
-with CP exclusively via the HTTP contracts in base `Abstractions`.
+Contracts that only the ControlPlane itself implements internally. No other component
+references this project.
 
-#### `Metrics/`
+### `Metrics/`
 ```
 IJobLifecycleMetrics.cs           ← OTel instruments emitted inside the CP process
 IJobMetricsStore.cs               ← CP persists incoming agent metrics
@@ -187,33 +237,34 @@ IJobSnapshotStore.cs              ← CP persists incoming agent snapshots
 
 ---
 
-### `DevOpsMigrationPlatform.Abstractions.Agent` — Agent-internal only
+## `DevOpsMigrationPlatform.Abstractions.Agent` — Agent-internal only
 
-Contracts used exclusively inside the Migration Agent (and `CLI.TfsMigration` which
-is the TFS Export Agent running inline).
+Contracts used exclusively inside the Migration Agent and `CLI.TfsMigration`
+(the TFS Export Agent running inline).
 
-#### `Storage/`
+### `Storage/`
 ```
 IArtefactStore.cs
 IStateStore.cs
 ```
 
-#### `Checkpointing/`
+### `Checkpointing/`
 ```
 CursorEntry.cs
 CursorStage.cs
 JobPhaseRecord.cs
 ```
 
-#### `Runtime/`
+### `Runtime/`
 Agent lifecycle singletons — set when a lease is acquired, cleared on release.
 ```
 ActiveLeaseState.cs
 ActivePackageState.cs
-PackagePaths.cs                   ← package path constants (IArtefactStore paths)
+PackagePaths.cs
+PathUtilities.cs                  ← moved from Utilities/; rename to PackagePathUtilities
 ```
 
-#### `WorkItems/`
+### `WorkItems/`
 ```
 WorkItemRevision.cs
 WorkItemField.cs
@@ -234,7 +285,7 @@ FetchedWorkItem.cs
 IdMapEntry.cs
 ```
 
-#### `Attachments/`
+### `Attachments/`
 ```
 AttachmentMetadata.cs
 AttachmentCounters.cs
@@ -244,30 +295,30 @@ EmbeddedImageMetadata.cs
 EmbeddedImageDownloadResult.cs
 ```
 
-#### `Export/`
+### `Export/`
 ```
 ExportContext.cs
 BatchContinuationToken.cs
 RevisionProcessResult.cs
 DiscoveryContext.cs
-InventoryReport.cs                ← written by Agent to inventory.json; CLI never compiles against this
+InventoryReport.cs
 InventorySummary.cs
-InventoryProgressEvent.cs         ← internal Agent progress signal; CLI receives ProgressEvent from CP instead
+InventoryProgressEvent.cs
 ProjectDiscoverySummary.cs
 DependencyRecord.cs
 DependencySummary.cs
 DependencyProgressEvent.cs
 ```
 
-#### `Import/`
+### `Import/`
 ```
 ImportContext.cs
 ImportedWorkItemResult.cs
 ```
 
-#### `Services/`
+### `Services/`
 ```
-ICatalogService.cs                ← queries source systems for project/count data; Agent-execution concern
+ICatalogService.cs
 IInventoryService.cs
 IInventoryServiceFactory.cs
 IProjectDiscoveryService.cs
@@ -288,7 +339,7 @@ IPackageStoreFactory.cs
 IPackageValidator.cs
 IPhaseTrackingService.cs
 IPhaseTrackingServiceFactory.cs
-IProgressSink.cs                  ← also used by CLI.TfsMigration (legitimate — it IS the TFS agent)
+IProgressSink.cs
 IQueryFingerprintService.cs
 IRevisionFolderProcessor.cs
 IRevisionFolderProcessorFactory.cs
@@ -306,7 +357,7 @@ IWorkItemRevisionSource.cs
 IWorkItemRevisionSourceFactory.cs
 ```
 
-#### `Telemetry/`
+### `Telemetry/`
 OTel metric interfaces — only emitted from within Agent execution.
 ```
 IDiscoveryMetrics.cs
@@ -315,7 +366,7 @@ IAttachmentDownloadMetrics.cs
 IMigrationMetrics.cs
 ```
 
-#### `Modules/`
+### `Modules/`
 ```
 IModule.cs
 IDiscoveryModule.cs
@@ -326,172 +377,80 @@ EmbeddedImagesExtensionOptions.cs
 
 ---
 
-## Project reference topology — enforced by compiler
+## Migration path
 
-| Project | Abstractions | Abstractions.ControlPlane | Abstractions.Agent |
-|---------|:---:|:---:|:---:|
-| `CLI.Migration` | ✅ | ❌ | ❌ |
-| `TUI` | ✅ | ❌ | ❌ |
-| `ControlPlane` / `ControlPlaneHost` | ✅ | ✅ | ❌ |
-| `MigrationAgent` | ✅ | ❌ | ✅ |
-| `CLI.TfsMigration` (.NET 4.8) | ✅ | ❌ | ✅ |
-| `Infrastructure` | ✅ | ❌ | ✅ |
+### Step 1 — Delete in-process fallback from `LocalStackHost`
 
-All three communicating components (CLI, Agent, TUI) talk to the ControlPlane exclusively
-via HTTP contracts in base `Abstractions` (`IControlPlaneClient`, `IJobRunner`,
-`IControlPlaneTelemetryClient`). No component other than `ControlPlane`/`ControlPlaneHost`
-needs `Abstractions.ControlPlane`. The CP-internal store and OTel interfaces are invisible
-to everything outside the CP process boundary.
+Remove `StartControlPlaneInProcessAsync()` and `StartAgentInProcessAsync()`.
+When published binaries are not found, fail with an actionable error:
+`"ControlPlane/Agent binaries not found. Run 'build.ps1 Install' to publish."`.
 
----
+This immediately removes the need for three project references:
+`ControlPlane`, `MigrationAgent`, and most of `Infrastructure`.
 
-## Problem 2 — `CLI.Migration` pulls in unused Agent-side execution services
+### Step 2 — Move config-schema types to `Abstractions/Options/`
 
-### Current `CLI.Migration.csproj` references (problematic lines)
+Move `AzureDevOpsEndpointOptions`, `AzureDevOpsOrganisationEntry`,
+`SimulatedEndpointOptions`, `SimulatedOrganisationEntry` from their
+`Infrastructure.*` projects into `Abstractions/Options/`.
 
+Move endpoint type-registration extension methods (`AddEndpointOptionsType`,
+`AddOrganisationEntryType`) to `Abstractions` so any component can register
+polymorphic config types without referencing `Infrastructure`.
+
+### Step 3 — Move serialization to `Abstractions/Serialization/`
+
+Move `PolymorphicEndpointOptionsConverter` and `AddMigrationPlatformPolymorphicSerializers()`
+from `Infrastructure.Serialization` to `Abstractions/Serialization/`.
+
+### Step 4 — Extract `IPreFlightValidator` to `Abstractions/Configuration/`
+
+`QueueCommand` currently references `AzureDevOpsValidation` (concrete class in
+`Infrastructure.AzureDevOps`). Extract `IPreFlightValidator` interface to
+`Abstractions/Configuration/`. The implementation stays in `Infrastructure.AzureDevOps`
+and is resolved via DI — the CLI never holds a direct reference.
+
+### Step 5 — Remove concrete `ConfigurationService` usage from CLI commands
+
+`QueueCommand`, `ConfigNewCommand`, `ConfigureCommand`, `PrepareCommand` all
+`new` up `ConfigurationService` (a concrete class in `Infrastructure.Services`).
+Register it via `IConfigurationService` from a CLI composition-root extension method.
+The concrete class stays in `Infrastructure`.
+
+### Step 6 — Move `TokenResolver` to `Abstractions/Options/`
+
+Currently in `Utilities/`. It resolves config tokens (`{env:VAR}`) — a cross-cutting
+config concern. Rename to `ConfigTokenResolver` for clarity.
+
+### Step 7 — Remove all invalid project references
+
+Delete from `CLI.Migration.csproj`:
 ```xml
+<ProjectReference Include="..\DevOpsMigrationPlatform.ControlPlane\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.MigrationAgent\..." />
+<ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure\..." />
 <ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure.AzureDevOps\..." />
 <ProjectReference Include="..\DevOpsMigrationPlatform.Infrastructure.Simulated\..." />
 ```
 
-### What the CLI actually needs from these
+### Step 8 — Create `Abstractions.ControlPlane` and `Abstractions.Agent` projects
 
-`InventoryCommand` calls `AddAzureDevOpsInventory(config)`.
-`DependencyCommand` calls `AddAzureDevOpsDependencyAnalysis(config)`.
-
-Both commands then resolve **only**:
-- `IAnsiConsole`
-- `IOptions<DiscoveryOptions>` — config binding
-- `ControlPlaneClient` — HTTP submission
-
-They build a `DiscoveryJob` and submit it via HTTP. They **never** resolve the
-execution services from the CLI DI container.
-
-### Services registered in the CLI process but never resolved
-
-```
-IWorkItemDiscoveryService
-IProjectDiscoveryService
-IRepoDiscoveryService
-IWorkItemFetchService
-IWiqlQueryClientFactory
-IAzureDevOpsClientFactory
-IWorkItemQueryWindowStrategy
-IInventoryService
-IInventoryServiceFactory
-```
-
-`AddSimulatedServices()` (called unconditionally from `MigrationCliServiceCollectionExtensions`)
-also registers:
-```
-IWorkItemRevisionSourceFactory    ← Agent-only
-IWorkItemImportTargetFactory      ← Agent-only
-```
-
-### Root cause
-
-The `AddAzureDevOpsInventory()` and `AddSimulatedServices()` extension methods bundle
-CLI config concerns and Agent execution concerns into a single call. The CLI has no way
-to take only config binding without pulling in execution services.
-
-### Proposed fix — split infrastructure registration by audience
-
-```csharp
-// CLI-safe — config binding and endpoint type registration only
-services.AddAzureDevOpsDiscoveryConfiguration(config);
-services.AddSimulatedEndpointTypes();
-
-// Agent-only — execution services (registered only inside MigrationAgent DI setup)
-services.AddAzureDevOpsInventoryExecution();
-services.AddSimulatedWorkItemExecution();
-```
-
-Once split, `CLI.Migration` calls only `*Configuration` / `*EndpointTypes` variants.
-Config binding can then move to `Infrastructure` (already referenced by CLI), allowing
-the `Infrastructure.AzureDevOps` and `Infrastructure.Simulated` project references to
-be **removed from `CLI.Migration.csproj` entirely**.
-
-### Exception — `CLI.TfsMigration` is correct
-
-`CLI.TfsMigration` directly resolves `IWorkItemDiscoveryService` because it **is** the
-TFS Export Agent running inline — not a CLI submitting to ControlPlane. This reference
-is legitimate and is not a violation.
+Split the files from `DevOpsMigrationPlatform.Abstractions` into the three projects
+as specified above. Update all consuming projects to reference the correct subset.
 
 ---
 
-## Problem 3 — `CLI.Migration` is the composition root for ControlPlane and Agent
+## Notes
 
-### Current state
+### `CLI.TfsMigration` is not a violation
 
-`LocalStackHost` has two modes:
-1. **Process-per-component** (correct) — launches `ControlPlaneHost.exe` and `MigrationAgent.exe`
-   as child processes via `ChildProcessHost`. No assembly dependencies needed.
-2. **In-process fallback** (violation) — when published binaries are not found, `LocalStackHost`
-   calls `AddControlPlaneServices()`, `AddMigrationAgentServices()`, and hosts both components
-   inside the CLI process. This is why `CLI.Migration.csproj` references `ControlPlane`,
-   `MigrationAgent`, `Infrastructure`, `Infrastructure.AzureDevOps`, and `Infrastructure.Simulated`.
+`CLI.TfsMigration` IS the TFS Export Agent — it runs work item export inline, not via
+ControlPlane. It correctly references `Abstractions` + `Abstractions.Agent` and directly
+resolves `IWorkItemDiscoveryService`, `IProgressSink`, etc. This is by design.
 
-### Why the in-process fallback must be deleted
+### `Infrastructure` references `Abstractions.Agent`
 
-The fallback makes the CLI the composition root for CP and Agent. This:
-- **Breaks the three-channel topology.** The CLI holds `IArtefactStore`, `IModule`, every
-  Agent-internal contract. A developer can inject anything.
-- **Breaks telemetry isolation.** Multiple OTel pipelines in one process produce phantom
-  dependency arrows on Application Insights. The existing code already warns about this.
-- **Is unnecessary.** The TFS export pattern proves the CLI can launch child processes
-  without in-process hosting. `ChildProcessHost` and `ExternalToolRunner` already work.
-  The `dotnet run` case should build-then-launch rather than host in-process.
-
-### What the CLI should reference after remediation
-
-```xml
-<!-- CLI.Migration.csproj — target state -->
-<ProjectReference Include="..\DevOpsMigrationPlatform.Abstractions\DevOpsMigrationPlatform.Abstractions.csproj" />
-```
-
-That is it. The CLI should compile against `Abstractions` only. Everything else is
-launched as a child process or accessed via HTTP.
-
-### Detailed dependency analysis for remaining usages
-
-| Current usage | File | What it touches | Fix |
-|---|---|---|---|
-| `AddControlPlaneServices()` | `LocalStackHost.cs` | `ControlPlane` | Delete in-process fallback |
-| `AddMigrationAgentServices()` | `LocalStackHost.cs` | `MigrationAgent` | Delete in-process fallback |
-| `ControlPlaneServiceExtensions.Assembly` | `LocalStackHost.cs` | `ControlPlane` | Delete in-process fallback |
-| `AddEndpointOptionsType("AzureDevOpsServices", ...)` | `LocalStackHost.cs`, `MigrationCliServiceCollectionExtensions.cs` | `Infrastructure.AzureDevOps` (endpoint types) | Move type registration to `Abstractions` or to a thin `Infrastructure.Configuration` package |
-| `AddSimulatedServices()` | `MigrationCliServiceCollectionExtensions.cs` | `Infrastructure.Simulated` (Agent factories) | Replace with `AddSimulatedConfigurationTypes()` in thin config package |
-| `AddMigrationPlatformPolymorphicSerializers()` | `LocalStackHost.cs`, `MigrationPlatformHost.cs` | `Infrastructure` (serialisation) | Move polymorphic serializer registration to `Abstractions` or thin `Infrastructure.Serialization` package |
-| `ConfigurationService` (concrete class) | `QueueCommand.cs`, `ConfigNewCommand.cs`, `ConfigureCommand.cs`, `PrepareCommand.cs` | `Infrastructure.Services` | Register via `IConfigurationService` from a CLI composition-root extension method; move `ConfigurationService` into a thin config package |
-| `AzureDevOpsEndpointOptions` | `QueueCommand.cs`, `LocalStackHost.cs`, `InteractiveConfigurationBuilder.cs` | `Infrastructure.AzureDevOps.Options` | Move endpoint option types to `Abstractions/Options/` — they are config schema, not execution |
-| `SimulatedEndpointOptions` | `LocalStackHost.cs` | `Infrastructure.Simulated.Options` | Same — move to `Abstractions/Options/` |
-| `AzureDevOpsValidation` | `QueueCommand.cs` | `Infrastructure.AzureDevOps.Validation` | Extract `IPreFlightValidator` interface to `Abstractions`; implementation stays in `Infrastructure.AzureDevOps` but is resolved by DI, not direct reference |
-| `AddDataClassificationFilter()` | `LocalStackHost.cs` | `Infrastructure.Telemetry` | Delete in-process fallback |
-| `PolymorphicEndpointOptionsConverter` | `LocalStackHost.cs` | `Infrastructure.Serialization` | Delete in-process fallback |
-| `IProgressSink` + `AnsiProgressSink` | `QueueCommand.cs` | `Abstractions` (interface) + CLI (impl) | Already correct — `IProgressSink` moves to `Abstractions.Agent`, and `QueueCommand` only uses it for TFS subprocess output. The CLI can hold its own `AnsiProgressSink` implementation since the TFS CLI IS an agent. |
-
-### Execution plan (ordered)
-
-1. **Delete `StartControlPlaneInProcessAsync()` and `StartAgentInProcessAsync()` from `LocalStackHost`.** 
-   Require published binaries. If not found, fail with an actionable error message telling the
-   developer to run `build.ps1 Install`.
-2. **Move `AzureDevOpsEndpointOptions`, `SimulatedEndpointOptions`, and related type-registration
-   extension methods to `Abstractions/Options/`** — they are config schema, not execution contracts.
-3. **Move `ConfigurationService` registration to a `AddMigrationCliConfiguration()` extension
-   method** in `Infrastructure` so the CLI resolves only the interface.
-4. **Extract `IPreFlightValidator` to `Abstractions`** and remove direct reference to
-   `AzureDevOpsValidation` from `QueueCommand`.
-5. **Move polymorphic serialiser setup to `Abstractions`** — `PolymorphicEndpointOptionsConverter`
-   is needed by anyone who deserialises the config file (CLI, CP, Agent).
-6. **Remove all five invalid project references from `CLI.Migration.csproj`.**
-
----
-
-## `Utilities/` — screaming architecture violation
-
-`PathUtilities` is a package-path helper (Agent concern).
-`TokenResolver` resolves config tokens (cross-cutting / CLI concern).
-
-Neither belongs in a folder named `Utilities`. Resolution:
-- `PathUtilities` → inline into `PackagePaths` or move to `Abstractions.Agent/Runtime/`
-- `TokenResolver` → move to `Abstractions/Options/` or keep at root as `ConfigTokenResolver`
+`Infrastructure` implements Agent modules (`InventoryDiscoveryModule`,
+`WorkItemExportOrchestrator`, etc.) and uses `IArtefactStore`, `ICheckpointingService`,
+and other Agent-internal contracts. It correctly references `Abstractions` +
+`Abstractions.Agent`.

--- a/analysis/separation-of-concerns.md
+++ b/analysis/separation-of-concerns.md
@@ -772,6 +772,10 @@ config and job payloads. Currently in `Infrastructure.Serialization`.
 Update namespace: `DevOpsMigrationPlatform.Infrastructure.Serialization` →
 `DevOpsMigrationPlatform.Abstractions.Serialization`.
 
+**Verify:** Round-trip test — serialise and deserialise a config file containing each
+endpoint type (AzureDevOps, Simulated). Confirm polymorphic type resolution still works
+after the assembly move.
+
 #### Step 1.6 — Remove invalid project references
 
 Delete from `CLI.Migration.csproj`:
@@ -1514,6 +1518,10 @@ For any test that currently depends on a removed reference:
 `Infrastructure.Tests` may NOT reference `Abstractions.Agent` — only the split
 `Infrastructure.Agent.Tests` project can. This prevents Agent test types from leaking
 into base infrastructure tests.
+
+**Internal type visibility:** If any test fails due to inaccessible `internal` types
+after the split, add `<InternalsVisibleTo Include="TestProjectName" />` to the
+production project's `.csproj`. Prefer making types `public` where possible.
 
 #### Step 6.2 — Build gate
 

--- a/analysis/separation-of-concerns.md
+++ b/analysis/separation-of-concerns.md
@@ -483,7 +483,7 @@ What remains here are internal helpers:
 EndpointOptionsTypeRegistry.cs
 EndpointOptionsRegistration.cs
 EndpointOptionsRegistrationExtensions.cs  ← stays here (depends on serialization + DI)
-PolymorphicOrganisationEntryConverter.cs  ← if not also moved to Abstractions
+PolymorphicOrganisationEntryConverter.cs  ← stays here (depends on EndpointOptionsTypeRegistry)
 ```
 
 ### `Telemetry/`
@@ -1031,7 +1031,7 @@ Delete `Errors/` after Phase 3.
 
 | Source | Destination | Rename |
 |--------|-------------|--------|
-| `Abstractions/Utilities/TokenResolver.cs` | `Abstractions/Options/ConfigTokenResolver.cs` | class: `TokenResolver` → `ConfigTokenResolver` |
+| `Abstractions/Utilities/TokenResolver.cs` | `Abstractions/Options/ConfigTokenResolver.cs` | class: `TokenResolver` → `ConfigTokenResolver`. **Before renaming:** grep for string `"TokenResolver"` in config files, JSON, and attributes. Update any string references in the same commit. |
 | `Abstractions/Utilities/PathUtilities.cs` | stays temporarily | moves to `Agent/Lease/PackagePathUtilities.cs` in Phase 3 |
 | `CLI.Migration/Utilities/PathUtilities.cs` | `CLI.Migration/Services/CliPathUtilities.cs` | rename to distinguish from Agent version |
 | `CLI.Migration/Utilities/ExceptionSanitizer.cs` | `CLI.Migration/Services/ExceptionSanitizer.cs` | |
@@ -1569,6 +1569,43 @@ Any ❌ cell that has a reference is a violation. Fix before declaring done.
 #### Step 6.5 — Scenario smoke test
 
 Run at least one scenario config via `launch.json` debug profile and verify observable output.
+
+#### Step 6.6 — Aspire orchestration verification
+
+```powershell
+dotnet run --project AppHost
+```
+
+Verify that `ControlPlaneHost` and `MigrationAgent` launch correctly via Aspire
+orchestration. The new library projects (`Infrastructure.Agent`, `Infrastructure.ControlPlane`,
+`Abstractions.Agent`, `Abstractions.ControlPlane`) must not break the Aspire project
+discovery or build graph.
+
+#### Step 6.7 — Update `build.ps1`
+
+Add the four new projects to `build.ps1` build and publish targets:
+- `DevOpsMigrationPlatform.Abstractions.Agent`
+- `DevOpsMigrationPlatform.Abstractions.ControlPlane`
+- `DevOpsMigrationPlatform.Infrastructure.Agent`
+- `DevOpsMigrationPlatform.Infrastructure.ControlPlane`
+
+These are library projects (not deployable hosts), but they must be included in the
+build matrix for CI coverage.
+
+#### Step 6.8 — NuGet package distribution
+
+Verify that NuGet package references are correctly distributed after the split:
+
+| Package | Must be in | Must NOT be in |
+|---------|-----------|----------------|
+| `Microsoft.Data.Sqlite` | `Infrastructure.Agent` | base `Infrastructure` |
+| `Azure.Storage.Blobs` (if used) | `Infrastructure.Agent` | base `Infrastructure` |
+| `Microsoft.Extensions.Http` | `Infrastructure.Agent` (for CP telemetry client) | — |
+| OTel metric packages | both `Infrastructure.Agent` and `Infrastructure.ControlPlane` | — |
+| EF Core / Aspire packages | `Infrastructure.ControlPlane` | `Infrastructure.Agent` |
+
+Run `dotnet list package` for each new project and verify no unnecessary transitive
+dependencies leak across boundaries.
 
 ---
 

--- a/src/DevOpsMigrationPlatform.Abstractions/Checkpointing/CursorEntry.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions/Checkpointing/CursorEntry.cs
@@ -7,4 +7,19 @@ public record CursorEntry
     public string LastProcessed { get; init; } = string.Empty;
     public string Stage { get; init; } = CursorStage.Completed;
     public DateTimeOffset UpdatedAt { get; init; }
+
+    /// <summary>Cumulative count of work items fully processed when this cursor was written.</summary>
+    public int WorkItemsProcessed { get; init; }
+
+    /// <summary>Cumulative count of revisions processed when this cursor was written.</summary>
+    public int RevisionsProcessed { get; init; }
+
+    /// <summary>ID of the last work item that was fully processed.</summary>
+    public int LastWorkItemId { get; init; }
+
+    /// <summary>
+    /// Total work items in scope as counted at job start.
+    /// Stored in the cursor so that resume runs skip the pre-flight count.
+    /// </summary>
+    public int TotalWorkItems { get; init; }
 }

--- a/src/DevOpsMigrationPlatform.Abstractions/Models/AttachmentCounters.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions/Models/AttachmentCounters.cs
@@ -15,4 +15,24 @@ public record AttachmentCounters
 
     /// <summary>Total bytes transferred for attachments.</summary>
     public long TotalBytes { get; init; }
+
+    /// <summary>Duration in milliseconds for the most recently completed attachment download.</summary>
+    public double LastDownloadDurationMs { get; init; }
+
+    /// <summary>Rolling average download duration in milliseconds across all completed attachments.</summary>
+    public double AverageDownloadDurationMs { get; init; }
+
+    /// <summary>Size in bytes of the most recently completed attachment download.</summary>
+    public long LastSizeBytes { get; init; }
+
+    /// <summary>Rolling average size in bytes across all completed attachments. Zero when none processed.</summary>
+    public long AverageSizeBytes { get; init; }
+
+    // ── In-flight attachment (current) ───────────────────────────────────────────
+
+    /// <summary>
+    /// File name of the attachment currently being downloaded.
+    /// Null when no download is in flight.
+    /// </summary>
+    public string? CurrentAttachmentName { get; init; }
 }

--- a/src/DevOpsMigrationPlatform.Abstractions/Models/WorkItemCounters.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions/Models/WorkItemCounters.cs
@@ -71,6 +71,21 @@ public record WorkItemCounters
     /// </summary>
     public double AverageRevisionDurationMs { get; init; }
 
+    // ── Last work item outcome ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Azure DevOps ID of the most recently resolved work item (completed, skipped, or failed).
+    /// Zero until the first work item is resolved.
+    /// </summary>
+    public int LastWorkItemId { get; init; }
+
+    /// <summary>
+    /// Outcome of the most recently resolved work item.
+    /// One of: <c>"Exported"</c>, <c>"Skipped"</c>, <c>"Failed"</c>.
+    /// Null until the first work item is resolved.
+    /// </summary>
+    public string? LastWorkItemStatus { get; init; }
+
     /// <summary>Optional attachment counters. Null when no attachments have been processed.</summary>
     public AttachmentCounters? Attachments { get; init; }
 }

--- a/src/DevOpsMigrationPlatform.Abstractions/Models/WorkItemCounters.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions/Models/WorkItemCounters.cs
@@ -33,6 +33,44 @@ public record WorkItemCounters
     /// </summary>
     public double AverageWorkItemDurationMs { get; init; }
 
+    /// <summary>
+    /// Number of revisions written for the most recently completed work item.
+    /// </summary>
+    public int LastWorkItemRevisions { get; init; }
+
+    // ── In-flight work item (current) ────────────────────────────────────────────
+
+    /// <summary>
+    /// Azure DevOps ID of the work item currently being exported.
+    /// Zero when no work item is in flight.
+    /// </summary>
+    public int CurrentWorkItemId { get; init; }
+
+    /// <summary>
+    /// 1-based ordinal position of <see cref="CurrentWorkItemId"/> in the overall
+    /// export run (i.e. how many distinct work items have been started so far).
+    /// Zero when no work item is in flight.
+    /// </summary>
+    public int CurrentWorkItemIndex { get; init; }
+
+    /// <summary>
+    /// Number of revisions written so far for <see cref="CurrentWorkItemId"/>.
+    /// Increments with each revision and resets to zero when the next WI starts.
+    /// </summary>
+    public int CurrentWorkItemRevisionsWritten { get; init; }
+
+    // ── Per-revision timing ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Duration in milliseconds for the most recently written revision.
+    /// </summary>
+    public double LastRevisionDurationMs { get; init; }
+
+    /// <summary>
+    /// Rolling average duration in milliseconds per revision across all revisions written so far.
+    /// </summary>
+    public double AverageRevisionDurationMs { get; init; }
+
     /// <summary>Optional attachment counters. Null when no attachments have been processed.</summary>
     public AttachmentCounters? Attachments { get; init; }
 }

--- a/src/DevOpsMigrationPlatform.Abstractions/Models/WorkItemCounters.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions/Models/WorkItemCounters.cs
@@ -21,6 +21,18 @@ public record WorkItemCounters
     /// <summary>Total revisions processed across all work items.</summary>
     public long RevisionsProcessed { get; init; }
 
+    /// <summary>
+    /// Duration in milliseconds for the most recently completed work item.
+    /// Used to detect back-off / throttling: a sudden spike indicates server-side rate limiting.
+    /// </summary>
+    public double LastWorkItemDurationMs { get; init; }
+
+    /// <summary>
+    /// Rolling average duration in milliseconds per completed work item.
+    /// Baseline to compare against <see cref="LastWorkItemDurationMs"/>.
+    /// </summary>
+    public double AverageWorkItemDurationMs { get; init; }
+
     /// <summary>Optional attachment counters. Null when no attachments have been processed.</summary>
     public AttachmentCounters? Attachments { get; init; }
 }

--- a/src/DevOpsMigrationPlatform.Abstractions/Telemetry/IMigrationMetrics.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions/Telemetry/IMigrationMetrics.cs
@@ -19,6 +19,8 @@ public interface IMigrationMetrics
     // --- Payload / Complexity ---
     void RecordFieldCount(int count, in TagList tags);
     void RecordAttachmentCount(int count, in TagList tags);
+    void RecordAttachmentDownloadDuration(double milliseconds, in TagList tags);
+    void RecordAttachmentDownloadBytes(long bytes, in TagList tags);
     void RecordLinkCount(int count, in TagList tags);
     void RecordRevisionCount(int count, in TagList tags);
     void RecordPayloadBytes(long bytes, in TagList tags);

--- a/src/DevOpsMigrationPlatform.Abstractions/Telemetry/WellKnownMetricNames.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions/Telemetry/WellKnownMetricNames.cs
@@ -16,6 +16,8 @@ public static class WellKnownMetricNames
     // --- Payload / Complexity ---
     public const string FieldCount = "migration.workitem.fields.count";
     public const string AttachmentCount = "migration.workitem.attachments.count";
+    public const string AttachmentDownloadDurationMs = "migration.attachment.download.duration.ms";
+    public const string AttachmentDownloadBytes = "migration.attachment.download.bytes";
     public const string LinkCount = "migration.workitem.links.count";
     public const string RevisionCount = "migration.workitem.revisions.count";
     public const string PayloadBytes = "migration.workitem.payload.bytes";

--- a/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
@@ -464,6 +464,8 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         var progressStartTime = DateTimeOffset.UtcNow;
         int processed = 0;
         int revisions = 0;
+        double lastWiDurationMs = 0;
+        double avgWiDurationMs = 0;
         string currentStage = string.Empty;
 
         if (Console.IsOutputRedirected)
@@ -482,6 +484,10 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                         totalWorkItems = (int)evt.Metrics.Scope.WorkItemsTotal;
                     processed = (int)(evt.Metrics?.Migration?.WorkItems?.Completed ?? processed);
                     revisions = (int)(evt.Metrics?.Migration?.WorkItems?.RevisionsProcessed ?? revisions);
+                    if (evt.Metrics?.Migration?.WorkItems?.LastWorkItemDurationMs > 0)
+                        lastWiDurationMs = evt.Metrics.Migration.WorkItems.LastWorkItemDurationMs;
+                    if (evt.Metrics?.Migration?.WorkItems?.AverageWorkItemDurationMs > 0)
+                        avgWiDurationMs = evt.Metrics.Migration.WorkItems.AverageWorkItemDurationMs;
                 }
             }
             catch (InvalidOperationException ex) when (ex.Message.Contains("Job failed"))
@@ -532,13 +538,18 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                                 totalWorkItems = (int)evt.Metrics.Scope.WorkItemsTotal;
                             processed = (int)(evt.Metrics?.Migration?.WorkItems?.Completed ?? processed);
                             revisions = (int)(evt.Metrics?.Migration?.WorkItems?.RevisionsProcessed ?? revisions);
+                            if (evt.Metrics?.Migration?.WorkItems?.LastWorkItemDurationMs > 0)
+                                lastWiDurationMs = evt.Metrics.Migration.WorkItems.LastWorkItemDurationMs;
+                            if (evt.Metrics?.Migration?.WorkItems?.AverageWorkItemDurationMs > 0)
+                                avgWiDurationMs = evt.Metrics.Migration.WorkItems.AverageWorkItemDurationMs;
 
                             ctx.UpdateTarget(BuildProgressRenderable(
                                 processed, totalWorkItems,
                                 0, 0,
                                 0, 0,
                                 currentStage, progressStartTime,
-                                evt.LastCheckpointAt, evt.NextCheckpointDueAt));
+                                evt.LastCheckpointAt, evt.NextCheckpointDueAt,
+                                lastWiDurationMs, avgWiDurationMs));
                         }
                     });
             }
@@ -610,7 +621,8 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         int currentWiId, int currentWiRevisions,
         int lastCompletedWiId, int lastCompletedRevisions,
         string stage, DateTimeOffset startTime,
-        DateTimeOffset? lastCheckpointAt = null, DateTimeOffset? nextCheckpointDueAt = null)
+        DateTimeOffset? lastCheckpointAt = null, DateTimeOffset? nextCheckpointDueAt = null,
+        double lastWiDurationMs = 0, double avgWiDurationMs = 0)
     {
         const int BarWidth = 38;
         const int WiBarWidth = 20;
@@ -627,9 +639,27 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
             $"  [grey]{pct * 100.0:F1}%[/]  [grey]ETA: {Markup.Escape(etaStr)}[/]");
 
         // ── Row 2: last completed WI (full bar = 100 %) ──────────────────────────────
-        IRenderable completedRow = lastCompletedWiId > 0
-            ? new Markup($"  [grey]✓ WI {lastCompletedWiId}  {new string('━', WiBarWidth)}  {lastCompletedRevisions} rev  done[/]")
-            : new Markup("  [grey]─[/]");
+        IRenderable completedRow;
+        if (lastWiDurationMs > 0)
+        {
+            var lastSec = lastWiDurationMs / 1000.0;
+            var avgSec  = avgWiDurationMs  / 1000.0;
+            // Flag likely throttling: last WI took more than 3× the average.
+            var isSlowdown = avgWiDurationMs > 0 && lastWiDurationMs > avgWiDurationMs * 3;
+            var durationColor = isSlowdown ? "red" : lastWiDurationMs > avgWiDurationMs * 1.5 ? "yellow" : "green";
+            var throttleWarning = isSlowdown ? "  [red bold]⚠ possible back-off[/]" : string.Empty;
+            completedRow = new Markup(
+                $"  [grey]last:[/] [{durationColor}]{lastSec:F1}s[/]" +
+                $"  [grey]avg:[/] [grey]{avgSec:F1}s[/]{throttleWarning}");
+        }
+        else if (lastCompletedWiId > 0)
+        {
+            completedRow = new Markup($"  [grey]✓ WI {lastCompletedWiId}  {new string('━', WiBarWidth)}  {lastCompletedRevisions} rev  done[/]");
+        }
+        else
+        {
+            completedRow = new Markup("  [grey]─[/]");
+        }
 
         // ── Row 3: current WI in progress (partial bar, never reaches 100 %) ─────────
         IRenderable currentRow;

--- a/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
@@ -523,23 +523,23 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                         ctx.Refresh();
 
                         await foreach (var evt in client.FollowLogsAsync(parsedJobId, followCts.Token).ConfigureAwait(false))
-                    {
-                        lastEvt = evt;
-                        if (!string.IsNullOrEmpty(evt.Stage))
-                            currentStage = evt.Stage;
-                        // The Agent emits a ScopeResolved event with WorkItemsTotal when it completes the count.
-                        if (evt.Metrics?.Scope?.WorkItemsTotal > 0)
-                            totalWorkItems = (int)evt.Metrics.Scope.WorkItemsTotal;
-                        processed = (int)(evt.Metrics?.Migration?.WorkItems?.Completed ?? processed);
-                        revisions = (int)(evt.Metrics?.Migration?.WorkItems?.RevisionsProcessed ?? revisions);
+                        {
+                            lastEvt = evt;
+                            if (!string.IsNullOrEmpty(evt.Stage))
+                                currentStage = evt.Stage;
+                            // The Agent emits a ScopeResolved event with WorkItemsTotal when it completes the count.
+                            if (evt.Metrics?.Scope?.WorkItemsTotal > 0)
+                                totalWorkItems = (int)evt.Metrics.Scope.WorkItemsTotal;
+                            processed = (int)(evt.Metrics?.Migration?.WorkItems?.Completed ?? processed);
+                            revisions = (int)(evt.Metrics?.Migration?.WorkItems?.RevisionsProcessed ?? revisions);
 
-                        ctx.UpdateTarget(BuildProgressRenderable(
-                            processed, totalWorkItems,
-                            0, 0,
-                            0, 0,
-                            currentStage, progressStartTime,
-                            evt.LastCheckpointAt, evt.NextCheckpointDueAt));
-                    }
+                            ctx.UpdateTarget(BuildProgressRenderable(
+                                processed, totalWorkItems,
+                                0, 0,
+                                0, 0,
+                                currentStage, progressStartTime,
+                                evt.LastCheckpointAt, evt.NextCheckpointDueAt));
+                        }
                     });
             }
             catch (InvalidOperationException ex) when (ex.Message.Contains("Job failed"))

--- a/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
@@ -677,23 +677,11 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
             var curPct = refRevs > 0 ? Math.Min(1.0, (double)currentWiRevisions / refRevs) : 0.0;
             var curFilled = Math.Clamp((int)(curPct * BarWidth), 0, BarWidth);
             var curBar = new string('━', curFilled) + new string('─', BarWidth - curFilled);
-            var cumStr = totalRevisions > 0 ? $"  [grey]total: {totalRevisions:N0} rev[/]" : string.Empty;
             var lastRevStr = lastCompletedRevisions > 0 ? $"  [grey](prev: {lastCompletedRevisions} rev)[/]" : string.Empty;
             revRow = new Markup(
                 $"  [grey]↳ WI {currentWiId}[/]   [blue]{Markup.Escape(curBar)}[/]"
                 + $"  [bold]{currentWiRevisions:N0}[/][grey] rev[/]"
-                + $"{lastRevStr}{cumStr}");
-        }
-        else if (totalRevisions > 0)
-        {
-            // No WI in flight yet — show cumulative totals.
-            var revPct = estimatedTotalRevisions > 0 ? Math.Min(1.0, (double)totalRevisions / estimatedTotalRevisions) : 0.0;
-            var revFilled = Math.Clamp((int)(revPct * BarWidth), 0, BarWidth);
-            var revBar = new string('━', revFilled) + new string('─', BarWidth - revFilled);
-            var revTotalStr = estimatedTotalRevisions > 0 ? $"[grey]/~{estimatedTotalRevisions:N0}[/]" : string.Empty;
-            revRow = new Markup(
-                $"  [grey]↳ Revisions[/]   [blue]{Markup.Escape(revBar)}[/]"
-                + $"  [bold]{totalRevisions:N0}[/]{revTotalStr}");
+                + $"{lastRevStr}");
         }
         else
         {

--- a/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
@@ -464,8 +464,13 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         var progressStartTime = DateTimeOffset.UtcNow;
         int processed = 0;
         int revisions = 0;
+        int lastWiRevisions = 0;
+        int currentWiId = 0;
+        int currentWiIndex = 0;
+        int currentWiRevsWritten = 0;
         double lastWiDurationMs = 0;
         double avgWiDurationMs = 0;
+        double avgRevDurationMs = 0;
         string currentStage = string.Empty;
 
         if (Console.IsOutputRedirected)
@@ -488,6 +493,13 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                         lastWiDurationMs = evt.Metrics.Migration.WorkItems.LastWorkItemDurationMs;
                     if (evt.Metrics?.Migration?.WorkItems?.AverageWorkItemDurationMs > 0)
                         avgWiDurationMs = evt.Metrics.Migration.WorkItems.AverageWorkItemDurationMs;
+                    var wi = evt.Metrics?.Migration?.WorkItems;
+                    if (wi?.CurrentWorkItemId > 0)
+                    {
+                        currentWiId = wi.CurrentWorkItemId;
+                        currentWiIndex = wi.CurrentWorkItemIndex;
+                        currentWiRevsWritten = wi.CurrentWorkItemRevisionsWritten;
+                    }
                 }
             }
             catch (InvalidOperationException ex) when (ex.Message.Contains("Job failed"))
@@ -519,7 +531,7 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
             try
             {
                 await console.Live(BuildProgressRenderable(
-                        0, totalWorkItems, 0, 0, 0, 0, string.Empty, progressStartTime))
+                        0, totalWorkItems, 0, 0, 0, 0, string.Empty))
                     .AutoClear(false)
                     .Overflow(VerticalOverflow.Ellipsis)
                     .StartAsync(async ctx =>
@@ -542,14 +554,26 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                                 lastWiDurationMs = evt.Metrics.Migration.WorkItems.LastWorkItemDurationMs;
                             if (evt.Metrics?.Migration?.WorkItems?.AverageWorkItemDurationMs > 0)
                                 avgWiDurationMs = evt.Metrics.Migration.WorkItems.AverageWorkItemDurationMs;
+                            if (evt.Metrics?.Migration?.WorkItems?.LastWorkItemRevisions > 0)
+                                lastWiRevisions = (int)evt.Metrics.Migration.WorkItems.LastWorkItemRevisions;
+                            var wi = evt.Metrics?.Migration?.WorkItems;
+                            if (wi?.CurrentWorkItemId > 0)
+                            {
+                                currentWiId = wi.CurrentWorkItemId;
+                                currentWiIndex = wi.CurrentWorkItemIndex;
+                                currentWiRevsWritten = wi.CurrentWorkItemRevisionsWritten;
+                            }
+                            if (evt.Metrics?.Migration?.WorkItems?.AverageRevisionDurationMs > 0)
+                                avgRevDurationMs = evt.Metrics.Migration.WorkItems.AverageRevisionDurationMs;
 
                             ctx.UpdateTarget(BuildProgressRenderable(
                                 processed, totalWorkItems,
-                                0, 0,
-                                0, 0,
-                                currentStage, progressStartTime,
+                                currentWiId, currentWiRevsWritten,
+                                currentWiIndex, lastWiRevisions,
+                                currentStage,
                                 evt.LastCheckpointAt, evt.NextCheckpointDueAt,
-                                lastWiDurationMs, avgWiDurationMs));
+                                lastWiDurationMs, avgWiDurationMs,
+                                revisions, avgRevDurationMs));
                         }
                     });
             }
@@ -620,61 +644,81 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         int processed, int total,
         int currentWiId, int currentWiRevisions,
         int lastCompletedWiId, int lastCompletedRevisions,
-        string stage, DateTimeOffset startTime,
+        string stage,
         DateTimeOffset? lastCheckpointAt = null, DateTimeOffset? nextCheckpointDueAt = null,
-        double lastWiDurationMs = 0, double avgWiDurationMs = 0)
+        double lastWiDurationMs = 0, double avgWiDurationMs = 0,
+        int totalRevisions = 0, double avgRevDurationMs = 0)
     {
         const int BarWidth = 38;
-        const int WiBarWidth = 20;
 
-        // ── Row 1: overall progress ──────────────────────────────────────────────────
-        var pct = total > 0 ? (double)processed / total : 0.0;
-        var filled = Math.Clamp((int)(pct * BarWidth), 0, BarWidth);
-        var overallBar = new string('━', filled) + new string('─', BarWidth - filled);
+        // Estimate total revisions (used for both the bar and ETA).
+        int estimatedTotalRevisions = processed > 0 && total > 0
+            ? (int)((double)totalRevisions / processed * total)
+            : 0;
+
+        // ── Row 1: work items progress bar (parent) ──────────────────────────────────
+        var wiPct = total > 0 ? (double)processed / total : 0.0;
+        var wiFilled = Math.Clamp((int)(wiPct * BarWidth), 0, BarWidth);
+        var wiBar = new string('━', wiFilled) + new string('─', BarWidth - wiFilled);
         var stageStr = string.IsNullOrEmpty(stage) ? string.Empty : $"  [grey]{Markup.Escape(stage)}[/]";
-        var etaStr = ComputeEta(startTime, processed, total);
-        var overall = new Markup(
-            $"[bold]WorkItems[/]{stageStr}  [blue]{Markup.Escape(overallBar)}[/]" +
-            $"  [bold]{processed:N0}[/][grey]/{total:N0}[/]" +
-            $"  [grey]{pct * 100.0:F1}%[/]  [grey]ETA: {Markup.Escape(etaStr)}[/]");
+        var etaStr = ComputeRevisionEta(totalRevisions, estimatedTotalRevisions, avgRevDurationMs);
+        var wiRow = new Markup(
+            $"[bold]WorkItems[/]{stageStr}  [blue]{Markup.Escape(wiBar)}[/]"
+            + $"  [bold]{processed:N0}[/][grey]/{total:N0}[/]"
+            + $"  [grey]{wiPct * 100.0:F1}%[/]  [grey]ETA: {Markup.Escape(etaStr)}[/]");
 
-        // ── Row 2: last completed WI (full bar = 100 %) ──────────────────────────────
-        IRenderable completedRow;
+        // ── Row 2: current work item revision counter (child) ────────────────────────
+        // Shows the in-progress WI's revision count.  The bar fills against the last
+        // completed WI's revision count as a rough reference — it overflows past 100 %
+        // if the current WI has more revisions than the previous one, which is fine.
+        IRenderable revRow;
+        if (currentWiId > 0)
+        {
+            // Use lastCompletedRevisions as a soft "expected" upper bound for the bar.
+            // Fall back to currentWiRevisions so the bar always shows some fill.
+            int refRevs = lastCompletedRevisions > 0 ? lastCompletedRevisions : currentWiRevisions;
+            var curPct = refRevs > 0 ? Math.Min(1.0, (double)currentWiRevisions / refRevs) : 0.0;
+            var curFilled = Math.Clamp((int)(curPct * BarWidth), 0, BarWidth);
+            var curBar = new string('━', curFilled) + new string('─', BarWidth - curFilled);
+            var cumStr = totalRevisions > 0 ? $"  [grey]total: {totalRevisions:N0} rev[/]" : string.Empty;
+            var lastRevStr = lastCompletedRevisions > 0 ? $"  [grey](prev: {lastCompletedRevisions} rev)[/]" : string.Empty;
+            revRow = new Markup(
+                $"  [grey]↳ WI {currentWiId}[/]   [blue]{Markup.Escape(curBar)}[/]"
+                + $"  [bold]{currentWiRevisions:N0}[/][grey] rev[/]"
+                + $"{lastRevStr}{cumStr}");
+        }
+        else if (totalRevisions > 0)
+        {
+            // No WI in flight yet — show cumulative totals.
+            var revPct = estimatedTotalRevisions > 0 ? Math.Min(1.0, (double)totalRevisions / estimatedTotalRevisions) : 0.0;
+            var revFilled = Math.Clamp((int)(revPct * BarWidth), 0, BarWidth);
+            var revBar = new string('━', revFilled) + new string('─', BarWidth - revFilled);
+            var revTotalStr = estimatedTotalRevisions > 0 ? $"[grey]/~{estimatedTotalRevisions:N0}[/]" : string.Empty;
+            revRow = new Markup(
+                $"  [grey]↳ Revisions[/]   [blue]{Markup.Escape(revBar)}[/]"
+                + $"  [bold]{totalRevisions:N0}[/]{revTotalStr}");
+        }
+        else
+        {
+            revRow = new Markup("  [grey]↳ Revisions   waiting…[/]");
+        }
+
+        // ── Row 3: last WI timing / throttle indicator ───────────────────────────────
+        IRenderable timingRow;
         if (lastWiDurationMs > 0)
         {
             var lastSec = lastWiDurationMs / 1000.0;
-            var avgSec  = avgWiDurationMs  / 1000.0;
-            // Flag likely throttling: last WI took more than 3× the average.
+            var avgSec = avgWiDurationMs / 1000.0;
             var isSlowdown = avgWiDurationMs > 0 && lastWiDurationMs > avgWiDurationMs * 3;
             var durationColor = isSlowdown ? "red" : lastWiDurationMs > avgWiDurationMs * 1.5 ? "yellow" : "green";
             var throttleWarning = isSlowdown ? "  [red bold]⚠ possible back-off[/]" : string.Empty;
-            completedRow = new Markup(
+            timingRow = new Markup(
                 $"  [grey]last:[/] [{durationColor}]{lastSec:F1}s[/]" +
                 $"  [grey]avg:[/] [grey]{avgSec:F1}s[/]{throttleWarning}");
         }
-        else if (lastCompletedWiId > 0)
-        {
-            completedRow = new Markup($"  [grey]✓ WI {lastCompletedWiId}  {new string('━', WiBarWidth)}  {lastCompletedRevisions} rev  done[/]");
-        }
         else
         {
-            completedRow = new Markup("  [grey]─[/]");
-        }
-
-        // ── Row 3: current WI in progress (partial bar, never reaches 100 %) ─────────
-        IRenderable currentRow;
-        if (currentWiId > 0)
-        {
-            // Bar fills as revisions arrive; capped one below full so it never
-            // reads as 100 % while the item is still being processed.
-            var wiBarFilled = Math.Min(currentWiRevisions, WiBarWidth - 1);
-            var wiBar = new string('━', wiBarFilled) + new string('─', WiBarWidth - wiBarFilled);
-            currentRow = new Markup(
-                $"  [grey]↳[/] WI [bold]{currentWiId}[/]  [blue]{Markup.Escape(wiBar)}[/]  [grey]{currentWiRevisions} rev[/]");
-        }
-        else
-        {
-            currentRow = new Markup("  [grey]↳ waiting…[/]");
+            timingRow = new Markup("  [grey]─[/]");
         }
 
         // ── Row 4: checkpoint safety indicator ───────────────────────────────────────
@@ -691,15 +735,15 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         else
             checkpointRow = new Markup("  [grey]─[/]");
 
-        return new Rows(overall, completedRow, currentRow, checkpointRow);
+        return new Rows(wiRow, revRow, timingRow, checkpointRow);
     }
 
-    private static string ComputeEta(DateTimeOffset startTime, int processed, int total)
+    private static string ComputeRevisionEta(int revisionsWritten, int estimatedTotalRevisions, double avgRevDurationMs)
     {
-        if (processed <= 0 || total <= 0) return "--:--:--";
-        var elapsedSecs = (DateTimeOffset.UtcNow - startTime).TotalSeconds;
-        if (elapsedSecs < 1) return "--:--:--";
-        var remainingSecs = (total - processed) / (processed / elapsedSecs);
+        if (avgRevDurationMs <= 0 || estimatedTotalRevisions <= 0 || revisionsWritten <= 0)
+            return "--:--:--";
+        var remainingRevisions = Math.Max(0, estimatedTotalRevisions - revisionsWritten);
+        var remainingSecs = remainingRevisions * avgRevDurationMs / 1000.0;
         var eta = TimeSpan.FromSeconds(remainingSecs);
         return eta.TotalHours >= 1
             ? $"{(int)eta.TotalHours}:{eta.Minutes:D2}:{eta.Seconds:D2}"

--- a/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
@@ -468,8 +468,7 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         int currentWiId = 0;
         int currentWiIndex = 0;
         int currentWiRevsWritten = 0;
-        double lastWiDurationMs = 0;
-        double avgWiDurationMs = 0;
+        double lastRevDurationMs = 0;
         double avgRevDurationMs = 0;
         string currentStage = string.Empty;
 
@@ -489,10 +488,10 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                         totalWorkItems = (int)evt.Metrics.Scope.WorkItemsTotal;
                     processed = (int)(evt.Metrics?.Migration?.WorkItems?.Completed ?? processed);
                     revisions = (int)(evt.Metrics?.Migration?.WorkItems?.RevisionsProcessed ?? revisions);
-                    if (evt.Metrics?.Migration?.WorkItems?.LastWorkItemDurationMs > 0)
-                        lastWiDurationMs = evt.Metrics.Migration.WorkItems.LastWorkItemDurationMs;
-                    if (evt.Metrics?.Migration?.WorkItems?.AverageWorkItemDurationMs > 0)
-                        avgWiDurationMs = evt.Metrics.Migration.WorkItems.AverageWorkItemDurationMs;
+                    if (evt.Metrics?.Migration?.WorkItems?.LastRevisionDurationMs > 0)
+                        lastRevDurationMs = evt.Metrics.Migration.WorkItems.LastRevisionDurationMs;
+                    if (evt.Metrics?.Migration?.WorkItems?.AverageRevisionDurationMs > 0)
+                        avgRevDurationMs = evt.Metrics.Migration.WorkItems.AverageRevisionDurationMs;
                     var wi = evt.Metrics?.Migration?.WorkItems;
                     if (wi?.CurrentWorkItemId > 0)
                     {
@@ -550,10 +549,6 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                                 totalWorkItems = (int)evt.Metrics.Scope.WorkItemsTotal;
                             processed = (int)(evt.Metrics?.Migration?.WorkItems?.Completed ?? processed);
                             revisions = (int)(evt.Metrics?.Migration?.WorkItems?.RevisionsProcessed ?? revisions);
-                            if (evt.Metrics?.Migration?.WorkItems?.LastWorkItemDurationMs > 0)
-                                lastWiDurationMs = evt.Metrics.Migration.WorkItems.LastWorkItemDurationMs;
-                            if (evt.Metrics?.Migration?.WorkItems?.AverageWorkItemDurationMs > 0)
-                                avgWiDurationMs = evt.Metrics.Migration.WorkItems.AverageWorkItemDurationMs;
                             if (evt.Metrics?.Migration?.WorkItems?.LastWorkItemRevisions > 0)
                                 lastWiRevisions = (int)evt.Metrics.Migration.WorkItems.LastWorkItemRevisions;
                             var wi = evt.Metrics?.Migration?.WorkItems;
@@ -563,6 +558,8 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                                 currentWiIndex = wi.CurrentWorkItemIndex;
                                 currentWiRevsWritten = wi.CurrentWorkItemRevisionsWritten;
                             }
+                            if (evt.Metrics?.Migration?.WorkItems?.LastRevisionDurationMs > 0)
+                                lastRevDurationMs = evt.Metrics.Migration.WorkItems.LastRevisionDurationMs;
                             if (evt.Metrics?.Migration?.WorkItems?.AverageRevisionDurationMs > 0)
                                 avgRevDurationMs = evt.Metrics.Migration.WorkItems.AverageRevisionDurationMs;
 
@@ -572,8 +569,8 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                                 currentWiIndex, lastWiRevisions,
                                 currentStage,
                                 evt.LastCheckpointAt, evt.NextCheckpointDueAt,
-                                lastWiDurationMs, avgWiDurationMs,
-                                revisions, avgRevDurationMs));
+                                lastRevDurationMs, avgRevDurationMs,
+                                revisions));
                         }
                     });
             }
@@ -646,8 +643,8 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         int lastCompletedWiId, int lastCompletedRevisions,
         string stage,
         DateTimeOffset? lastCheckpointAt = null, DateTimeOffset? nextCheckpointDueAt = null,
-        double lastWiDurationMs = 0, double avgWiDurationMs = 0,
-        int totalRevisions = 0, double avgRevDurationMs = 0)
+        double lastRevDurationMs = 0, double avgRevDurationMs = 0,
+        int totalRevisions = 0)
     {
         const int BarWidth = 38;
 
@@ -703,14 +700,15 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
             revRow = new Markup("  [grey]↳ Revisions   waiting…[/]");
         }
 
-        // ── Row 3: last WI timing / throttle indicator ───────────────────────────────
+        // ── Row 3: revision timing / back-off indicator ──────────────────────────────
         IRenderable timingRow;
-        if (lastWiDurationMs > 0)
+        if (lastRevDurationMs > 0)
         {
-            var lastSec = lastWiDurationMs / 1000.0;
-            var avgSec = avgWiDurationMs / 1000.0;
-            var isSlowdown = avgWiDurationMs > 0 && lastWiDurationMs > avgWiDurationMs * 3;
-            var durationColor = isSlowdown ? "red" : lastWiDurationMs > avgWiDurationMs * 1.5 ? "yellow" : "green";
+            var lastSec = lastRevDurationMs / 1000.0;
+            var avgSec = avgRevDurationMs / 1000.0;
+            // Flag likely throttling: last revision took more than 3× the average.
+            var isSlowdown = avgRevDurationMs > 0 && lastRevDurationMs > avgRevDurationMs * 3;
+            var durationColor = isSlowdown ? "red" : lastRevDurationMs > avgRevDurationMs * 1.5 ? "yellow" : "green";
             var throttleWarning = isSlowdown ? "  [red bold]⚠ possible back-off[/]" : string.Empty;
             timingRow = new Markup(
                 $"  [grey]last:[/] [{durationColor}]{lastSec:F1}s[/]" +

--- a/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
@@ -54,9 +54,6 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
 
             services.AddTransient<IJobRunner>(sp => sp.GetRequiredService<ControlPlaneClient>());
 
-            // Pre-flight work item counting — uses the same date-window WIQL strategy as export.
-            services.AddExportPreflightServices();
-
             // TFS subprocess services — registered unconditionally so DI resolves them
             // correctly when the source type is TeamFoundationServer.
             services.AddSingleton<IProgressSink, AnsiProgressSink>();
@@ -365,27 +362,6 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         }
 
         var totalWorkItems = 0;
-        var discovery = GetRequiredService<IWorkItemDiscoveryService>();
-
-        // Pass the source endpoint options directly (already a MigrationEndpointOptions)
-        var sourceEndpoint = config.Source!;
-        var sourceOrgEndpoint = sourceEndpoint.ToOrganisationEndpoint();
-
-        await console.Status()
-            .Spinner(Spinner.Known.Dots)
-            .SpinnerStyle(Style.Plain)
-            .StartAsync("[grey]Counting work items…[/]", async _ =>
-            {
-                await foreach (var snapshot in discovery.CountWorkItemsAsync(
-                    sourceOrgEndpoint, project, baseQuery, cancellationToken))
-                {
-                    if (snapshot.IsWorkItemComplete)
-                        totalWorkItems = snapshot.WorkItemsCount;
-                }
-            });
-
-        if (totalWorkItems > 0)
-            console.MarkupLine($"[blue]ℹ[/] Work items found: [bold]{totalWorkItems:N0}[/]");
 
         // Build MigrationJob — no migration logic here.
         var job = new MigrationJob
@@ -428,12 +404,16 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         // without cancelling the job.
         using var followCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-        // Register Ctrl+C handler for graceful detach.
-        Console.CancelKeyPress += (_, e) =>
+        // Guard against the handler firing after followCts has been disposed (e.g. a
+        // second Ctrl+C after the first already triggered detach and the using block exited).
+        var followCtsDisposed = false;
+        ConsoleCancelEventHandler ctrlCHandler = (_, e) =>
         {
             e.Cancel = true; // Prevent process exit.
-            followCts.Cancel();
+            if (!followCtsDisposed)
+                followCts.Cancel();
         };
+        Console.CancelKeyPress += ctrlCHandler;
 
         // Submit the job first.
         try
@@ -498,6 +478,8 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                     lastEvt = evt;
                     if (!string.IsNullOrEmpty(evt.Stage))
                         currentStage = evt.Stage;
+                    if (evt.Metrics?.Scope?.WorkItemsTotal > 0)
+                        totalWorkItems = (int)evt.Metrics.Scope.WorkItemsTotal;
                     processed = (int)(evt.Metrics?.Migration?.WorkItems?.Completed ?? processed);
                     revisions = (int)(evt.Metrics?.Migration?.WorkItems?.RevisionsProcessed ?? revisions);
                 }
@@ -541,22 +523,23 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                         ctx.Refresh();
 
                         await foreach (var evt in client.FollowLogsAsync(parsedJobId, followCts.Token).ConfigureAwait(false))
-                        {
-                            lastEvt = evt;
+                    {
+                        lastEvt = evt;
+                        if (!string.IsNullOrEmpty(evt.Stage))
+                            currentStage = evt.Stage;
+                        // The Agent emits a ScopeResolved event with WorkItemsTotal when it completes the count.
+                        if (evt.Metrics?.Scope?.WorkItemsTotal > 0)
+                            totalWorkItems = (int)evt.Metrics.Scope.WorkItemsTotal;
+                        processed = (int)(evt.Metrics?.Migration?.WorkItems?.Completed ?? processed);
+                        revisions = (int)(evt.Metrics?.Migration?.WorkItems?.RevisionsProcessed ?? revisions);
 
-                            if (!string.IsNullOrEmpty(evt.Stage))
-                                currentStage = evt.Stage;
-
-                            processed = (int)(evt.Metrics?.Migration?.WorkItems?.Completed ?? processed);
-                            revisions = (int)(evt.Metrics?.Migration?.WorkItems?.RevisionsProcessed ?? revisions);
-
-                            ctx.UpdateTarget(BuildProgressRenderable(
-                                processed, totalWorkItems,
-                                0, 0,
-                                0, 0,
-                                currentStage, progressStartTime,
-                                evt.LastCheckpointAt, evt.NextCheckpointDueAt));
-                        }
+                        ctx.UpdateTarget(BuildProgressRenderable(
+                            processed, totalWorkItems,
+                            0, 0,
+                            0, 0,
+                            currentStage, progressStartTime,
+                            evt.LastCheckpointAt, evt.NextCheckpointDueAt));
+                    }
                     });
             }
             catch (InvalidOperationException ex) when (ex.Message.Contains("Job failed"))
@@ -569,12 +552,24 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
             catch (OperationCanceledException)
             {
                 // Ctrl+C pressed — detach.
-                console.MarkupLine("[yellow]Detached from diagnostic stream. Job continues running on the server.[/]");
-                console.MarkupLine("[grey]Use [bold]tui[/] to resume watching.[/]");
+                if (isStandaloneMode)
+                {
+                    console.MarkupLine("[yellow]Cancelled. Job has been stopped.[/]");
+                }
+                else
+                {
+                    console.MarkupLine("[yellow]Detached from diagnostic stream. Job continues running on the server.[/]");
+                    console.MarkupLine("[grey]Use [bold]tui[/] to resume watching.[/]");
+                }
                 return 0;
             }
             finally
             {
+                // Deregister Ctrl+C handler and mark CTS as disposed before the using block
+                // exits so a late-firing second Ctrl+C cannot call Cancel() on a disposed CTS.
+                Console.CancelKeyPress -= ctrlCHandler;
+                followCtsDisposed = true;
+
                 // Restore stdout and flush anything the Console logger wrote during the live render.
                 Console.SetOut(originalOut);
                 var captured = logBuffer.ToString();

--- a/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
@@ -462,7 +462,8 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         }, followCts.Token);
 
         var progressStartTime = DateTimeOffset.UtcNow;
-        int processed = 0;
+        int completed = 0;
+        int skipped = 0;
         int revisions = 0;
         int lastWiRevisions = 0;
         int currentWiId = 0;
@@ -476,6 +477,7 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         double avgAttDurationMs = 0;
         long avgAttSizeBytes = 0;
         string? currentAttName = null;
+        string? lastWiStatus = null;
 
         if (Console.IsOutputRedirected)
         {
@@ -491,12 +493,19 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                         currentStage = evt.Stage;
                     if (evt.Metrics?.Scope?.WorkItemsTotal > 0)
                         totalWorkItems = (int)evt.Metrics.Scope.WorkItemsTotal;
-                    processed = (int)(evt.Metrics?.Migration?.WorkItems?.Completed ?? processed);
-                    revisions = (int)(evt.Metrics?.Migration?.WorkItems?.RevisionsProcessed ?? revisions);
-                    if (evt.Metrics?.Migration?.WorkItems?.LastRevisionDurationMs > 0)
-                        lastRevDurationMs = evt.Metrics.Migration.WorkItems.LastRevisionDurationMs;
-                    if (evt.Metrics?.Migration?.WorkItems?.AverageRevisionDurationMs > 0)
-                        avgRevDurationMs = evt.Metrics.Migration.WorkItems.AverageRevisionDurationMs;
+                    var wi = evt.Metrics?.Migration?.WorkItems;
+                    if (wi != null)
+                    {
+                        completed = (int)wi.Completed;
+                        skipped = (int)wi.Skipped;
+                        revisions = (int)(wi.RevisionsProcessed > 0 ? wi.RevisionsProcessed : revisions);
+                        if (wi.LastRevisionDurationMs > 0)
+                            lastRevDurationMs = wi.LastRevisionDurationMs;
+                        if (wi.AverageRevisionDurationMs > 0)
+                            avgRevDurationMs = wi.AverageRevisionDurationMs;
+                        if (wi.LastWorkItemStatus != null)
+                            lastWiStatus = wi.LastWorkItemStatus;
+                    }
                     var att = evt.Metrics?.Migration?.WorkItems?.Attachments;
                     if (att != null)
                     {
@@ -506,7 +515,6 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                         avgAttSizeBytes = att.AverageSizeBytes;
                         currentAttName = att.CurrentAttachmentName;
                     }
-                    var wi = evt.Metrics?.Migration?.WorkItems;
                     if (wi?.CurrentWorkItemId > 0)
                     {
                         currentWiId = wi.CurrentWorkItemId;
@@ -520,7 +528,7 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                 jobFailed = true;
                 ShowError(console, ex.Message);
                 if (lastEvt is not null)
-                    ShowError(console, $"Last progress: {processed} work items / {revisions} revisions");
+                    ShowError(console, $"Last progress: {completed} exported / {skipped} skipped / {revisions} revisions");
             }
             catch (OperationCanceledException)
             {
@@ -544,7 +552,7 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
             try
             {
                 await console.Live(BuildProgressRenderable(
-                        0, totalWorkItems, 0, 0, 0, 0, string.Empty))
+                        0, 0, totalWorkItems, 0, 0, 0, 0, string.Empty))
                     .AutoClear(false)
                     .Overflow(VerticalOverflow.Ellipsis)
                     .StartAsync(async ctx =>
@@ -561,21 +569,27 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                             // The Agent emits a ScopeResolved event with WorkItemsTotal when it completes the count.
                             if (evt.Metrics?.Scope?.WorkItemsTotal > 0)
                                 totalWorkItems = (int)evt.Metrics.Scope.WorkItemsTotal;
-                            processed = (int)(evt.Metrics?.Migration?.WorkItems?.Completed ?? processed);
-                            revisions = (int)(evt.Metrics?.Migration?.WorkItems?.RevisionsProcessed ?? revisions);
-                            if (evt.Metrics?.Migration?.WorkItems?.LastWorkItemRevisions > 0)
-                                lastWiRevisions = (int)evt.Metrics.Migration.WorkItems.LastWorkItemRevisions;
                             var wi = evt.Metrics?.Migration?.WorkItems;
-                            if (wi?.CurrentWorkItemId > 0)
+                            if (wi != null)
                             {
-                                currentWiId = wi.CurrentWorkItemId;
-                                currentWiIndex = wi.CurrentWorkItemIndex;
-                                currentWiRevsWritten = wi.CurrentWorkItemRevisionsWritten;
+                                completed = (int)wi.Completed;
+                                skipped = (int)wi.Skipped;
+                                revisions = (int)(wi.RevisionsProcessed > 0 ? wi.RevisionsProcessed : revisions);
+                                if (wi.LastWorkItemRevisions > 0)
+                                    lastWiRevisions = (int)wi.LastWorkItemRevisions;
+                                if (wi.LastRevisionDurationMs > 0)
+                                    lastRevDurationMs = wi.LastRevisionDurationMs;
+                                if (wi.AverageRevisionDurationMs > 0)
+                                    avgRevDurationMs = wi.AverageRevisionDurationMs;
+                                if (wi.LastWorkItemStatus != null)
+                                    lastWiStatus = wi.LastWorkItemStatus;
+                                if (wi.CurrentWorkItemId > 0)
+                                {
+                                    currentWiId = wi.CurrentWorkItemId;
+                                    currentWiIndex = wi.CurrentWorkItemIndex;
+                                    currentWiRevsWritten = wi.CurrentWorkItemRevisionsWritten;
+                                }
                             }
-                            if (evt.Metrics?.Migration?.WorkItems?.LastRevisionDurationMs > 0)
-                                lastRevDurationMs = evt.Metrics.Migration.WorkItems.LastRevisionDurationMs;
-                            if (evt.Metrics?.Migration?.WorkItems?.AverageRevisionDurationMs > 0)
-                                avgRevDurationMs = evt.Metrics.Migration.WorkItems.AverageRevisionDurationMs;
 
                             var att = evt.Metrics?.Migration?.WorkItems?.Attachments;
                             if (att != null)
@@ -588,10 +602,10 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                             }
 
                             ctx.UpdateTarget(BuildProgressRenderable(
-                                processed, totalWorkItems,
+                                completed, skipped, totalWorkItems,
                                 currentWiId, currentWiRevsWritten,
                                 currentWiIndex, lastWiRevisions,
-                                currentStage,
+                                currentStage, lastWiStatus,
                                 evt.LastCheckpointAt, evt.NextCheckpointDueAt,
                                 lastRevDurationMs, avgRevDurationMs,
                                 revisions,
@@ -604,7 +618,7 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                 jobFailed = true;
                 ShowError(console, ex.Message);
                 if (lastEvt is not null)
-                    ShowError(console, $"Last progress: {processed} work items / {revisions} revisions");
+                    ShowError(console, $"Last progress: {completed} exported / {skipped} skipped / {revisions} revisions");
             }
             catch (OperationCanceledException)
             {
@@ -648,7 +662,7 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
             return 1;
 
         if (lastEvt is not null)
-            ShowSuccess(console, $"Export complete — {processed} work items / {revisions} revisions written to package.");
+            ShowSuccess(console, $"Export complete — {completed} exported / {skipped} skipped / {revisions} revisions written to package.");
         else
             ShowSuccess(console, "Work item export complete.");
         return 0;
@@ -663,10 +677,10 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
     /// Row count is always exactly 4 so Live()'s cursor-up stays stable.
     /// </summary>
     private static IRenderable BuildProgressRenderable(
-        int processed, int total,
+        int completed, int skipped, int total,
         int currentWiId, int currentWiRevisions,
         int lastCompletedWiId, int lastCompletedRevisions,
-        string stage,
+        string stage, string? lastWiStatus = null,
         DateTimeOffset? lastCheckpointAt = null, DateTimeOffset? nextCheckpointDueAt = null,
         double lastRevDurationMs = 0, double avgRevDurationMs = 0,
         int totalRevisions = 0,
@@ -675,39 +689,46 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         string? currentAttName = null)
     {
         const int BarWidth = 38;
+        int processed = completed + skipped;
 
-        // Estimate total revisions (used for both the bar and ETA).
-        int estimatedTotalRevisions = processed > 0 && total > 0
-            ? (int)((double)totalRevisions / processed * total)
+        // Estimate total revisions — base only on completed (exported) items, not skipped.
+        int estimatedTotalRevisions = completed > 0 && total > 0
+            ? (int)((double)totalRevisions / completed * total)
             : 0;
 
         // ── Row 1: work items progress bar (parent) ──────────────────────────────────
+        // Bar position = processed (completed + skipped); counts shown separately.
         var wiPct = total > 0 ? (double)processed / total : 0.0;
         var wiFilled = Math.Clamp((int)(wiPct * BarWidth), 0, BarWidth);
         var wiBar = new string('━', wiFilled) + new string('─', BarWidth - wiFilled);
         var stageStr = string.IsNullOrEmpty(stage) ? string.Empty : $"  [grey]{Markup.Escape(stage)}[/]";
         var etaStr = ComputeRevisionEta(totalRevisions, estimatedTotalRevisions, avgRevDurationMs);
+        var skippedStr = skipped > 0 ? $"  [grey]{skipped:N0} skipped[/]" : string.Empty;
         var wiRow = new Markup(
             $"[bold]WorkItems[/]{stageStr}  [blue]{Markup.Escape(wiBar)}[/]"
-            + $"  [bold]{processed:N0}[/][grey]/{total:N0}[/]"
+            + $"  [bold]{completed:N0}[/][grey]/{total:N0}[/]{skippedStr}"
             + $"  [grey]{wiPct * 100.0:F1}%[/]  [grey]ETA: {Markup.Escape(etaStr)}[/]");
 
-        // ── Row 2: current work item revision counter (child) ────────────────────────
-        // Shows the in-progress WI's revision count.  The bar fills against the last
-        // completed WI's revision count as a rough reference — it overflows past 100 %
-        // if the current WI has more revisions than the previous one, which is fine.
+        // ── Row 2: current work item / fast-forward indicator ─────────────────────────
         IRenderable revRow;
-        if (currentWiId > 0)
+        var isResuming = string.Equals(stage, "Resuming", StringComparison.OrdinalIgnoreCase);
+        if (isResuming && currentWiId > 0)
         {
-            // Use lastCompletedRevisions as a soft "expected" upper bound for the bar.
-            // Fall back to currentWiRevisions so the bar always shows some fill.
+            revRow = new Markup(
+                $"  [grey]↳ Resuming WI {currentWiId}[/]  [grey](fast-forwarding {skipped:N0}/{total:N0})[/]");
+        }
+        else if (currentWiId > 0)
+        {
             int refRevs = lastCompletedRevisions > 0 ? lastCompletedRevisions : currentWiRevisions;
             var curPct = refRevs > 0 ? Math.Min(1.0, (double)currentWiRevisions / refRevs) : 0.0;
             var curFilled = Math.Clamp((int)(curPct * BarWidth), 0, BarWidth);
             var curBar = new string('━', curFilled) + new string('─', BarWidth - curFilled);
             var lastRevStr = lastCompletedRevisions > 0 ? $"  [grey](prev: {lastCompletedRevisions} rev)[/]" : string.Empty;
+            var statusBadge = lastWiStatus == "Exported" ? " [green]✓[/]"
+                            : lastWiStatus == "Failed"   ? " [red]✗[/]"
+                            : string.Empty;
             revRow = new Markup(
-                $"  [grey]↳ WI {currentWiId}[/]   [blue]{Markup.Escape(curBar)}[/]"
+                $"  [grey]↳ WI {currentWiId}[/]{statusBadge}   [blue]{Markup.Escape(curBar)}[/]"
                 + $"  [bold]{currentWiRevisions:N0}[/][grey] rev[/]"
                 + $"{lastRevStr}");
         }
@@ -717,12 +738,17 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         }
 
         // ── Row 3: revision timing / back-off indicator ──────────────────────────────
+        // Suppressed during fast-forward — no revision work happening, stale values
+        // would produce false back-off warnings.
         IRenderable timingRow;
-        if (lastRevDurationMs > 0)
+        if (isResuming)
+        {
+            timingRow = new Markup("  [grey]─ (fast-forwarding, no timing)[/]");
+        }
+        else if (lastRevDurationMs > 0)
         {
             var lastSec = lastRevDurationMs / 1000.0;
             var avgSec = avgRevDurationMs / 1000.0;
-            // Flag likely throttling: last revision took more than 3× the average.
             var isSlowdown = avgRevDurationMs > 0 && lastRevDurationMs > avgRevDurationMs * 3;
             var durationColor = isSlowdown ? "red" : lastRevDurationMs > avgRevDurationMs * 1.5 ? "yellow" : "green";
             var throttleWarning = isSlowdown ? "  [red bold]⚠ possible back-off[/]" : string.Empty;

--- a/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
@@ -471,6 +471,11 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         double lastRevDurationMs = 0;
         double avgRevDurationMs = 0;
         string currentStage = string.Empty;
+        int attProcessed = 0;
+        int attFailed = 0;
+        double avgAttDurationMs = 0;
+        long avgAttSizeBytes = 0;
+        string? currentAttName = null;
 
         if (Console.IsOutputRedirected)
         {
@@ -492,6 +497,15 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                         lastRevDurationMs = evt.Metrics.Migration.WorkItems.LastRevisionDurationMs;
                     if (evt.Metrics?.Migration?.WorkItems?.AverageRevisionDurationMs > 0)
                         avgRevDurationMs = evt.Metrics.Migration.WorkItems.AverageRevisionDurationMs;
+                    var att = evt.Metrics?.Migration?.WorkItems?.Attachments;
+                    if (att != null)
+                    {
+                        attProcessed = (int)att.Processed;
+                        attFailed = (int)att.Failed;
+                        avgAttDurationMs = att.AverageDownloadDurationMs;
+                        avgAttSizeBytes = att.AverageSizeBytes;
+                        currentAttName = att.CurrentAttachmentName;
+                    }
                     var wi = evt.Metrics?.Migration?.WorkItems;
                     if (wi?.CurrentWorkItemId > 0)
                     {
@@ -563,6 +577,16 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                             if (evt.Metrics?.Migration?.WorkItems?.AverageRevisionDurationMs > 0)
                                 avgRevDurationMs = evt.Metrics.Migration.WorkItems.AverageRevisionDurationMs;
 
+                            var att = evt.Metrics?.Migration?.WorkItems?.Attachments;
+                            if (att != null)
+                            {
+                                attProcessed = (int)att.Processed;
+                                attFailed = (int)att.Failed;
+                                avgAttDurationMs = att.AverageDownloadDurationMs;
+                                avgAttSizeBytes = att.AverageSizeBytes;
+                                currentAttName = att.CurrentAttachmentName;
+                            }
+
                             ctx.UpdateTarget(BuildProgressRenderable(
                                 processed, totalWorkItems,
                                 currentWiId, currentWiRevsWritten,
@@ -570,7 +594,8 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                                 currentStage,
                                 evt.LastCheckpointAt, evt.NextCheckpointDueAt,
                                 lastRevDurationMs, avgRevDurationMs,
-                                revisions));
+                                revisions,
+                                attProcessed, attFailed, avgAttDurationMs, avgAttSizeBytes, currentAttName));
                         }
                     });
             }
@@ -644,7 +669,10 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         string stage,
         DateTimeOffset? lastCheckpointAt = null, DateTimeOffset? nextCheckpointDueAt = null,
         double lastRevDurationMs = 0, double avgRevDurationMs = 0,
-        int totalRevisions = 0)
+        int totalRevisions = 0,
+        int attProcessed = 0, int attFailed = 0,
+        double avgAttDurationMs = 0, long avgAttSizeBytes = 0,
+        string? currentAttName = null)
     {
         const int BarWidth = 38;
 
@@ -721,7 +749,25 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         else
             checkpointRow = new Markup("  [grey]─[/]");
 
-        return new Rows(wiRow, revRow, timingRow, checkpointRow);
+        // ── Row 5: attachments summary ────────────────────────────────────────────────
+        IRenderable attachmentRow;
+        if (attProcessed > 0 || attFailed > 0 || currentAttName != null)
+        {
+            var avgDurStr = avgAttDurationMs > 0 ? $"  [grey]avg dl:[/] [white]{avgAttDurationMs / 1000.0:F1}s[/]" : string.Empty;
+            var avgSzStr = avgAttSizeBytes > 0 ? $"  [grey]avg size:[/] [white]{FormatBytes(avgAttSizeBytes)}[/]" : string.Empty;
+            var failStr = attFailed > 0 ? $"  [red]{attFailed} failed[/]" : string.Empty;
+            var inFlightStr = currentAttName != null
+                ? $"  [yellow]↓ {Markup.Escape(TruncateName(currentAttName, 28))}[/]"
+                : string.Empty;
+            attachmentRow = new Markup(
+                $"  [grey]Attachments:[/] [bold]{attProcessed:N0}[/][grey] done[/]{failStr}{inFlightStr}{avgDurStr}{avgSzStr}");
+        }
+        else
+        {
+            attachmentRow = new Markup("  [grey]Attachments   –[/]");
+        }
+
+        return new Rows(wiRow, revRow, timingRow, attachmentRow, checkpointRow);
     }
 
     private static string ComputeRevisionEta(int revisionsWritten, int estimatedTotalRevisions, double avgRevDurationMs)
@@ -735,6 +781,18 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
             ? $"{(int)eta.TotalHours}:{eta.Minutes:D2}:{eta.Seconds:D2}"
             : $"--:{eta.Minutes:D2}:{eta.Seconds:D2}";
     }
+
+    private static string FormatBytes(long bytes) =>
+        bytes switch
+        {
+            >= 1_073_741_824 => $"{bytes / 1_073_741_824.0:F1} GB",
+            >= 1_048_576     => $"{bytes / 1_048_576.0:F1} MB",
+            >= 1_024         => $"{bytes / 1_024.0:F1} KB",
+            _                => $"{bytes} B"
+        };
+
+    private static string TruncateName(string name, int maxLen) =>
+        name.Length <= maxLen ? name : "…" + name[^(maxLen - 1)..];
 
     /// <summary>
     /// Converts <see cref="MigrationOptions.Modules"/> into <see cref="JobModule"/> entries.

--- a/src/DevOpsMigrationPlatform.CLI.Migration/MigrationCliServiceCollectionExtensions.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/MigrationCliServiceCollectionExtensions.cs
@@ -16,15 +16,6 @@ namespace DevOpsMigrationPlatform.CLI.Migration;
 public static class MigrationCliServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the services required for pre-flight work item counting before
-    /// submitting an export job.  Delegates to the ADO implementation without
-    /// leaking that implementation detail into command classes.
-    /// </summary>
-    public static IServiceCollection AddExportPreflightServices(
-        this IServiceCollection services)
-        => services.AddAzureDevOpsWorkItemCount();
-
-    /// <summary>
     /// Registers the ADO endpoint option types for polymorphic JSON deserialization.
     /// Called by the shared host builder so every CLI command can load configuration files
     /// that reference <c>"Type": "AzureDevOpsServices"</c>.

--- a/src/DevOpsMigrationPlatform.CLI.Migration/Views/TuiMetricsView.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Views/TuiMetricsView.cs
@@ -72,6 +72,7 @@ public sealed class TuiMetricsView : FrameView
         return
             $"Work Items Attempted : {wi?.Attempted ?? 0,8}\n" +
             $"Work Items Completed : {wi?.Completed ?? 0,8}\n" +
+            $"Revisions Written    : {wi?.RevisionsProcessed ?? 0,8:N0}\n" +
             $"Work Items Failed    : {wi?.Failed ?? 0,8}\n" +
             $"Work Items Skipped   : {wi?.Skipped ?? 0,8}\n" +
             $"In-Flight            : {diag?.WorkItemsInFlight ?? 0,8}\n" +

--- a/src/DevOpsMigrationPlatform.CLI.Migration/Views/TuiMetricsView.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Views/TuiMetricsView.cs
@@ -64,7 +64,7 @@ public sealed class TuiMetricsView : FrameView
         var diag = m.Migration?.Diagnostics;
 
         var lastMs = wi?.LastWorkItemDurationMs ?? 0;
-        var avgMs  = wi?.AverageWorkItemDurationMs ?? 0;
+        var avgMs = wi?.AverageWorkItemDurationMs ?? 0;
         var throttleIndicator = lastMs > 0 && avgMs > 0 && lastMs > avgMs * 3
             ? "  *** POSSIBLE BACK-OFF ***"
             : string.Empty;

--- a/src/DevOpsMigrationPlatform.CLI.Migration/Views/TuiMetricsView.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Views/TuiMetricsView.cs
@@ -63,6 +63,12 @@ public sealed class TuiMetricsView : FrameView
         var wi = m.Migration?.WorkItems;
         var diag = m.Migration?.Diagnostics;
 
+        var lastMs = wi?.LastWorkItemDurationMs ?? 0;
+        var avgMs  = wi?.AverageWorkItemDurationMs ?? 0;
+        var throttleIndicator = lastMs > 0 && avgMs > 0 && lastMs > avgMs * 3
+            ? "  *** POSSIBLE BACK-OFF ***"
+            : string.Empty;
+
         return
             $"Work Items Attempted : {wi?.Attempted ?? 0,8}\n" +
             $"Work Items Completed : {wi?.Completed ?? 0,8}\n" +
@@ -71,7 +77,8 @@ public sealed class TuiMetricsView : FrameView
             $"In-Flight            : {diag?.WorkItemsInFlight ?? 0,8}\n" +
             $"Queue Depth          : {diag?.QueueDepth ?? 0,8}\n" +
             $"\n" +
-            $"Avg Duration         : {FormatMean(diag?.WorkItemDurationMeanMs, "ms")}\n" +
+            $"Last WI Duration     : {FormatMean(lastMs > 0 ? lastMs : null, "ms")}{throttleIndicator}\n" +
+            $"Avg WI Duration      : {FormatMean(avgMs > 0 ? avgMs : diag?.WorkItemDurationMeanMs, "ms")}\n" +
             $"Avg Revisions        : {FormatMean(diag?.RevisionCountMean)}\n" +
             $"Avg Attachments      : {FormatMean(diag?.AttachmentCountMean)}\n" +
             $"Avg Links            : {FormatMean(diag?.LinkCountMean)}\n" +

--- a/src/DevOpsMigrationPlatform.Infrastructure.AzureDevOps/ExportServiceCollectionExtensions.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure.AzureDevOps/ExportServiceCollectionExtensions.cs
@@ -49,6 +49,14 @@ public static class ExportServiceCollectionExtensions
         // Inline comment fetching: factories registered; activated when the Comments extension is enabled.
         services.AddSingleton<IWorkItemCommentSourceFactory, AzureDevOpsWorkItemCommentSourceFactory>();
 
+        // Work item discovery (count by WIQL query) — used by WorkItemExportOrchestrator
+        // at job start to populate TotalWorkItems and emit a ScopeResolved event.
+        // Registered here so the Agent has it available without the CLI needing it.
+        if (!services.Any(x => x.ServiceType == typeof(IWorkItemDiscoveryService)))
+        {
+            services.AddSingleton<IWorkItemDiscoveryService, AzureDevOpsWorkItemDiscoveryService>();
+        }
+
         // Embedded image download and processing
         services.AddHttpClient<AzureDevOpsEmbeddedImageDownloader>()
             .AddPolicyHandler(GetRetryPolicy());

--- a/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
@@ -611,8 +611,8 @@ public sealed class WorkItemExportOrchestrator
             ids.Add(item.Id);
             fetched++;
 
-            // Emit progress every 500 items so the operator can see the fetch is alive.
-            if (fetched % 500 == 0)
+            // Emit progress every 100 items so the operator can see the fetch is alive.
+            if (fetched % 100 == 0)
             {
                 _logger?.LogInformation("[WorkItems] Pre-filter pass: {Fetched} work items fetched so far…", fetched);
                 _progressSink?.Emit(new ProgressEvent

--- a/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
@@ -210,6 +210,11 @@ public sealed class WorkItemExportOrchestrator
         }
         int attachmentsProcessed = 0;
         int attachmentsFailed = 0;
+        double totalAttachmentDurationMs = 0;
+        double lastAttachmentDurationMs = 0;
+        long totalAttachmentBytes = 0;
+        long lastAttachmentBytes = 0;
+        var attachmentStopwatch = new Stopwatch();
 
         // Per-work-item timing for duration histogram.
         var workItemStopwatch = Stopwatch.StartNew();
@@ -492,15 +497,54 @@ public sealed class WorkItemExportOrchestrator
                         previousAttachmentUrls.Contains(downloadUrl))
                     {
                         if (_logger != null)
-                            _logger.LogDebug("[WorkItems] WI {WorkItemId} rev {RevisionIndex}: attachment delta-skipped (same URL as previous revision).",
+                            _logger.LogDebug("[Attachments] WI {WorkItemId} rev {RevisionIndex}: attachment delta-skipped (same URL as previous revision).",
                                     revision.WorkItemId, revision.RevisionIndex);
                         continue;
                     }
+
+                    var attachmentName = attachment.OriginalName is { Length: > 0 } n ? n : attachment.RelativePath ?? "(unknown)";
+
+                    // ── Found ──
+                    _logger?.LogInformation("[Attachments] WI {WorkItemId} rev {RevisionIndex}: found attachment '{Name}' ({Bytes} bytes).",
+                        revision.WorkItemId, revision.RevisionIndex, attachmentName, attachment.Size);
+                    _progressSink?.Emit(new ProgressEvent
+                    {
+                        Module = "WorkItems",
+                        Stage = "Attachment",
+                        Message = $"[Attachments] WI {revision.WorkItemId} rev {revision.RevisionIndex}: found '{attachmentName}' ({FormatBytes(attachment.Size)})",
+                        Metrics = new JobMetrics
+                        {
+                            Migration = new MigrationCounters
+                            {
+                                WorkItems = new WorkItemCounters
+                                {
+                                    Completed = workItemsProcessed,
+                                    RevisionsProcessed = revisionsProcessed,
+                                    CurrentWorkItemId = revision.WorkItemId,
+                                    Attachments = new AttachmentCounters
+                                    {
+                                        Processed = attachmentsProcessed,
+                                        Failed = attachmentsFailed,
+                                        TotalBytes = totalAttachmentBytes,
+                                        LastDownloadDurationMs = lastAttachmentDurationMs,
+                                        AverageDownloadDurationMs = attachmentsProcessed > 0 ? totalAttachmentDurationMs / attachmentsProcessed : 0,
+                                        LastSizeBytes = lastAttachmentBytes,
+                                        AverageSizeBytes = attachmentsProcessed > 0 ? totalAttachmentBytes / attachmentsProcessed : 0,
+                                        CurrentAttachmentName = attachmentName
+                                    }
+                                }
+                            }
+                        }
+                    });
 
                     var targetPath = $"{folderPath}{attachment.RelativePath}";
 
                     using var attachmentActivity = ActivitySource.StartActivity("attachment.download", ActivityKind.Internal);
                     attachmentActivity?.SetTag("workitem.id", revision.WorkItemId);
+
+                    attachmentStopwatch.Restart();
+                    long downloadedBytes = 0;
+                    bool downloadSucceeded;
 
                     // Prefer streaming path when the source supports it (no byte[] buffering).
                     if (streamingSource != null)
@@ -510,10 +554,9 @@ public sealed class WorkItemExportOrchestrator
                                 _artefactStore, targetPath, cancellationToken)
                             .ConfigureAwait(false);
 
+                        downloadSucceeded = result.HasValue;
                         if (result.HasValue)
-                            attachmentsProcessed++;
-                        else
-                            attachmentsFailed++;
+                            downloadedBytes = result.Value.Size;
                     }
                     else
                     {
@@ -527,12 +570,96 @@ public sealed class WorkItemExportOrchestrator
                             await _artefactStore
                                 .WriteBinaryAsync(targetPath, bytes, cancellationToken)
                                 .ConfigureAwait(false);
-                            attachmentsProcessed++;
+                            downloadedBytes = bytes.Length;
+                            downloadSucceeded = true;
                         }
                         else
                         {
-                            attachmentsFailed++;
+                            downloadSucceeded = false;
                         }
+                    }
+
+                    lastAttachmentDurationMs = attachmentStopwatch.Elapsed.TotalMilliseconds;
+
+                    if (downloadSucceeded)
+                    {
+                        attachmentsProcessed++;
+                        totalAttachmentDurationMs += lastAttachmentDurationMs;
+                        lastAttachmentBytes = downloadedBytes;
+                        totalAttachmentBytes += downloadedBytes;
+
+                        // Record per-download OTel metrics.
+                        if (_metrics != null)
+                        {
+                            _metrics.RecordAttachmentDownloadDuration(lastAttachmentDurationMs, exportTags);
+                            _metrics.RecordAttachmentDownloadBytes(downloadedBytes, exportTags);
+                        }
+
+                        // ── Done ──
+                        _logger?.LogInformation("[Attachments] WI {WorkItemId} rev {RevisionIndex}: downloaded '{Name}' — {Bytes} in {Ms:F0}ms.",
+                            revision.WorkItemId, revision.RevisionIndex, attachmentName, FormatBytes(downloadedBytes), lastAttachmentDurationMs);
+                        _progressSink?.Emit(new ProgressEvent
+                        {
+                            Module = "WorkItems",
+                            Stage = "Attachment",
+                            Message = $"[Attachments] WI {revision.WorkItemId}: '{attachmentName}' done — {FormatBytes(downloadedBytes)} in {lastAttachmentDurationMs:F0}ms",
+                            Metrics = new JobMetrics
+                            {
+                                Migration = new MigrationCounters
+                                {
+                                    WorkItems = new WorkItemCounters
+                                    {
+                                        Completed = workItemsProcessed,
+                                        RevisionsProcessed = revisionsProcessed,
+                                        CurrentWorkItemId = revision.WorkItemId,
+                                        Attachments = new AttachmentCounters
+                                        {
+                                            Processed = attachmentsProcessed,
+                                            Failed = attachmentsFailed,
+                                            TotalBytes = totalAttachmentBytes,
+                                            LastDownloadDurationMs = lastAttachmentDurationMs,
+                                            AverageDownloadDurationMs = totalAttachmentDurationMs / attachmentsProcessed,
+                                            LastSizeBytes = lastAttachmentBytes,
+                                            AverageSizeBytes = totalAttachmentBytes / attachmentsProcessed
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                    }
+                    else
+                    {
+                        attachmentsFailed++;
+                        _logger?.LogWarning("[Attachments] WI {WorkItemId} rev {RevisionIndex}: failed to download '{Name}'.",
+                            revision.WorkItemId, revision.RevisionIndex, attachmentName);
+                        _progressSink?.Emit(new ProgressEvent
+                        {
+                            Module = "WorkItems",
+                            Stage = "Attachment",
+                            Message = $"[Attachments] WI {revision.WorkItemId}: '{attachmentName}' FAILED",
+                            Metrics = new JobMetrics
+                            {
+                                Migration = new MigrationCounters
+                                {
+                                    WorkItems = new WorkItemCounters
+                                    {
+                                        Completed = workItemsProcessed,
+                                        RevisionsProcessed = revisionsProcessed,
+                                        CurrentWorkItemId = revision.WorkItemId,
+                                        Attachments = new AttachmentCounters
+                                        {
+                                            Processed = attachmentsProcessed,
+                                            Failed = attachmentsFailed,
+                                            TotalBytes = totalAttachmentBytes,
+                                            LastDownloadDurationMs = lastAttachmentDurationMs,
+                                            AverageDownloadDurationMs = attachmentsProcessed > 0 ? totalAttachmentDurationMs / attachmentsProcessed : 0,
+                                            LastSizeBytes = lastAttachmentBytes,
+                                            AverageSizeBytes = attachmentsProcessed > 0 ? totalAttachmentBytes / attachmentsProcessed : 0
+                                        }
+                                    }
+                                }
+                            }
+                        });
                     }
                 }
             }
@@ -667,5 +794,14 @@ public sealed class WorkItemExportOrchestrator
         var ticks = changedDate.Ticks.ToString("D20");
         return $"WorkItems/{date}/{ticks}-{workItemId}-{revisionIndex}/";
     }
+
+    private static string FormatBytes(long bytes) =>
+        bytes switch
+        {
+            >= 1_073_741_824 => $"{bytes / 1_073_741_824.0:F1} GB",
+            >= 1_048_576     => $"{bytes / 1_048_576.0:F1} MB",
+            >= 1_024         => $"{bytes / 1_024.0:F1} KB",
+            _                => $"{bytes} B"
+        };
 }
 

--- a/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
@@ -138,6 +138,7 @@ public sealed class WorkItemExportOrchestrator
         int lastWorkItemId = cursor?.LastWorkItemId ?? 0;
         double lastWorkItemDurationMs = 0;
         double totalWorkItemDurationMs = 0;
+        int lastCompletedRevisions = 0;
 
         // Determine total work items: use cached cursor value on resume, otherwise count via
         // discovery service. Counting happens here in the Agent — never in the CLI.
@@ -197,6 +198,10 @@ public sealed class WorkItemExportOrchestrator
 
         // Per-work-item timing for duration histogram.
         var workItemStopwatch = Stopwatch.StartNew();
+        // Per-revision timing so the CLI can show last/avg revision latency.
+        var revisionStopwatch = Stopwatch.StartNew();
+        double lastRevisionDurationMs = 0;
+        double totalRevisionDurationMs = 0;
         TagList exportTags = _metrics != null
             ? MigrationTagList.Create(_jobId ?? "not-set", "export", "workitems")
             : default;
@@ -316,6 +321,12 @@ public sealed class WorkItemExportOrchestrator
                 }
             }
 
+            // Capture revision duration before the WI-boundary check so it covers the
+            // full cost of writing revision.json + comments (but not attachments).
+            lastRevisionDurationMs = revisionStopwatch.Elapsed.TotalMilliseconds;
+            totalRevisionDurationMs += lastRevisionDurationMs;
+            revisionStopwatch.Restart();
+
             revisionsProcessed++;
 
             if (revision.WorkItemId != lastWorkItemId)
@@ -325,6 +336,7 @@ public sealed class WorkItemExportOrchestrator
                 {
                     lastWorkItemDurationMs = workItemStopwatch.Elapsed.TotalMilliseconds;
                     totalWorkItemDurationMs += lastWorkItemDurationMs;
+                    lastCompletedRevisions = revisionsForCurrentWorkItem;
                     if (_metrics != null)
                     {
                         _metrics.RecordWorkItemCompleted(exportTags);
@@ -373,7 +385,15 @@ public sealed class WorkItemExportOrchestrator
                                 LastWorkItemDurationMs = lastWorkItemDurationMs,
                                 AverageWorkItemDurationMs = workItemsProcessed > 1
                                     ? totalWorkItemDurationMs / (workItemsProcessed - 1)
-                                    : lastWorkItemDurationMs
+                                    : lastWorkItemDurationMs,
+                                LastWorkItemRevisions = lastCompletedRevisions,
+                                CurrentWorkItemId = revision.WorkItemId,
+                                CurrentWorkItemIndex = workItemsProcessed,
+                                CurrentWorkItemRevisionsWritten = revisionsForCurrentWorkItem,
+                                LastRevisionDurationMs = lastRevisionDurationMs,
+                                AverageRevisionDurationMs = revisionsProcessed > 0
+                                    ? totalRevisionDurationMs / revisionsProcessed
+                                    : lastRevisionDurationMs
                             }
                         }
                     }
@@ -382,6 +402,35 @@ public sealed class WorkItemExportOrchestrator
             else
             {
                 revisionsForCurrentWorkItem++;
+
+                // Emit a lightweight per-revision event so consumers can track intra-WI progress.
+                _progressSink?.Emit(new ProgressEvent
+                {
+                    Module = "WorkItems",
+                    Stage = "Export",
+                    Message = $"[WorkItems] WI {revision.WorkItemId} rev {revisionsForCurrentWorkItem}",
+                    LastCheckpointAt = DateTimeOffset.UtcNow,
+                    NextCheckpointDueAt = null,
+                    Metrics = new JobMetrics
+                    {
+                        Migration = new MigrationCounters
+                        {
+                            WorkItems = new WorkItemCounters
+                            {
+                                Completed = workItemsProcessed,
+                                RevisionsProcessed = revisionsProcessed,
+                                LastWorkItemRevisions = lastCompletedRevisions,
+                                CurrentWorkItemId = revision.WorkItemId,
+                                CurrentWorkItemIndex = workItemsProcessed,
+                                CurrentWorkItemRevisionsWritten = revisionsForCurrentWorkItem,
+                                LastRevisionDurationMs = lastRevisionDurationMs,
+                                AverageRevisionDurationMs = revisionsProcessed > 0
+                                    ? totalRevisionDurationMs / revisionsProcessed
+                                    : lastRevisionDurationMs
+                            }
+                        }
+                    }
+                });
             }
 
             // Write attachment binaries beside revision.json when a binary source is available.

--- a/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
@@ -136,6 +136,8 @@ public sealed class WorkItemExportOrchestrator
         int workItemsProcessed = cursor?.WorkItemsProcessed ?? 0;
         int revisionsProcessed = cursor?.RevisionsProcessed ?? 0;
         int lastWorkItemId = cursor?.LastWorkItemId ?? 0;
+        double lastWorkItemDurationMs = 0;
+        double totalWorkItemDurationMs = 0;
 
         // Determine total work items: use cached cursor value on resume, otherwise count via
         // discovery service. Counting happens here in the Agent — never in the CLI.
@@ -321,10 +323,12 @@ public sealed class WorkItemExportOrchestrator
                 // Record completion of the previous work item (if any).
                 if (lastWorkItemId != 0)
                 {
+                    lastWorkItemDurationMs = workItemStopwatch.Elapsed.TotalMilliseconds;
+                    totalWorkItemDurationMs += lastWorkItemDurationMs;
                     if (_metrics != null)
                     {
                         _metrics.RecordWorkItemCompleted(exportTags);
-                        _metrics.RecordWorkItemDuration(workItemStopwatch.Elapsed.TotalMilliseconds, exportTags);
+                        _metrics.RecordWorkItemDuration(lastWorkItemDurationMs, exportTags);
                         _metrics.RecordRevisionCount(revisionsForCurrentWorkItem, exportTags);
                         _metrics.DecrementInFlight(exportTags);
                     }
@@ -365,7 +369,11 @@ public sealed class WorkItemExportOrchestrator
                             WorkItems = new WorkItemCounters
                             {
                                 Completed = workItemsProcessed,
-                                RevisionsProcessed = revisionsProcessed
+                                RevisionsProcessed = revisionsProcessed,
+                                LastWorkItemDurationMs = lastWorkItemDurationMs,
+                                AverageWorkItemDurationMs = workItemsProcessed > 1
+                                    ? totalWorkItemDurationMs / (workItemsProcessed - 1)
+                                    : lastWorkItemDurationMs
                             }
                         }
                     }

--- a/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
@@ -110,17 +110,24 @@ public sealed class WorkItemExportOrchestrator
         if (_filterOptions is { Count: > 0 } && _fetchService != null && _endpoint != null &&
             !string.IsNullOrEmpty(_project))
         {
-            filteredIds = await BuildFilteredIdSetAsync(_filterOptions, cancellationToken)
-                .ConfigureAwait(false);
-
+            _logger?.LogInformation("[WorkItems] Starting pre-filter pass — fetching work items to evaluate {FilterCount} filter(s).", _filterOptions.Count);
             _progressSink?.Emit(new ProgressEvent
             {
                 Module = "WorkItems",
-                Stage = "Export",
-                Message = $"[WorkItems] Pre-filter pass complete: {filteredIds.Count} work items pass the configured filter(s)."
+                Stage = "Filtering",
+                Message = $"[WorkItems] Pre-filter pass starting — evaluating {_filterOptions.Count} filter(s)…"
             });
 
+            filteredIds = await BuildFilteredIdSetAsync(_filterOptions, cancellationToken)
+                .ConfigureAwait(false);
+
             _logger?.LogInformation("[WorkItems] Pre-filter pass complete: {FilteredCount} work items pass filters.", filteredIds.Count);
+            _progressSink?.Emit(new ProgressEvent
+            {
+                Module = "WorkItems",
+                Stage = "Filtering",
+                Message = $"[WorkItems] Pre-filter pass complete: {filteredIds.Count} work items pass the configured filter(s)."
+            });
         }
 
         var cursor = await _checkpointingService
@@ -128,9 +135,17 @@ public sealed class WorkItemExportOrchestrator
             .ConfigureAwait(false);
 
         if (cursor != null)
+        {
             _logger?.LogInformation(
                 "[WorkItems] Resuming export from cursor: {Cursor} (previously {WorkItemsProcessed} work items / {RevisionsProcessed} revisions)",
                 cursor.LastProcessed, cursor.WorkItemsProcessed, cursor.RevisionsProcessed);
+            _progressSink?.Emit(new ProgressEvent
+            {
+                Module = "WorkItems",
+                Stage = "Resuming",
+                Message = $"[WorkItems] Resuming from cursor — {cursor.WorkItemsProcessed} work items / {cursor.RevisionsProcessed} revisions already exported."
+            });
+        }
 
         // Seed counters from cursor so progress is accurate on resume.
         int workItemsProcessed = cursor?.WorkItemsProcessed ?? 0;
@@ -216,6 +231,8 @@ public sealed class WorkItemExportOrchestrator
 
         Activity? workItemActivity = null;
 
+        int resumeSkipLastWorkItemId = 0;
+
         await foreach (var revision in source.GetRevisionsAsync(cancellationToken))
         {
             var folderPath = BuildFolderPath(revision.WorkItemId, revision.RevisionIndex, revision.ChangedDate);
@@ -224,6 +241,30 @@ public sealed class WorkItemExportOrchestrator
             if (cursor != null &&
                 string.Compare(folderPath, cursor.LastProcessed, StringComparison.Ordinal) <= 0)
             {
+                // Emit a progress event each time we cross a new work item boundary during
+                // the skip phase so the CLI shows "Resuming…" activity rather than silence.
+                if (revision.WorkItemId != resumeSkipLastWorkItemId)
+                {
+                    resumeSkipLastWorkItemId = revision.WorkItemId;
+                    _progressSink?.Emit(new ProgressEvent
+                    {
+                        Module = "WorkItems",
+                        Stage = "Resuming",
+                        Message = $"[WorkItems] Resuming — skipping WI {revision.WorkItemId} (already exported)",
+                        Metrics = new JobMetrics
+                        {
+                            Scope = new JobScopeCounters { WorkItemsTotal = totalWorkItems },
+                            Migration = new MigrationCounters
+                            {
+                                WorkItems = new WorkItemCounters
+                                {
+                                    Completed = workItemsProcessed,
+                                    RevisionsProcessed = revisionsProcessed
+                                }
+                            }
+                        }
+                    });
+                }
                 continue;
             }
 
@@ -562,11 +603,25 @@ public sealed class WorkItemExportOrchestrator
         var scope = new WorkItemFetchScope(Fields: filterFields, FilterOptions: filterOptions);
 
         var orgEndpoint = _endpoint!.ToOrganisationEndpoint();
+        int fetched = 0;
 
         await foreach (var item in _fetchService!.FetchAsync(orgEndpoint, _project!, scope, cancellationToken)
             .ConfigureAwait(false))
         {
             ids.Add(item.Id);
+            fetched++;
+
+            // Emit progress every 500 items so the operator can see the fetch is alive.
+            if (fetched % 500 == 0)
+            {
+                _logger?.LogInformation("[WorkItems] Pre-filter pass: {Fetched} work items fetched so far…", fetched);
+                _progressSink?.Emit(new ProgressEvent
+                {
+                    Module = "WorkItems",
+                    Stage = "Filtering",
+                    Message = $"[WorkItems] Pre-filter pass: {fetched:N0} work items fetched so far…"
+                });
+            }
         }
 
         return ids;

--- a/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
@@ -167,24 +167,29 @@ public sealed class WorkItemExportOrchestrator
         }
 
         // Emit scope-resolved event so the CLI progress bar can set its total.
-        _progressSink?.Emit(new ProgressEvent
+        // Only emitted when we have a known total — avoids spurious events in tests
+        // and in partial setups where no discovery service is wired.
+        if (totalWorkItems > 0)
         {
-            Module = "WorkItems",
-            Stage = "ScopeResolved",
-            Message = $"[WorkItems] Scope resolved: {totalWorkItems:N0} work items",
-            Metrics = new JobMetrics
+            _progressSink?.Emit(new ProgressEvent
             {
-                Scope = new JobScopeCounters { WorkItemsTotal = totalWorkItems },
-                Migration = new MigrationCounters
+                Module = "WorkItems",
+                Stage = "ScopeResolved",
+                Message = $"[WorkItems] Scope resolved: {totalWorkItems:N0} work items",
+                Metrics = new JobMetrics
                 {
-                    WorkItems = new WorkItemCounters
+                    Scope = new JobScopeCounters { WorkItemsTotal = totalWorkItems },
+                    Migration = new MigrationCounters
                     {
-                        Completed = workItemsProcessed,
-                        RevisionsProcessed = revisionsProcessed
+                        WorkItems = new WorkItemCounters
+                        {
+                            Completed = workItemsProcessed,
+                            RevisionsProcessed = revisionsProcessed
+                        }
                     }
                 }
-            }
-        });
+            });
+        }
         int attachmentsProcessed = 0;
         int attachmentsFailed = 0;
 

--- a/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
@@ -294,7 +294,18 @@ public sealed class WorkItemExportOrchestrator
                     Stage = "Export",
                     Message = $"[WorkItems] {workItemsProcessed} work items / {revisionsProcessed} revisions written",
                     LastCheckpointAt = DateTimeOffset.UtcNow,
-                    NextCheckpointDueAt = null // per-revision checkpoint — always safe to cancel
+                    NextCheckpointDueAt = null, // per-revision checkpoint — always safe to cancel
+                    Metrics = new JobMetrics
+                    {
+                        Migration = new MigrationCounters
+                        {
+                            WorkItems = new WorkItemCounters
+                            {
+                                Completed = workItemsProcessed,
+                                RevisionsProcessed = revisionsProcessed
+                            }
+                        }
+                    }
                 });
             }
             else

--- a/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
@@ -237,6 +237,12 @@ public sealed class WorkItemExportOrchestrator
         Activity? workItemActivity = null;
 
         int resumeSkipLastWorkItemId = 0;
+        // Separate counter for fast-forwarded (already-exported) work items during resume.
+        // This is NOT part of workItemsProcessed (which counts exported items only).
+        int workItemsSkipped = 0;
+        // Separate counter for filter-excluded work items.
+        int workItemsFilterSkipped = 0;
+        string lastWorkItemStatus = string.Empty;
 
         await foreach (var revision in source.GetRevisionsAsync(cancellationToken))
         {
@@ -251,6 +257,8 @@ public sealed class WorkItemExportOrchestrator
                 if (revision.WorkItemId != resumeSkipLastWorkItemId)
                 {
                     resumeSkipLastWorkItemId = revision.WorkItemId;
+                    workItemsSkipped++;
+                    lastWorkItemStatus = "Skipped";
                     _progressSink?.Emit(new ProgressEvent
                     {
                         Module = "WorkItems",
@@ -264,7 +272,11 @@ public sealed class WorkItemExportOrchestrator
                                 WorkItems = new WorkItemCounters
                                 {
                                     Completed = workItemsProcessed,
-                                    RevisionsProcessed = revisionsProcessed
+                                    Skipped = workItemsSkipped,
+                                    RevisionsProcessed = revisionsProcessed,
+                                    CurrentWorkItemId = revision.WorkItemId,
+                                    LastWorkItemId = revision.WorkItemId,
+                                    LastWorkItemStatus = "Skipped"
                                 }
                             }
                         }
@@ -278,12 +290,29 @@ public sealed class WorkItemExportOrchestrator
             {
                 if (revision.RevisionIndex == 0)
                 {
-                    // Log once per work item (at the first revision we encounter for it).
+                    workItemsFilterSkipped++;
+                    lastWorkItemStatus = "Skipped";
                     _progressSink?.Emit(new ProgressEvent
                     {
                         Module = "WorkItems",
                         Stage = "Export",
-                        Message = $"[WorkItems] Work item {revision.WorkItemId} skipped by filter scope."
+                        Message = $"[WorkItems] Work item {revision.WorkItemId} skipped by filter scope.",
+                        Metrics = new JobMetrics
+                        {
+                            Scope = new JobScopeCounters { WorkItemsTotal = totalWorkItems },
+                            Migration = new MigrationCounters
+                            {
+                                WorkItems = new WorkItemCounters
+                                {
+                                    Completed = workItemsProcessed,
+                                    Skipped = workItemsSkipped + workItemsFilterSkipped,
+                                    RevisionsProcessed = revisionsProcessed,
+                                    CurrentWorkItemId = revision.WorkItemId,
+                                    LastWorkItemId = revision.WorkItemId,
+                                    LastWorkItemStatus = "Skipped"
+                                }
+                            }
+                        }
                     });
 
                     if (_logger != null)
@@ -407,6 +436,7 @@ public sealed class WorkItemExportOrchestrator
                 // Emit once per work item (not per revision) to avoid flooding the channel.
                 workItemsProcessed++;
                 lastWorkItemId = revision.WorkItemId;
+                lastWorkItemStatus = "Exported";
 
                 if (_logger != null)
                     _logger.LogInformation(
@@ -427,6 +457,7 @@ public sealed class WorkItemExportOrchestrator
                             WorkItems = new WorkItemCounters
                             {
                                 Completed = workItemsProcessed,
+                                Skipped = workItemsSkipped + workItemsFilterSkipped,
                                 RevisionsProcessed = revisionsProcessed,
                                 LastWorkItemDurationMs = lastWorkItemDurationMs,
                                 AverageWorkItemDurationMs = workItemsProcessed > 1
@@ -439,7 +470,9 @@ public sealed class WorkItemExportOrchestrator
                                 LastRevisionDurationMs = lastRevisionDurationMs,
                                 AverageRevisionDurationMs = revisionsProcessed > 0
                                     ? totalRevisionDurationMs / revisionsProcessed
-                                    : lastRevisionDurationMs
+                                    : lastRevisionDurationMs,
+                                LastWorkItemId = lastWorkItemId,
+                                LastWorkItemStatus = lastWorkItemStatus
                             }
                         }
                     }
@@ -464,6 +497,7 @@ public sealed class WorkItemExportOrchestrator
                             WorkItems = new WorkItemCounters
                             {
                                 Completed = workItemsProcessed,
+                                Skipped = workItemsSkipped + workItemsFilterSkipped,
                                 RevisionsProcessed = revisionsProcessed,
                                 LastWorkItemRevisions = lastCompletedRevisions,
                                 CurrentWorkItemId = revision.WorkItemId,
@@ -472,7 +506,9 @@ public sealed class WorkItemExportOrchestrator
                                 LastRevisionDurationMs = lastRevisionDurationMs,
                                 AverageRevisionDurationMs = revisionsProcessed > 0
                                     ? totalRevisionDurationMs / revisionsProcessed
-                                    : lastRevisionDurationMs
+                                    : lastRevisionDurationMs,
+                                LastWorkItemId = lastWorkItemId,
+                                LastWorkItemStatus = lastWorkItemStatus
                             }
                         }
                     }
@@ -799,9 +835,9 @@ public sealed class WorkItemExportOrchestrator
         bytes switch
         {
             >= 1_073_741_824 => $"{bytes / 1_073_741_824.0:F1} GB",
-            >= 1_048_576     => $"{bytes / 1_048_576.0:F1} MB",
-            >= 1_024         => $"{bytes / 1_024.0:F1} KB",
-            _                => $"{bytes} B"
+            >= 1_048_576 => $"{bytes / 1_048_576.0:F1} MB",
+            >= 1_024 => $"{bytes / 1_024.0:F1} KB",
+            _ => $"{bytes} B"
         };
 }
 

--- a/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Export/WorkItemExportOrchestrator.cs
@@ -50,11 +50,13 @@ public sealed class WorkItemExportOrchestrator
     private readonly IWorkItemCommentSourceFactory? _inlineCommentSourceFactory;
     private readonly MigrationEndpointOptions? _endpoint;
     private readonly string? _project;
+    private readonly string? _wiqlQuery;
     private readonly IWorkItemFetchService? _fetchService;
     private readonly IReadOnlyList<WorkItemFieldFilterOptions>? _filterOptions;
     private readonly IMigrationMetrics? _metrics;
     private readonly string? _jobId;
     private readonly ILogger? _logger;
+    private readonly IWorkItemDiscoveryService? _discoveryService;
 
     public WorkItemExportOrchestrator(
         IArtefactStore artefactStore,
@@ -68,7 +70,9 @@ public sealed class WorkItemExportOrchestrator
         IReadOnlyList<WorkItemFieldFilterOptions>? filterOptions = null,
         IMigrationMetrics? metrics = null,
         string? jobId = null,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        string? wiqlQuery = null,
+        IWorkItemDiscoveryService? discoveryService = null)
     {
         _artefactStore = artefactStore;
         _checkpointingService = checkpointingService;
@@ -77,11 +81,13 @@ public sealed class WorkItemExportOrchestrator
         _inlineCommentSourceFactory = inlineCommentSourceFactory;
         _endpoint = endpoint;
         _project = project;
+        _wiqlQuery = wiqlQuery;
         _fetchService = fetchService;
         _filterOptions = filterOptions;
         _metrics = metrics;
         _jobId = jobId;
         _logger = logger;
+        _discoveryService = discoveryService;
     }
 
     /// <summary>
@@ -122,11 +128,63 @@ public sealed class WorkItemExportOrchestrator
             .ConfigureAwait(false);
 
         if (cursor != null)
-            _logger?.LogInformation("[WorkItems] Resuming export from cursor: {Cursor}", cursor.LastProcessed);
+            _logger?.LogInformation(
+                "[WorkItems] Resuming export from cursor: {Cursor} (previously {WorkItemsProcessed} work items / {RevisionsProcessed} revisions)",
+                cursor.LastProcessed, cursor.WorkItemsProcessed, cursor.RevisionsProcessed);
 
-        int workItemsProcessed = 0;
-        int revisionsProcessed = 0;
-        int lastWorkItemId = 0;
+        // Seed counters from cursor so progress is accurate on resume.
+        int workItemsProcessed = cursor?.WorkItemsProcessed ?? 0;
+        int revisionsProcessed = cursor?.RevisionsProcessed ?? 0;
+        int lastWorkItemId = cursor?.LastWorkItemId ?? 0;
+
+        // Determine total work items: use cached cursor value on resume, otherwise count via
+        // discovery service. Counting happens here in the Agent — never in the CLI.
+        int totalWorkItems = 0;
+        if (cursor?.TotalWorkItems > 0)
+        {
+            totalWorkItems = cursor.TotalWorkItems;
+            _logger?.LogInformation("[WorkItems] Total work items (from cursor): {TotalWorkItems}", totalWorkItems);
+        }
+        else if (_discoveryService != null && _endpoint != null && !string.IsNullOrEmpty(_project))
+        {
+            _logger?.LogInformation("[WorkItems] Counting work items in scope…");
+            _progressSink?.Emit(new ProgressEvent
+            {
+                Module = "WorkItems",
+                Stage = "Counting",
+                Message = "[WorkItems] Counting work items in scope…"
+            });
+
+            await foreach (var snapshot in _discoveryService.CountWorkItemsAsync(
+                _endpoint.ToOrganisationEndpoint(), _project!, _wiqlQuery, cancellationToken)
+                .ConfigureAwait(false))
+            {
+                if (snapshot.IsWorkItemComplete)
+                    totalWorkItems = snapshot.WorkItemsCount;
+            }
+
+            _logger?.LogInformation("[WorkItems] Work items in scope: {TotalWorkItems}", totalWorkItems);
+        }
+
+        // Emit scope-resolved event so the CLI progress bar can set its total.
+        _progressSink?.Emit(new ProgressEvent
+        {
+            Module = "WorkItems",
+            Stage = "ScopeResolved",
+            Message = $"[WorkItems] Scope resolved: {totalWorkItems:N0} work items",
+            Metrics = new JobMetrics
+            {
+                Scope = new JobScopeCounters { WorkItemsTotal = totalWorkItems },
+                Migration = new MigrationCounters
+                {
+                    WorkItems = new WorkItemCounters
+                    {
+                        Completed = workItemsProcessed,
+                        RevisionsProcessed = revisionsProcessed
+                    }
+                }
+            }
+        });
         int attachmentsProcessed = 0;
         int attachmentsFailed = 0;
 
@@ -382,10 +440,18 @@ public sealed class WorkItemExportOrchestrator
             {
                 LastProcessed = folderPath,
                 Stage = CursorStage.Completed,
-                UpdatedAt = DateTimeOffset.UtcNow
+                UpdatedAt = DateTimeOffset.UtcNow,
+                WorkItemsProcessed = workItemsProcessed,
+                RevisionsProcessed = revisionsProcessed,
+                LastWorkItemId = lastWorkItemId,
+                TotalWorkItems = totalWorkItems
             };
+            // Use CancellationToken.None — the cursor write is critical safety state and
+            // must complete after a successful revision.json write even if the job is being
+            // cancelled. Using the job token here causes the write to be aborted on shutdown,
+            // leaving no cursor on disk and forcing the next run to start from the beginning.
             await _checkpointingService
-                .WriteCursorAsync("WorkItems", newCursor, cancellationToken)
+                .WriteCursorAsync("WorkItems", newCursor, CancellationToken.None)
                 .ConfigureAwait(false);
         }
 

--- a/src/DevOpsMigrationPlatform.Infrastructure/Modules/WorkItemsModule.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Modules/WorkItemsModule.cs
@@ -44,6 +44,7 @@ public sealed class WorkItemsModule : IModule
     private readonly ILogger<WorkItemImportOrchestrator> _orchestratorLogger;
     private readonly DevOpsMigrationPlatform.Abstractions.Services.IWorkItemFetchService? _fetchService;
     private readonly IMigrationMetrics? _metrics;
+    private readonly DevOpsMigrationPlatform.Abstractions.Services.IWorkItemDiscoveryService? _discoveryService;
 
     public WorkItemsModule(
         IWorkItemRevisionSourceFactory sourceFactory,
@@ -58,7 +59,8 @@ public sealed class WorkItemsModule : IModule
         IAttachmentBinarySource? attachmentBinarySource = null,
         IWorkItemCommentSourceFactory? inlineCommentSourceFactory = null,
         DevOpsMigrationPlatform.Abstractions.Services.IWorkItemFetchService? fetchService = null,
-        IMigrationMetrics? metrics = null)
+        IMigrationMetrics? metrics = null,
+        DevOpsMigrationPlatform.Abstractions.Services.IWorkItemDiscoveryService? discoveryService = null)
     {
         _sourceFactory = sourceFactory ?? throw new ArgumentNullException(nameof(sourceFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -73,6 +75,7 @@ public sealed class WorkItemsModule : IModule
         _inlineCommentSourceFactory = inlineCommentSourceFactory;
         _fetchService = fetchService;
         _metrics = metrics;
+        _discoveryService = discoveryService;
     }
 
     /// <inheritdoc/>
@@ -122,7 +125,9 @@ public sealed class WorkItemsModule : IModule
             filterOptions: allFilters.Count > 0 ? allFilters : null,
             metrics: _metrics,
             jobId: job.JobId,
-            logger: _logger);
+            logger: _logger,
+            wiqlQuery: ext.Query,
+            discoveryService: _discoveryService);
 
         await orchestrator.ExportAsync(source, ct).ConfigureAwait(false);
 

--- a/src/DevOpsMigrationPlatform.Infrastructure/Telemetry/MigrationMetrics.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure/Telemetry/MigrationMetrics.cs
@@ -24,6 +24,8 @@ internal sealed class MigrationMetrics : IMigrationMetrics, IDisposable
     // --- Payload / Complexity histograms ---
     private readonly Histogram<int> _fieldCount;
     private readonly Histogram<int> _attachmentCount;
+    private readonly Histogram<double> _attachmentDownloadDuration;
+    private readonly Histogram<long> _attachmentDownloadBytes;
     private readonly Histogram<int> _linkCount;
     private readonly Histogram<int> _revisionCount;
     private readonly Histogram<long> _payloadBytes;
@@ -61,6 +63,8 @@ internal sealed class MigrationMetrics : IMigrationMetrics, IDisposable
         // Payload
         _fieldCount = _meter.CreateHistogram<int>(WellKnownMetricNames.FieldCount, unit: "{field}");
         _attachmentCount = _meter.CreateHistogram<int>(WellKnownMetricNames.AttachmentCount, unit: "{attachment}");
+        _attachmentDownloadDuration = _meter.CreateHistogram<double>(WellKnownMetricNames.AttachmentDownloadDurationMs, unit: "ms");
+        _attachmentDownloadBytes = _meter.CreateHistogram<long>(WellKnownMetricNames.AttachmentDownloadBytes, unit: "By");
         _linkCount = _meter.CreateHistogram<int>(WellKnownMetricNames.LinkCount, unit: "{link}");
         _revisionCount = _meter.CreateHistogram<int>(WellKnownMetricNames.RevisionCount, unit: "{revision}");
         _payloadBytes = _meter.CreateHistogram<long>(WellKnownMetricNames.PayloadBytes, unit: "By");
@@ -95,6 +99,8 @@ internal sealed class MigrationMetrics : IMigrationMetrics, IDisposable
     // --- Payload ---
     public void RecordFieldCount(int count, in TagList tags) => _fieldCount.Record(count, tags);
     public void RecordAttachmentCount(int count, in TagList tags) => _attachmentCount.Record(count, tags);
+    public void RecordAttachmentDownloadDuration(double milliseconds, in TagList tags) => _attachmentDownloadDuration.Record(milliseconds, tags);
+    public void RecordAttachmentDownloadBytes(long bytes, in TagList tags) => _attachmentDownloadBytes.Record(bytes, tags);
     public void RecordLinkCount(int count, in TagList tags) => _linkCount.Record(count, tags);
     public void RecordRevisionCount(int count, in TagList tags) => _revisionCount.Record(count, tags);
     public void RecordPayloadBytes(long bytes, in TagList tags) => _payloadBytes.Record(bytes, tags);

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Export/WorkItemExportOrchestratorTests.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Export/WorkItemExportOrchestratorTests.cs
@@ -689,11 +689,14 @@ public class WorkItemExportOrchestratorTests
 
         await sut.ExportAsync(mockSource.Object, CancellationToken.None);
 
-        // One progress event per unique work item (not per revision).
-        // ProgressEvent is now a pure envelope — counters are in Message text.
-        Assert.AreEqual(2, progressEvents.Count, "Should emit one progress event per work item.");
-        Assert.IsTrue(progressEvents[0].Message?.Contains("1 work items") == true, "First event should reflect 1 work item.");
-        Assert.IsTrue(progressEvents[1].Message?.Contains("2 work items") == true, "Second event should reflect 2 work items.");
+        // One boundary event per unique work item (not per revision).
+        // Per-revision events are also emitted (for intra-WI progress); filter those out.
+        var boundaryEvents = progressEvents
+            .Where(e => e.Message?.Contains("work items") == true)
+            .ToList();
+        Assert.AreEqual(2, boundaryEvents.Count, "Should emit one boundary progress event per work item.");
+        Assert.IsTrue(boundaryEvents[0].Message?.Contains("1 work items") == true, "First event should reflect 1 work item.");
+        Assert.IsTrue(boundaryEvents[1].Message?.Contains("2 work items") == true, "Second event should reflect 2 work items.");
     }
 
     [TestMethod]

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Telemetry/WellKnownMetricNamesTests.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Tests/Telemetry/WellKnownMetricNamesTests.cs
@@ -79,8 +79,8 @@ public class WellKnownMetricNamesTests
     [TestMethod]
     public void ConstantCount_Matches24Instruments()
     {
-        // Per spec SC-001: 24 total instruments
-        Assert.AreEqual(24, AllConstants.Length,
-            $"Expected 24 metric name constants but found {AllConstants.Length}.");
+        // Per spec SC-001: 24 total instruments + 2 attachment download instruments added in export-fix
+        Assert.AreEqual(26, AllConstants.Length,
+            $"Expected 26 metric name constants but found {AllConstants.Length}.");
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jobs can resume from persisted progress (work items, revisions, last item, totals); pre-flight counting is no longer mandatory.
  * Progress events now include scope totals and per-work-item metrics (last and average durations) for improved live reporting.

* **Bug Fixes**
  * Harder Ctrl+C handling to avoid late-detach issues and clearer detach/cancel messaging.
  * Cursor checkpointing now forces completion to improve resume reliability.

* **Documentation**
  * Added architecture guidance clarifying component boundaries and recommended project organisation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->