### PR TITLE
Strengthen package validator safety net

### DIFF
--- a/.output/nkda-tddsn/agent_validation_safety/01-assessment.md
+++ b/.output/nkda-tddsn/agent_validation_safety/01-assessment.md
@@ -1,0 +1,278 @@
+# Assessment Report: agent_validation_safety
+
+## Scope
+
+Subsystem:
+  agent_validation_safety
+
+Analysed sources:
+  - `.agents/context/architecture/agent-validation-safety.md`
+  - `features/platform/validation/package-validation.feature`
+  - `src/DevOpsMigrationPlatform.Infrastructure.Agent/Validation/PackageValidator.cs`
+  - `src/DevOpsMigrationPlatform.Abstractions.Agent/Storage/IPackageValidator.cs`
+  - `src/DevOpsMigrationPlatform.Abstractions/Validation/ValidationResult.cs`
+  - `src/DevOpsMigrationPlatform.Abstractions/Validation/ValidationError.cs`
+  - `src/DevOpsMigrationPlatform.MigrationAgent/JobAgentWorker.cs`
+
+Analysed tests:
+  - `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Platform/PackageValidatorTests.cs`
+  - `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Platform/PackageValidationContext.cs`
+  - `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Platform/PackageValidationSteps.cs`
+  - `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/JobAgentWorkerDispatchTests.cs` (excluded from current test project compile)
+  - `tests/DevOpsMigrationPlatform.TfsMigrationAgent.Tests/TfsJobAgentWorkerTests.cs`
+
+Partial analysis warnings:
+  - `dotnet` is unavailable in this container, so current test execution evidence cannot be produced here.
+  - `JobAgentWorkerDispatchTests.cs` is explicitly removed from `DevOpsMigrationPlatform.Infrastructure.Agent.Tests.csproj`; worker dispatch assertions in that file are not active in this project.
+  - The architecture document names fail-fast worker behaviour, but the current discoverable production implementation does not inject or invoke `IPackageValidator` from `JobAgentWorker`; this report treats that as an architectural drift risk rather than inventing undocumented execution behaviour.
+
+## Behaviour Model
+
+Purpose:
+  Validate package invariants before/after execution and expose structured validation failures without mutating package content. Invalid package inputs must be rejected early so later migration phases do not process corrupted or incomplete data.
+
+Primary behaviours:
+  B1. A package with a supported manifest schema version and valid WorkItems `revision.json` files returns `ValidationResult.Ok()`.
+  B2. Missing, malformed, or unsupported `manifest.json` content returns `ValidationResult.Fail()` with an error path of `manifest.json`.
+  B3. Each enumerated WorkItems `revision.json` file must be readable JSON and contain every required revision field.
+  B4. Invalid revisions return path-specific `ValidationError` entries that identify the offending file and missing/invalid content.
+  B5. Non-`revision.json` WorkItems artefacts are outside the current `PackageValidator` contract and are ignored.
+  B6. Validation is read-only: no writes, binary writes, stream writes, appends, target calls, or package side effects.
+  B7. Pre-import fail-fast orchestration is intended by feature/docs, but is not currently active in the compiled worker surface inspected here.
+
+State transitions:
+  S1. Valid package -> `Passed = true`, `Errors = []`.
+  S2. Any manifest or revision error -> `Passed = false`, `Errors = validation errors`.
+  S3. Failed pre-import validation -> intended orchestration status `ValidationFailed`; current active worker code requires follow-up verification/implementation.
+
+External contracts:
+  C1. `IPackageValidator.ValidateAsync(CancellationToken)` returns `ValidationResult`.
+  C2. `IArtefactStore.ReadAsync` is used for package reads.
+  C3. `IArtefactStore.EnumerateAsync("WorkItems/", cancellationToken)` is used to stream candidate revision paths.
+  C4. `ValidationError.Path` is package-relative.
+  C5. `ValidationError.Message` identifies missing fields, invalid JSON, unsupported schemas, or missing files.
+
+Failure and rejection behaviours:
+  F1. Missing manifest is rejected as `manifest.json not found.`.
+  F2. Missing manifest `schemaVersion` is rejected.
+  F3. Unsupported schema version is rejected.
+  F4. Invalid JSON in manifest or revision is rejected.
+  F5. Enumerated revision path that cannot be read is rejected as `File not found.`.
+  F6. Missing required revision fields are rejected.
+
+Boundary conditions:
+  E1. Empty WorkItems folder with valid manifest currently passes because no revision files are enumerated.
+  E2. Only paths ending with `revision.json` are inspected.
+  E3. Path casing for `revision.json` is case-insensitive.
+  E4. Validation reports one missing field per invalid revision because `ValidateRevisionAsync` returns on first missing required field.
+
+Drift risks:
+  D1. Tests using real filesystem can drift into integration behaviour and violate unit-test guardrails.
+  D2. Missing schemaVersion, invalid manifest JSON, unreadable enumerated paths, multiple invalid revisions, and ignored non-revision artefacts were not explicitly covered by plain unit tests.
+  D3. Feature-level steps contain simulated orchestration for pre-import fail-fast, not compiled production worker verification.
+  D4. Architecture docs mention fail-fast worker behaviour that is not evident in current active `JobAgentWorker` dependencies.
+  D5. Package guardrails mention richer pre-flight/post-flight validation than the current `PackageValidator` implementation provides; this is out of scope for the minimal safety-net rebuild but should remain visible.
+
+## Current Test Inventory
+
+| Test | Type | Behaviour Protected | Score | Classification | Action |
+|------|------|---------------------|-------|----------------|--------|
+| `PackageValidatorTests.ValidateAsync_WellFormedPackage_ReturnsPassed` | Unit with real filesystem | Valid package passes | 28/36 | Partial | Rewrite to in-memory fake |
+| `PackageValidatorTests.ValidateAsync_MissingManifest_ReturnsFailed` | Unit with real filesystem | Missing manifest rejects | 27/36 | Partial | Rewrite |
+| `PackageValidatorTests.ValidateAsync_UnsupportedSchemaVersion_ReturnsFailed` | Unit with real filesystem | Unsupported schema rejects | 27/36 | Partial | Rewrite |
+| `PackageValidatorTests.ValidateAsync_RevisionMissingWorkItemId_ReturnsFailed` | Unit with real filesystem | Required revision field rejects | 27/36 | Partial | Rewrite |
+| `PackageValidatorTests.ValidateAsync_InvalidJson_ReturnsFailed` | Unit with real filesystem | Invalid revision JSON rejects | 27/36 | Partial | Rewrite/rename for precision |
+| `PackageValidatorTests.ValidateAsync_IsReadOnly_NoFilesCreated` | Unit with real filesystem | No file count side effects | 24/36 | Weak | Rewrite to assert no `IArtefactStore` writes/appends |
+| `PackageValidationSteps` scenarios | Feature step definitions | Gherkin behaviour examples | 20/36 | Weak | Keep as feature mapping but do not rely on simulated orchestration as unit proof |
+| `JobAgentWorkerDispatchTests` validation references | Excluded unit tests | Intended worker dispatch/fail-fast | 8/36 | Failing/inactive | Follow-up; not rebuilt in this pass |
+
+## Detailed Scoring
+
+### PackageValidatorTests.ValidateAsync_WellFormedPackage_ReturnsPassed
+
+Type:
+  Unit test with real filesystem dependency
+
+Protects:
+  Valid manifest and valid revision produce a passed result.
+
+Scores:
+  Behaviour Focus: 3 | Directly checks validator contract.
+  Small and Focused: 3 | Single behaviour.
+  Readable as Example: 3 | Inputs are visible.
+  Fails for Right Reason: 2 | Could fail due filesystem setup/cleanup rather than validator logic.
+  Deterministic: 2 | Temp filesystem dependency is usually deterministic but unnecessary.
+  Fast for Type: 2 | Real I/O is slower than needed.
+  Independent: 3 | Uses unique temp directory.
+  Clear Name: 3 | Name follows convention.
+  Meaningful Example: 3 | Valid package sample is concrete.
+  Minimises Mocking: 2 | Uses real infrastructure rather than fake store.
+  Drives Design Pressure: 1 | Does not pressure `IArtefactStore` read-only boundary.
+  Asserts Outcomes, State, or Contracts: 1 | Only result; no store interaction contract.
+
+Total:
+  28/36
+
+Classification:
+  Partial
+
+Recommended action:
+  rewrite
+
+### PackageValidatorTests.ValidateAsync_IsReadOnly_NoFilesCreated
+
+Type:
+  Unit test with real filesystem dependency
+
+Protects:
+  Validator does not create additional files.
+
+Scores:
+  Behaviour Focus: 2 | Targets read-only property but only file count.
+  Small and Focused: 2 | Includes setup and filesystem counting.
+  Readable as Example: 2 | Intent is clear but implementation-centric.
+  Fails for Right Reason: 1 | A rewrite of existing file content could pass.
+  Deterministic: 2 | Real filesystem dependency.
+  Fast for Type: 1 | I/O-heavy for unit contract.
+  Independent: 3 | Temp folder isolation.
+  Clear Name: 2 | Says no files created, not no writes.
+  Meaningful Example: 2 | Valid package sample.
+  Minimises Mocking: 1 | Real store hides interaction contract.
+  Drives Design Pressure: 2 | Some read-only pressure.
+  Asserts Outcomes, State, or Contracts: 1 | Only file count is asserted, so existing-file writes could go undetected.
+
+Total:
+  21/36
+
+Classification:
+  Weak
+
+Recommended action:
+  rewrite
+
+## Drift Risk Map
+
+### D1: Unit tests drift into filesystem integration tests
+
+Behaviour:
+  Package validation should be testable through `IArtefactStore` without direct filesystem dependency.
+
+Current protection:
+  weak
+
+Why drift can occur:
+  File count assertions can miss writes to existing files and make tests slower/flakier than necessary.
+
+Proposed protection:
+  - `ValidateAsync_IsReadOnly_NoPackageWritesPerformed`
+
+Priority:
+  high
+
+### D2: Manifest boundary errors not fully protected
+
+Behaviour:
+  Manifest must exist, parse, and contain supported `schemaVersion`.
+
+Current protection:
+  partial
+
+Why drift can occur:
+  Missing `schemaVersion` and malformed manifest JSON were not directly protected by plain unit tests.
+
+Proposed protection:
+  - `ValidateAsync_MissingSchemaVersion_ReturnsFailed`
+  - `ValidateAsync_InvalidManifestJson_ReturnsManifestError`
+
+Priority:
+  high
+
+### D3: Revision enumeration/read boundaries not fully protected
+
+Behaviour:
+  Every enumerated `revision.json` path must be checked and invalid revisions reported.
+
+Current protection:
+  partial
+
+Why drift can occur:
+  Tests did not cover an enumerated path whose read returns null, multiple invalid revisions, or non-revision artefact filtering.
+
+Proposed protection:
+  - `ValidateAsync_RevisionListedButUnreadable_ReturnsFileNotFoundErrorForListedPath`
+  - `ValidateAsync_MultipleInvalidRevisionFiles_ReturnsErrorForEachInvalidRevision`
+  - `ValidateAsync_NonRevisionWorkItemsArtefact_IsIgnored`
+
+Priority:
+  high
+
+### D4: Intended fail-fast worker orchestration is not actively protected
+
+Behaviour:
+  Import should not begin when pre-import validation fails.
+
+Current protection:
+  weak/inactive
+
+Why drift can occur:
+  Feature steps simulate the validator result, and `JobAgentWorkerDispatchTests.cs` is excluded from the infrastructure agent test project.
+
+Proposed protection:
+  - Follow-up worker-level target test after confirming intended production seam for `IPackageValidator`.
+
+Priority:
+  critical follow-up
+
+## Gap Map
+
+| Behaviour / Risk | Existing Protection | Missing Tests | Priority |
+|------------------|--------------------|---------------|----------|
+| Valid package passes | partial | rewritten in-memory test | high |
+| Missing manifest rejects | partial | rewritten in-memory test | high |
+| Unsupported schema rejects | partial | rewritten in-memory test | high |
+| Missing schemaVersion rejects | none | `ValidateAsync_MissingSchemaVersion_ReturnsFailed` | high |
+| Invalid manifest JSON rejects | none | `ValidateAsync_InvalidManifestJson_ReturnsManifestError` | high |
+| Missing revision field rejects | partial | rewritten in-memory test | high |
+| Invalid revision JSON rejects | partial | renamed/revised in-memory test | high |
+| Enumerated unreadable revision rejects | none | `ValidateAsync_RevisionListedButUnreadable_ReturnsFileNotFoundErrorForListedPath` | high |
+| Multiple invalid revisions all reported | none | `ValidateAsync_MultipleInvalidRevisionFiles_ReturnsErrorForEachInvalidRevision` | high |
+| Non-revision artefacts ignored | none | `ValidateAsync_NonRevisionWorkItemsArtefact_IsIgnored` | medium |
+| Read-only behaviour | weak | `ValidateAsync_IsReadOnly_NoPackageWritesPerformed` | high |
+| Worker fail-fast orchestration | weak/inactive | follow-up worker test | critical follow-up |
+
+## Design Feedback
+
+Issue: The current `PackageValidator` is cohesive and testable through `IArtefactStore`, but the broader fail-fast orchestration described by docs is not connected to the active worker dependency graph inspected here.
+
+Evidence: `PackageValidator` implements `IPackageValidator`; search of active worker code did not reveal injection/use of `IPackageValidator` in `JobAgentWorker`.
+
+Impact on tests: Unit tests can stabilize validator invariants now. Worker fail-fast should not be faked in validator unit tests; it needs a separate orchestration seam.
+
+Recommended seam: Add an explicit pre-import validation dependency to the worker or phase orchestration layer, then test terminal fail signalling and skipped import execution through active compiled tests.
+
+Proposed first test after seam: `OnJobAsync_Migrate_WhenPreImportValidationFails_SignalsFailAndDoesNotExecuteImportPhase`.
+
+## Summary
+
+Keep:
+  - Core `PackageValidator` production implementation in this pass.
+
+Rewrite:
+  - All plain `PackageValidatorTests` to use an in-memory `IArtefactStore` fake.
+  - Read-only test to assert no store write/append methods are called.
+
+Delete:
+  - Filesystem setup/cleanup from validator unit tests.
+
+Add:
+  - Missing schema version test.
+  - Invalid manifest JSON test.
+  - Enumerated unreadable revision test.
+  - Multiple invalid revisions test.
+  - Non-revision artefact ignored test.
+
+Highest risk missing protection:
+  - Worker-level pre-import fail-fast orchestration remains unverified by active compiled tests.
+
+Next best action:
+  - Implement the in-memory validator unit test rebuild now, then open a follow-up for worker fail-fast orchestration once the intended seam is confirmed.

--- a/.output/nkda-tddsn/agent_validation_safety/02-target-test-suite.md
+++ b/.output/nkda-tddsn/agent_validation_safety/02-target-test-suite.md
@@ -1,0 +1,115 @@
+# Target Test Suite: agent_validation_safety
+
+## Proposed Test Classes
+
+### `PackageValidatorTests`
+
+1. `ValidateAsync_WellFormedPackage_ReturnsPassed`
+   Type: Unit
+   Status: rewrite
+   Protects: Valid manifest and revision produce passed validation.
+   Expected assertions:
+   - `Passed` is true.
+   - Error count is zero.
+
+2. `ValidateAsync_MissingManifest_ReturnsFailed`
+   Type: Unit
+   Status: rewrite
+   Protects: Missing `manifest.json` fails validation.
+   Expected assertions:
+   - `Passed` is false.
+   - First error message mentions not found.
+
+3. `ValidateAsync_UnsupportedSchemaVersion_ReturnsFailed`
+   Type: Unit
+   Status: rewrite
+   Protects: Unsupported schema versions fail validation.
+   Expected assertions:
+   - `Passed` is false.
+   - Error message mentions unsupported schema version.
+
+4. `ValidateAsync_MissingSchemaVersion_ReturnsFailed`
+   Type: Unit
+   Status: add
+   Protects: Manifest without `schemaVersion` fails validation.
+   Expected assertions:
+   - `Passed` is false.
+   - Error path is `manifest.json`.
+   - Error message mentions `schemaVersion`.
+
+5. `ValidateAsync_InvalidManifestJson_ReturnsManifestError`
+   Type: Unit
+   Status: add
+   Protects: Malformed manifest JSON is reported as a manifest error.
+   Expected assertions:
+   - `Passed` is false.
+   - An error exists for `manifest.json` with `Invalid JSON` in the message.
+
+6. `ValidateAsync_RevisionMissingWorkItemId_ReturnsFailed`
+   Type: Unit
+   Status: rewrite
+   Protects: Required revision fields are enforced.
+   Expected assertions:
+   - `Passed` is false.
+   - Error message mentions `workItemId`.
+
+7. `ValidateAsync_InvalidRevisionJson_ReturnsFailed`
+   Type: Unit
+   Status: rewrite/rename from generic invalid JSON test
+   Protects: Malformed revision JSON fails validation.
+   Expected assertions:
+   - `Passed` is false.
+   - Error message mentions `Invalid JSON`.
+
+8. `ValidateAsync_RevisionListedButUnreadable_ReturnsFileNotFoundErrorForListedPath`
+   Type: Unit
+   Status: add
+   Protects: Enumerated revision paths that cannot be read are rejected.
+   Expected assertions:
+   - `Passed` is false.
+   - Error path equals the enumerated path.
+   - Error message is `File not found.`.
+
+9. `ValidateAsync_MultipleInvalidRevisionFiles_ReturnsErrorForEachInvalidRevision`
+   Type: Unit
+   Status: add
+   Protects: Validation does not stop after the first invalid revision.
+   Expected assertions:
+   - `Passed` is false.
+   - Error count is 2.
+   - One error mentions invalid JSON.
+   - One error mentions missing `revisionIndex`.
+
+10. `ValidateAsync_NonRevisionWorkItemsArtefact_IsIgnored`
+    Type: Unit
+    Status: add
+    Protects: Current validator scope only inspects `revision.json` files.
+    Expected assertions:
+    - `Passed` is true when non-revision WorkItems artefact is malformed but revision is valid.
+
+11. `ValidateAsync_IsReadOnly_NoPackageWritesPerformed`
+    Type: Unit
+    Status: rewrite
+    Protects: Validation is read-only through the package abstraction.
+    Expected assertions:
+    - No `WriteAsync` calls.
+    - No `WriteBinaryAsync` calls.
+    - No `WriteStreamAsync` calls.
+    - No `AppendAsync` calls.
+
+## Existing Test Decisions
+
+| Existing Test | Decision | Reason |
+| ------------- | -------- | ------ |
+| `ValidateAsync_WellFormedPackage_ReturnsPassed` | Rewrite | Replace filesystem with in-memory store. |
+| `ValidateAsync_MissingManifest_ReturnsFailed` | Rewrite | Replace filesystem with in-memory store. |
+| `ValidateAsync_UnsupportedSchemaVersion_ReturnsFailed` | Rewrite | Replace filesystem with in-memory store. |
+| `ValidateAsync_RevisionMissingWorkItemId_ReturnsFailed` | Rewrite | Replace filesystem with in-memory store. |
+| `ValidateAsync_InvalidJson_ReturnsFailed` | Rewrite/rename | Clarify that the invalid JSON is a revision file. |
+| `ValidateAsync_IsReadOnly_NoFilesCreated` | Rewrite | File count is weaker than asserting no package write methods. |
+| `PackageValidationSteps` | Keep | Feature mapping remains useful but not sufficient unit proof. |
+| Worker fail-fast tests | Defer | Current active seam is unclear; follow-up required. |
+
+## Target Suite Gate Status
+
+Passed for the PackageValidator unit-test rebuild: every target test has a name, type, protected behaviour, and expected assertion. Worker-level fail-fast remains a documented follow-up outside the minimal validator rebuild.

--- a/.output/nkda-tddsn/agent_validation_safety/03-architecture-update.md
+++ b/.output/nkda-tddsn/agent_validation_safety/03-architecture-update.md
@@ -1,0 +1,41 @@
+# Architecture Update: agent_validation_safety
+
+## Current Architecture Narrative
+
+`agent_validation_safety` is centered on a small validation port and implementation:
+
+- `IPackageValidator` exposes `ValidateAsync(CancellationToken)`.
+- `PackageValidator` reads package artefacts through `IArtefactStore`.
+- `ValidationResult` and `ValidationError` carry the validation outcome and package-relative failure details.
+- The validator is read-only and does not call target APIs.
+
+The subsystem documentation also describes intended fail-fast orchestration through the migration worker: invalid validation results should emit failure progress and signal the control plane lease as failed before import begins.
+
+## Architecture Alignment From This Rebuild
+
+The rebuilt unit tests deepen the hexagonal boundary around `PackageValidator` by replacing direct filesystem use with an in-memory `IArtefactStore` fake. This keeps package validation tests at the unit layer and verifies the validator through its package port instead of an infrastructure store implementation.
+
+No production architecture change was required for the PackageValidator behaviours covered by the target suite.
+
+## Documentation Change Decision
+
+No canonical architecture document was changed in this pass because the existing `.agents/context/architecture/agent-validation-safety.md` already states the intended responsibility and sequence. The report records a drift risk instead: worker-level fail-fast orchestration is documented but not verified by active compiled tests and was not changed without a confirmed production seam.
+
+## Proposed Follow-Up Architecture Clarification
+
+Clarify whether pre-import and post-import validation are owned by:
+
+1. `JobAgentWorker` directly,
+2. `ModulePipelineWorkerBase`,
+3. `JobPlanExecutor`, or
+4. a dedicated validation orchestration service.
+
+Once the owner is confirmed, add an explicit dependency on `IPackageValidator` in that layer and protect it with an active test that proves failed validation prevents import execution and signals terminal failure to the control plane.
+
+## Guardrail Alignment
+
+- Clean Architecture: validator tests now depend on `IArtefactStore`, not `FileSystemArtefactStore`.
+- Hexagonal Architecture: package storage remains a port boundary.
+- Testing Rules: validator logic is protected by unit tests rather than real I/O.
+- Package Rules: validator remains read-only and package-relative.
+- Observability: no new telemetry was added; the rebuild only changes tests.

--- a/.output/nkda-tddsn/agent_validation_safety/04-rebuild-plan.md
+++ b/.output/nkda-tddsn/agent_validation_safety/04-rebuild-plan.md
@@ -1,0 +1,44 @@
+# Rebuild Plan: agent_validation_safety
+
+## Priority 1: Stop critical validator drift
+
+* Replace filesystem-backed `PackageValidatorTests` setup with an in-memory `IArtefactStore` fake.
+* Preserve tests for valid package, missing manifest, unsupported schema, missing revision field, invalid revision JSON, and read-only behaviour.
+
+Stopping point:
+* Existing validator tests are expressed through the package port and no longer require temp filesystem setup.
+
+## Priority 2: Add missing manifest boundary protection
+
+* Add `ValidateAsync_MissingSchemaVersion_ReturnsFailed`.
+* Add `ValidateAsync_InvalidManifestJson_ReturnsManifestError`.
+
+Stopping point:
+* Manifest existence, parseability, and schema support are all protected by unit tests.
+
+## Priority 3: Add missing revision enumeration protection
+
+* Add `ValidateAsync_RevisionListedButUnreadable_ReturnsFileNotFoundErrorForListedPath`.
+* Add `ValidateAsync_MultipleInvalidRevisionFiles_ReturnsErrorForEachInvalidRevision`.
+* Add `ValidateAsync_NonRevisionWorkItemsArtefact_IsIgnored`.
+
+Stopping point:
+* Revision path enumeration, unreadable listed paths, multi-error accumulation, and non-revision filtering are protected.
+
+## Priority 4: Strengthen read-only contract
+
+* Replace file-count assertion with interaction counters on the in-memory store.
+* Assert no `WriteAsync`, `WriteBinaryAsync`, `WriteStreamAsync`, or `AppendAsync` calls occur during validation.
+
+Stopping point:
+* The validator read-only contract is tested through the abstraction it actually uses.
+
+## Priority 5: Follow-up outside this minimal rebuild
+
+* Confirm the intended pre-import fail-fast seam.
+* Add active worker/orchestrator tests for failed validation preventing import execution.
+* Implement minimal production wiring only after a failing target test exists.
+
+Minimal Change Gate:
+* No production code change is required for the PackageValidator target suite because current implementation already satisfies the newly specified validator behaviours by inspection.
+* Production code changes for worker fail-fast are explicitly deferred until the orchestration seam is confirmed and protected by a failing test.

--- a/.output/nkda-tddsn/agent_validation_safety/05-implementation-summary.md
+++ b/.output/nkda-tddsn/agent_validation_safety/05-implementation-summary.md
@@ -1,0 +1,43 @@
+# Implementation Summary: agent_validation_safety
+
+## Changes Made
+
+- Rebuilt `PackageValidatorTests` to use an in-memory `IArtefactStore` fake instead of `FileSystemArtefactStore` and temp directories.
+- Added manifest boundary tests for missing `schemaVersion` and invalid manifest JSON.
+- Added revision enumeration boundary tests for unreadable listed revision paths, multiple invalid revision files, and malformed non-revision WorkItems artefacts being ignored.
+- Replaced read-only file-count checking with explicit verification that no package write/append methods are invoked.
+- Left `PackageValidator` production code unchanged because the target validator behaviours are already satisfied by the implementation.
+
+## Minimal Production Code Change Gate
+
+No production code changes were made.
+
+Reason:
+- The implemented target tests exercise existing `PackageValidator` behaviours through a stronger unit seam.
+- The broader worker fail-fast behaviour is documented as a follow-up because implementing it without a confirmed seam would expand scope beyond the subsystem rebuild.
+
+## Target Tests Implemented
+
+| Target Test | Status | Evidence |
+| ----------- | ------ | -------- |
+| `ValidateAsync_WellFormedPackage_ReturnsPassed` | Implemented | Rewritten in `PackageValidatorTests`. |
+| `ValidateAsync_MissingManifest_ReturnsFailed` | Implemented | Rewritten in `PackageValidatorTests`. |
+| `ValidateAsync_UnsupportedSchemaVersion_ReturnsFailed` | Implemented | Rewritten in `PackageValidatorTests`. |
+| `ValidateAsync_MissingSchemaVersion_ReturnsFailed` | Implemented | Added to `PackageValidatorTests`. |
+| `ValidateAsync_InvalidManifestJson_ReturnsManifestError` | Implemented | Added to `PackageValidatorTests`. |
+| `ValidateAsync_RevisionMissingWorkItemId_ReturnsFailed` | Implemented | Rewritten in `PackageValidatorTests`. |
+| `ValidateAsync_InvalidRevisionJson_ReturnsFailed` | Implemented | Rewritten/renamed in `PackageValidatorTests`. |
+| `ValidateAsync_RevisionListedButUnreadable_ReturnsFileNotFoundErrorForListedPath` | Implemented | Added to `PackageValidatorTests`. |
+| `ValidateAsync_MultipleInvalidRevisionFiles_ReturnsErrorForEachInvalidRevision` | Implemented | Added to `PackageValidatorTests`. |
+| `ValidateAsync_NonRevisionWorkItemsArtefact_IsIgnored` | Implemented | Added to `PackageValidatorTests`. |
+| `ValidateAsync_IsReadOnly_NoPackageWritesPerformed` | Implemented | Rewritten in `PackageValidatorTests`. |
+
+## Files Changed
+
+- `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Platform/PackageValidatorTests.cs`
+- `.output/nkda-tddsn/agent_validation_safety/01-assessment.md`
+- `.output/nkda-tddsn/agent_validation_safety/02-target-test-suite.md`
+- `.output/nkda-tddsn/agent_validation_safety/03-architecture-update.md`
+- `.output/nkda-tddsn/agent_validation_safety/04-rebuild-plan.md`
+- `.output/nkda-tddsn/agent_validation_safety/05-implementation-summary.md`
+- `.output/nkda-tddsn/agent_validation_safety/06-verification.md`

--- a/.output/nkda-tddsn/agent_validation_safety/06-verification.md
+++ b/.output/nkda-tddsn/agent_validation_safety/06-verification.md
@@ -1,0 +1,56 @@
+# Verification Report: agent_validation_safety
+
+## Test Command
+
+```powershell
+dotnet test tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests.csproj --filter FullyQualifiedName~PackageValidatorTests --no-restore
+```
+
+## Test Result
+
+Warning / environment limitation: `dotnet` is not installed in this container. PowerShell returned:
+
+```text
+dotnet: The term 'dotnet' is not recognized as a name of a cmdlet, function, script file, or executable program.
+```
+
+Because the SDK is unavailable, test execution could not be completed here. The code and test changes were still reviewed for target-suite coverage and guardrail alignment.
+
+## Target Suite Coverage
+
+| Target Test | Status | Evidence |
+| ----------- | ------ | -------- |
+| `ValidateAsync_WellFormedPackage_ReturnsPassed` | Implemented | Present in `PackageValidatorTests`. |
+| `ValidateAsync_MissingManifest_ReturnsFailed` | Implemented | Present in `PackageValidatorTests`. |
+| `ValidateAsync_UnsupportedSchemaVersion_ReturnsFailed` | Implemented | Present in `PackageValidatorTests`. |
+| `ValidateAsync_MissingSchemaVersion_ReturnsFailed` | Implemented | Present in `PackageValidatorTests`. |
+| `ValidateAsync_InvalidManifestJson_ReturnsManifestError` | Implemented | Present in `PackageValidatorTests`. |
+| `ValidateAsync_RevisionMissingWorkItemId_ReturnsFailed` | Implemented | Present in `PackageValidatorTests`. |
+| `ValidateAsync_InvalidRevisionJson_ReturnsFailed` | Implemented | Present in `PackageValidatorTests`. |
+| `ValidateAsync_RevisionListedButUnreadable_ReturnsFileNotFoundErrorForListedPath` | Implemented | Present in `PackageValidatorTests`. |
+| `ValidateAsync_MultipleInvalidRevisionFiles_ReturnsErrorForEachInvalidRevision` | Implemented | Present in `PackageValidatorTests`. |
+| `ValidateAsync_NonRevisionWorkItemsArtefact_IsIgnored` | Implemented | Present in `PackageValidatorTests`. |
+| `ValidateAsync_IsReadOnly_NoPackageWritesPerformed` | Implemented | Present in `PackageValidatorTests`. |
+
+## Guardrail Review
+
+* testing rules: Improved alignment by removing real filesystem use from validator unit tests and using a fake `IArtefactStore` instead.
+* coding standards: SPDX headers retained; no try/catch imports added.
+* architecture boundaries: Tests target the package storage port rather than a concrete filesystem adapter.
+* observability requirements: No production observability behaviour changed.
+* definition of done: Target-suite coverage is implemented, but executable verification is partial because `dotnet` is unavailable.
+
+## Remaining Drift Risks
+
+* Worker-level pre-import fail-fast orchestration remains unverified by active compiled tests.
+* Package pre-flight/post-flight validation requirements in package guardrails are broader than current `PackageValidator` implementation.
+* Test execution must be rerun in an environment with the .NET SDK installed.
+
+## Final Classification
+
+partial
+
+## Required Follow-Up
+
+* Run the targeted `dotnet test` command in an SDK-enabled environment.
+* Confirm and implement the worker/orchestrator seam for pre-import validation fail-fast behaviour.

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Platform/PackageValidatorTests.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Platform/PackageValidatorTests.cs
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (c) Naked Agility Limited
 
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using DevOpsMigrationPlatform.Infrastructure.Agent.Storage;
+using DevOpsMigrationPlatform.Abstractions.Agent.Storage;
 using DevOpsMigrationPlatform.Infrastructure.Agent.Validation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -13,8 +16,7 @@ namespace DevOpsMigrationPlatform.Infrastructure.Tests.Platform;
 [TestClass]
 public class PackageValidatorTests
 {
-    private string _storeDir = null!;
-    private FileSystemArtefactStore _store = null!;
+    private InMemoryArtefactStore _store = null!;
     private PackageValidator _sut = null!;
 
     private const string ValidManifest = """{"schemaVersion":"1.0"}""";
@@ -23,30 +25,15 @@ public class PackageValidatorTests
     [TestInitialize]
     public void Setup()
     {
-        _storeDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        Directory.CreateDirectory(_storeDir);
-        _store = new FileSystemArtefactStore(_storeDir);
+        _store = new InMemoryArtefactStore();
         _sut = new PackageValidator(_store);
-    }
-
-    [TestCleanup]
-    public void Cleanup()
-    {
-        if (Directory.Exists(_storeDir)) Directory.Delete(_storeDir, recursive: true);
-    }
-
-    private void Write(string path, string content)
-    {
-        var full = System.IO.Path.Combine(_storeDir, path.Replace('/', System.IO.Path.DirectorySeparatorChar));
-        System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(full)!);
-        System.IO.File.WriteAllText(full, content);
     }
 
     [TestMethod]
     public async Task ValidateAsync_WellFormedPackage_ReturnsPassed()
     {
-        Write("manifest.json", ValidManifest);
-        Write("WorkItems/2024-01-01/00000000000000000001-1-0/revision.json", ValidRevision);
+        _store.Write("manifest.json", ValidManifest);
+        _store.Write("WorkItems/2024-01-01/00000000000000000001-1-0/revision.json", ValidRevision);
 
         var result = await _sut.ValidateAsync(CancellationToken.None);
 
@@ -60,55 +47,196 @@ public class PackageValidatorTests
         var result = await _sut.ValidateAsync(CancellationToken.None);
 
         Assert.IsFalse(result.Passed);
-        Assert.IsTrue(result.Errors[0].Message.Contains("not found"));
+        Assert.IsTrue(result.Errors[0].Message.Contains("not found", StringComparison.OrdinalIgnoreCase));
     }
 
     [TestMethod]
     public async Task ValidateAsync_UnsupportedSchemaVersion_ReturnsFailed()
     {
-        Write("manifest.json", """{"schemaVersion":"99.0"}""");
+        _store.Write("manifest.json", """{"schemaVersion":"99.0"}""");
 
         var result = await _sut.ValidateAsync(CancellationToken.None);
 
         Assert.IsFalse(result.Passed);
-        Assert.IsTrue(result.Errors[0].Message.Contains("Unsupported schema version"));
+        Assert.IsTrue(result.Errors[0].Message.Contains("Unsupported schema version", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
+    public async Task ValidateAsync_MissingSchemaVersion_ReturnsFailed()
+    {
+        _store.Write("manifest.json", """{"packageVersion":"2026.05"}""");
+
+        var result = await _sut.ValidateAsync(CancellationToken.None);
+
+        Assert.IsFalse(result.Passed);
+        Assert.AreEqual("manifest.json", result.Errors[0].Path);
+        StringAssert.Contains(result.Errors[0].Message, "schemaVersion");
+    }
+
+    [TestMethod]
+    public async Task ValidateAsync_InvalidManifestJson_ReturnsManifestError()
+    {
+        _store.Write("manifest.json", "not json");
+        _store.Write("WorkItems/2024-01-01/00000000000000000001-1-0/revision.json", ValidRevision);
+
+        var result = await _sut.ValidateAsync(CancellationToken.None);
+
+        Assert.IsFalse(result.Passed);
+        Assert.IsTrue(result.Errors.Any(error =>
+            error.Path == "manifest.json" && error.Message.Contains("Invalid JSON", StringComparison.OrdinalIgnoreCase)));
     }
 
     [TestMethod]
     public async Task ValidateAsync_RevisionMissingWorkItemId_ReturnsFailed()
     {
-        Write("manifest.json", ValidManifest);
-        Write("WorkItems/2024-01-01/00000000000000000001-1-0/revision.json",
+        _store.Write("manifest.json", ValidManifest);
+        _store.Write("WorkItems/2024-01-01/00000000000000000001-1-0/revision.json",
             """{"revisionIndex":0,"changedDate":"2024-01-01T00:00:00Z","fields":[],"externalLinks":[],"relatedLinks":[],"hyperlinks":[],"attachments":[]}""");
 
         var result = await _sut.ValidateAsync(CancellationToken.None);
 
         Assert.IsFalse(result.Passed);
-        Assert.IsTrue(result.Errors[0].Message.Contains("workItemId"));
+        Assert.IsTrue(result.Errors[0].Message.Contains("workItemId", StringComparison.OrdinalIgnoreCase));
     }
 
     [TestMethod]
-    public async Task ValidateAsync_InvalidJson_ReturnsFailed()
+    public async Task ValidateAsync_InvalidRevisionJson_ReturnsFailed()
     {
-        Write("manifest.json", ValidManifest);
-        Write("WorkItems/2024-01-01/00000000000000000001-1-0/revision.json", "not json");
+        _store.Write("manifest.json", ValidManifest);
+        _store.Write("WorkItems/2024-01-01/00000000000000000001-1-0/revision.json", "not json");
 
         var result = await _sut.ValidateAsync(CancellationToken.None);
 
         Assert.IsFalse(result.Passed);
-        Assert.IsTrue(result.Errors[0].Message.Contains("Invalid JSON"));
+        Assert.IsTrue(result.Errors[0].Message.Contains("Invalid JSON", StringComparison.OrdinalIgnoreCase));
     }
 
     [TestMethod]
-    public async Task ValidateAsync_IsReadOnly_NoFilesCreated()
+    public async Task ValidateAsync_RevisionListedButUnreadable_ReturnsFileNotFoundErrorForListedPath()
     {
-        Write("manifest.json", ValidManifest);
-        Write("WorkItems/2024-01-01/00000000000000000001-1-0/revision.json", ValidRevision);
+        const string missingRevisionPath = "WorkItems/2024-01-01/00000000000000000001-1-0/revision.json";
+        _store.Write("manifest.json", ValidManifest);
+        _store.AddEnumeratedPath(missingRevisionPath);
 
-        var beforeCount = Directory.GetFiles(_storeDir, "*", SearchOption.AllDirectories).Length;
+        var result = await _sut.ValidateAsync(CancellationToken.None);
+
+        Assert.IsFalse(result.Passed);
+        Assert.AreEqual(missingRevisionPath, result.Errors[0].Path);
+        Assert.AreEqual("File not found.", result.Errors[0].Message);
+    }
+
+    [TestMethod]
+    public async Task ValidateAsync_MultipleInvalidRevisionFiles_ReturnsErrorForEachInvalidRevision()
+    {
+        _store.Write("manifest.json", ValidManifest);
+        _store.Write("WorkItems/2024-01-01/00000000000000000001-1-0/revision.json", "not json");
+        _store.Write("WorkItems/2024-01-01/00000000000000000002-2-0/revision.json",
+            """{"workItemId":2,"changedDate":"2024-01-01T00:00:00Z","fields":[],"externalLinks":[],"relatedLinks":[],"hyperlinks":[],"attachments":[]}""");
+
+        var result = await _sut.ValidateAsync(CancellationToken.None);
+
+        Assert.IsFalse(result.Passed);
+        Assert.AreEqual(2, result.Errors.Count);
+        Assert.IsTrue(result.Errors.Any(error => error.Message.Contains("Invalid JSON", StringComparison.OrdinalIgnoreCase)));
+        Assert.IsTrue(result.Errors.Any(error => error.Message.Contains("revisionIndex", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [TestMethod]
+    public async Task ValidateAsync_NonRevisionWorkItemsArtefact_IsIgnored()
+    {
+        _store.Write("manifest.json", ValidManifest);
+        _store.Write("WorkItems/2024-01-01/00000000000000000001-1-0/revision.json", ValidRevision);
+        _store.Write("WorkItems/2024-01-01/00000000000000000001-1-0/attachment-metadata.json", "not json");
+
+        var result = await _sut.ValidateAsync(CancellationToken.None);
+
+        Assert.IsTrue(result.Passed);
+    }
+
+    [TestMethod]
+    public async Task ValidateAsync_IsReadOnly_NoPackageWritesPerformed()
+    {
+        _store.Write("manifest.json", ValidManifest);
+        _store.Write("WorkItems/2024-01-01/00000000000000000001-1-0/revision.json", ValidRevision);
+        _store.ResetWriteTracking();
+
         await _sut.ValidateAsync(CancellationToken.None);
-        var afterCount = Directory.GetFiles(_storeDir, "*", SearchOption.AllDirectories).Length;
 
-        Assert.AreEqual(beforeCount, afterCount, "Validator must not create or modify files.");
+        Assert.AreEqual(0, _store.WriteCalls, "Validator must not create or modify package files.");
+        Assert.AreEqual(0, _store.WriteBinaryCalls, "Validator must not create or modify package binaries.");
+        Assert.AreEqual(0, _store.WriteStreamCalls, "Validator must not create or modify package streams.");
+        Assert.AreEqual(0, _store.AppendCalls, "Validator must not append package logs or state.");
+    }
+
+    private sealed class InMemoryArtefactStore : IArtefactStore
+    {
+        private readonly Dictionary<string, string> _files = new(StringComparer.OrdinalIgnoreCase);
+        private readonly SortedSet<string> _extraEnumeratedPaths = new(StringComparer.OrdinalIgnoreCase);
+
+        public int WriteCalls { get; private set; }
+        public int WriteBinaryCalls { get; private set; }
+        public int WriteStreamCalls { get; private set; }
+        public int AppendCalls { get; private set; }
+
+        public void Write(string path, string content) => _files[path] = content;
+
+        public void AddEnumeratedPath(string path) => _extraEnumeratedPaths.Add(path);
+
+        public void ResetWriteTracking()
+        {
+            WriteCalls = 0;
+            WriteBinaryCalls = 0;
+            WriteStreamCalls = 0;
+            AppendCalls = 0;
+        }
+
+        public Task<string?> ReadAsync(string path, CancellationToken cancellationToken)
+            => Task.FromResult(_files.TryGetValue(path, out var content) ? content : null);
+
+        public Task WriteAsync(string path, string content, CancellationToken cancellationToken)
+        {
+            WriteCalls++;
+            _files[path] = content;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> ExistsAsync(string path, CancellationToken cancellationToken)
+            => Task.FromResult(_files.ContainsKey(path));
+
+        public Task WriteBinaryAsync(string path, byte[] content, CancellationToken cancellationToken)
+        {
+            WriteBinaryCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task<Stream?> ReadBinaryAsync(string path, CancellationToken cancellationToken)
+            => Task.FromResult<Stream?>(null);
+
+        public async IAsyncEnumerable<string> EnumerateAsync(
+            string prefix,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            foreach (var path in _files.Keys
+                .Concat(_extraEnumeratedPaths)
+                .Where(path => path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Yield();
+                yield return path;
+            }
+        }
+
+        public Task WriteStreamAsync(string path, Stream content, CancellationToken cancellationToken)
+        {
+            WriteStreamCalls++;
+            return Task.CompletedTask;
+        }
+
+        public Task AppendAsync(string path, string content, CancellationToken cancellationToken)
+        {
+            AppendCalls++;
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Reduce fragile, filesystem-dependent unit tests by exercising the validator through its `IArtefactStore` port. 
- Close gaps in package validation around manifest boundaries and revision enumeration so validation fails are explicit and actionable. 
- Keep production code unchanged while raising confidence in the validator behaviour and the read-only contract.

### Description

- Rewrote `PackageValidatorTests` to use an in-memory `IArtefactStore` fake and removed temp-directory `FileSystemArtefactStore` setup.
- Added unit tests covering missing `schemaVersion`, malformed `manifest.json`, unreadable enumerated revision paths, multiple invalid revision files, and ignoring non-`revision.json` artefacts.
- Strengthened the read-only contract by asserting no `WriteAsync`, `WriteBinaryAsync`, `WriteStreamAsync`, or `AppendAsync` calls are made during validation, and left `PackageValidator` production code unchanged. 
- Produced NKDA TDD safety-net artefacts under `.output/nkda-tddsn/agent_validation_safety/` (`01-assessment.md`..`06-verification.md`).

### Testing

- Attempted to run the targeted unit tests with `dotnet test --filter FullyQualifiedName~PackageValidatorTests`, but the .NET SDK was not available in the environment so test execution could not be performed here. 
- Verified repository checks locally in the container with `git diff --cached --check` and staged/committed the changes (`Strengthen package validator safety net`).
- The new/rewritten tests are present in `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Platform/PackageValidatorTests.cs` and should be executed in an SDK-enabled environment as the next step using `dotnet test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde34959c08326bb3841267efa62fa)