### PR TITLE
Harden AgentWorkerBase lease cleanup and add lease-coordination safety-net test

### DIFF
--- a/.output/nkda-tddsn/agent_lease_coordination/01-assessment.md
+++ b/.output/nkda-tddsn/agent_lease_coordination/01-assessment.md
@@ -1,0 +1,134 @@
+# TDD Safety Net Assessment: agent_lease_coordination
+
+## 1. Scope
+
+Subsystem:
+agent_lease_coordination
+
+Analysed sources:
+- `.agents/context/architecture/agent-lease-coordination.md`
+- `.agents/context/control-plane-concept.md`
+- `.agents/context/entitlements-model.md`
+- `docs/agent-hosting.md`
+- `src/DevOpsMigrationPlatform.Infrastructure.Agent/AgentWorkerBase.cs`
+- `src/DevOpsMigrationPlatform.MigrationAgent/JobAgentWorker.cs`
+- `src/DevOpsMigrationPlatform.TfsMigrationAgent/TfsJobAgentWorker.cs`
+- `src/DevOpsMigrationPlatform.Abstractions.Agent/Lease/ActiveLeaseState.cs`
+- `src/DevOpsMigrationPlatform.Abstractions.Agent/Lease/ActivePackageState.cs`
+
+Analysed tests:
+- `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/JobAgentWorkerDispatchTests.cs` (present but excluded from compile by project file)
+- `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/JobAgentWorkerInventoryTests.cs`
+- `tests/DevOpsMigrationPlatform.TfsMigrationAgent.Tests/TfsJobAgentWorkerTests.cs`
+
+Partial analysis warnings:
+- `JobAgentWorkerDispatchTests.cs` is named in subsystem docs but removed from compilation in `DevOpsMigrationPlatform.Infrastructure.Agent.Tests.csproj`, so its apparent coverage is not executable evidence.
+- No direct existing executable unit test was found for the shared `AgentWorkerBase` lease acquire/release lifecycle.
+
+## 2. Behaviour Model
+
+Purpose:
+The subsystem coordinates agent work leases by polling the control plane for jobs matching agent capabilities, recording active lease/job/package state for collaborators, dispatching the leased job to the concrete worker, signalling terminal state, flushing job sinks, and clearing active state before the worker polls again.
+
+Primary behaviours:
+B1. Poll the control plane lease endpoint with the agent connector capabilities.
+B2. Treat HTTP 204 as no work and delay before the next poll.
+B3. Deserialize a lease response into a lease id and job.
+B4. Publish the active lease id and job before dispatch so telemetry, progress, and package services can observe job context.
+B5. Dispatch the job to the concrete worker with the control-plane client, lease id, and cancellation token.
+B6. Clear active lease and package state after dispatch completes.
+B7. Flush buffered post-job sinks before clearing package state.
+B8. Retry terminal complete/fail signalling with exponential backoff.
+
+State transitions:
+S1. Idle -> Leased when a lease response is received.
+S2. Leased -> Dispatching after active state is set and `OnJobAsync` starts.
+S3. Dispatching -> Released after `OnJobAsync` completes and post-job flush runs.
+S4. Dispatching -> Released even when `OnJobAsync` fails unexpectedly; active state must not leak into the next poll.
+S5. Released -> Idle after `ActivePackageState.Clear()` completes.
+
+External contracts:
+C1. GET `/agents/lease?capabilities=...` requests work for advertised connector capabilities.
+C2. POST `/agents/lease/{leaseId}/complete` and `/fail` are used by concrete workers to signal terminal states.
+C3. `ActiveLeaseState.CurrentLeaseId` is nullable and represents exactly one currently held lease.
+C4. `ActivePackageState.CurrentJob`, `CurrentStore`, and run id cache are per-job and must be cleared on lease release.
+
+Failure and rejection behaviours:
+F1. No-content lease response does not set active state.
+F2. Lease polling HTTP failure propagates to the background loop and is logged before retry.
+F3. Job dispatch failure must not leave stale active lease or package state.
+F4. Terminal signalling failures are retried and eventually logged without throwing after all attempts fail.
+
+Boundary conditions:
+E1. Empty capability list produces an empty capabilities query value.
+E2. Null lease response results in no dispatch and no active state.
+E3. Cancellation during polling or delay stops the background loop.
+E4. Dispatch failure before concrete worker cleanup still requires base lease/package cleanup.
+
+Drift risks:
+D1. Stale `ActiveLeaseState` can misattribute telemetry/progress to an expired lease after dispatch failure.
+D2. Stale `ActivePackageState.CurrentJob` or run id can send logs/artifacts to the wrong run folder.
+D3. Compile-excluded dispatch tests can give false confidence that job dispatch and cleanup contracts are protected.
+D4. TFS and .NET 10 agent workers share the base lease lifecycle, so base cleanup drift affects both runtimes.
+
+## 3. Current Test Inventory
+
+| Test | Type | Behaviour Protected | Score | Classification | Action |
+|------|------|---------------------|-------|----------------|--------|
+| `JobAgentWorkerDispatchTests.*` | Unit/design | Concrete .NET agent job dispatch, config context, completion marker behavior | 0/36 | POOR TDD | Rewrite/restore separately; excluded from compile |
+| `JobAgentWorkerInventoryTests.InventoryDispatch_*` | Unit/design | Multi-org inventory dispatch and progress/logging | 33/36 | GOOD TDD | Keep |
+| `TfsJobAgentWorkerTests.OnMigrationJob_*` | Unit/design | TFS migration job validation, service creation, terminal signalling | 31/36 | GOOD TDD | Keep |
+| `TfsJobAgentWorkerTests.OnDiscoveryJob_*` | Unit/design | TFS discovery dispatch and failure handling | 31/36 | GOOD TDD | Keep |
+| Missing `AgentWorkerBase` cleanup-on-dispatch-failure test | Unit/design | Shared lease/package cleanup under unexpected dispatch failure | 0/36 | POOR TDD | Add |
+
+## 4. Detailed Scoring
+
+### `JobAgentWorkerDispatchTests.*`
+- test type: unit/design
+- behaviour protected: concrete JobAgentWorker dispatch decisions and context cleanup
+- dimension scores: behaviour focus 0, focused 2, readable 2, right reason 0, deterministic 2, fast 2, independent 2, name 2, meaningful example 2, minimises mocking 1, design pressure 2, outcome/contract assertions 0
+- total: 17/36 before hard gates; gated classification `POOR TDD` because the file is excluded from compilation and therefore cannot fail.
+- action: restore executable coverage in a follow-up; do not count it as current safety net evidence.
+
+### `JobAgentWorkerInventoryTests.InventoryDispatch_*`
+- test type: unit/design
+- behaviour protected: multi-org inventory dispatch remains observable through calls, progress, metrics, and logs.
+- scores: 3,2,3,3,3,3,3,3,3,2,2,3 = 33/36
+- classification: GOOD TDD
+- action: keep.
+
+### `TfsJobAgentWorkerTests.OnMigrationJob_*` and `OnDiscoveryJob_*`
+- test type: unit/design
+- behaviour protected: TFS worker rejects invalid jobs, creates services for valid exports/discovery, streams counts, and signals terminal states.
+- scores: 3,2,2,3,3,3,3,3,2,2,2,3 = 31/36
+- classification: GOOD TDD
+- action: keep.
+
+### Missing `AgentWorkerBase` cleanup-on-dispatch-failure test
+- test type: unit/design
+- behaviour protected: shared base worker clears active lease/package state on unexpected dispatch failure.
+- scores: 0 across all dimensions because no executable test exists.
+- classification: POOR TDD
+- action: add a focused unit/design test.
+
+## 5. Drift Risk Map
+
+| Risk | Current Protection | Gap | Priority |
+|------|--------------------|-----|----------|
+| D1 stale lease after dispatch failure | None in executable shared-base tests | Add `AgentWorkerBase` failure cleanup test | High |
+| D2 stale package job/run after dispatch failure | None in executable shared-base tests | Assert `ActivePackageState.CurrentJob` and run cache clear | High |
+| D3 false confidence from excluded dispatch tests | Project file excludes the main dispatch test file | Document warning; follow-up restore | Medium |
+| D4 terminal signal retry drift | Indirect concrete-worker tests only | Future base-level retry tests | Medium |
+
+## 6. Suite-Level Gap Map
+
+- Add a compiled `AgentWorkerBase` unit/design test for lease/package cleanup on dispatch failure.
+- Add future base-level tests for no-content lease response and terminal signal retry exhaustion.
+- Restore or replace compile-excluded `JobAgentWorkerDispatchTests.cs` so concrete dispatch coverage is executable.
+
+## 7. Recommendations
+
+1. Add a new focused MSTest class under `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/AgentWorkerBaseLeaseCoordinationTests.cs`.
+2. First test: `ExecuteAsync_WhenJobDispatchThrows_ClearsActiveLeaseAndPackageState`.
+3. Implement the minimal production change in `AgentWorkerBase.PollAndExecuteAsync` using `try/finally` around dispatch, post-job flush, and package cleanup.
+4. Keep existing TFS and inventory tests unchanged.

--- a/.output/nkda-tddsn/agent_lease_coordination/02-target-test-suite.md
+++ b/.output/nkda-tddsn/agent_lease_coordination/02-target-test-suite.md
@@ -1,0 +1,18 @@
+# Target Behavioural Test Suite: agent_lease_coordination
+## 1. Source Assessment
+Consumes `.output/nkda-tddsn/agent_lease_coordination/01-assessment.md`.
+## 2. Target Suite Gate
+| Test Class | Test Method | Type | Protected Behaviour | Expected Assertions | Decision |
+|------------|-------------|------|---------------------|--------------------|----------|
+| `AgentWorkerBaseLeaseCoordinationTests` | `ExecuteAsync_WhenJobDispatchThrows_ClearsActiveLeaseAndPackageState` | Unit/design | Shared base worker releases active lease and package job state even when concrete dispatch throws unexpectedly | After dispatch has thrown and the hosted worker is stopped: `ActiveLeaseState.CurrentLeaseId` is null, `ActivePackageState.CurrentJob` is null, `ActivePackageState.CurrentRunId` is null, and dispatch was invoked once with the acquired lease id/job | Add |
+| `JobAgentWorkerInventoryTests` | existing `InventoryDispatch_*` methods | Unit/design | Multi-org inventory dispatch and observability | Existing call/progress/log assertions remain passing | Keep |
+| `TfsJobAgentWorkerTests` | existing migration/discovery methods | Unit/design | TFS job validation, dispatch, and terminal signalling | Existing terminal request and service assertions remain passing | Keep |
+| `JobAgentWorkerDispatchTests` | existing methods | Unit/design | .NET agent concrete dispatch | Not currently executable because project excludes file | Defer restore to separate follow-up |
+## 3. Required Test Support
+- A minimal concrete `AgentWorkerBase` test double whose `OnJobAsync` records the job and lease then throws a deterministic exception.
+- A fake `IHttpClientFactory` returning an `HttpClient` backed by an in-memory `HttpMessageHandler`.
+- The handler returns one serialized lease response for `GET /agents/lease?...`.
+- The test starts the background service, waits for the throwing dispatch path to be observed, cancels/stops the service, then asserts released state.
+## 4. Out-of-Scope Target Tests
+- Full restoration of `JobAgentWorkerDispatchTests.cs` is out of scope for this autonomous pass because it may expose broader compile and dependency drift unrelated to the shared lease cleanup gap.
+- Base terminal signal retry coverage remains a future medium-priority addition.

--- a/.output/nkda-tddsn/agent_lease_coordination/03-architecture-update.md
+++ b/.output/nkda-tddsn/agent_lease_coordination/03-architecture-update.md
@@ -1,0 +1,14 @@
+# Architecture Update: agent_lease_coordination
+## 1. Architecture Narrative
+The lease coordination architecture is a shared base-worker lifecycle. `AgentWorkerBase` owns polling, active lease publication, active job publication, dispatch, post-job flush, and cleanup. Concrete workers own job-kind dispatch and terminal signalling details.
+The critical invariant is that active lease/package state is scoped to exactly one acquired job. Any exit from dispatch other than host cancellation must release that state before the worker loop retries, otherwise telemetry, progress, logs, package run ids, and follow-up jobs can observe stale context.
+## 2. Proposed Documentation Change
+No canonical architecture documentation file is changed in this pass. The existing architecture summary already states that `ActiveLeaseState` is cleared after complete/fail. This rebuild strengthens implementation and tests to match that documented lifecycle for failure exits too.
+## 3. Boundary Review
+- Clean Architecture: production change remains inside infrastructure worker lifecycle; no domain dependency is introduced.
+- Hexagonal: no SDK or external API calls are added; the fake HTTP boundary is test-only.
+- Modular Monolith: no cross-module coupling is added.
+- Vertical Slice: tests target the lease-coordination behaviour directly.
+- Screaming Architecture: test and artifact names use `agent_lease_coordination` and `AgentWorkerBaseLeaseCoordination` language.
+## 4. Minimal Change Gate Input
+The only production change should be in `AgentWorkerBase.PollAndExecuteAsync`: wrap dispatch/post-job flush/cleanup in `try/finally` so cleanup runs on success and unexpected dispatch failure.

--- a/.output/nkda-tddsn/agent_lease_coordination/04-rebuild-plan.md
+++ b/.output/nkda-tddsn/agent_lease_coordination/04-rebuild-plan.md
@@ -1,0 +1,36 @@
+# Rebuild Plan: agent_lease_coordination
+
+## 1. Goal
+
+Close the high-priority behavioural drift risk where active lease/package state can remain set after unexpected job dispatch failure.
+
+## 2. Sequenced Work
+
+1. Add `AgentWorkerBaseLeaseCoordinationTests.ExecuteAsync_WhenJobDispatchThrows_ClearsActiveLeaseAndPackageState`.
+   - Expected initial result: fail because `AgentWorkerBase.PollAndExecuteAsync` currently clears state only after `OnJobAsync` returns normally.
+2. Make the minimal production change in `AgentWorkerBase`.
+   - Add `try/finally` around `OnJobAsync`, `_leaseState.CurrentLeaseId = null`, `OnPostJobFlushAsync`, and `_packageState.Clear()`.
+   - Preserve success ordering: dispatch, clear lease id, flush, clear package state.
+3. Run the focused test class.
+4. Run the relevant infrastructure agent test project.
+5. Run the TFS migration agent tests if the environment supports the target framework/runtime.
+6. Record results in `05-implementation-summary.md` and `06-verification.md`.
+
+## 3. Stopping Points
+
+- Stop if the new test cannot deterministically observe dispatch without sleeps.
+- Stop if the production change requires altering public contracts or concrete worker behaviour.
+- Stop if verification cannot produce executable evidence.
+
+## 4. Required Seams
+
+- Test-only `ThrowingAgentWorker` subclass.
+- Test-only `SingleLeaseResponseHandler`.
+- Test-only `TestHttpClientFactory`.
+
+## 5. Minimal Production Change Statement
+
+Required by target test: `ExecuteAsync_WhenJobDispatchThrows_ClearsActiveLeaseAndPackageState`.
+Behaviour corrected: active lease/package state is released after unexpected dispatch failure.
+Why minimal: one lifecycle `try/finally`, no public API changes, no terminal signalling changes, no concrete worker dispatch changes.
+Architecture docs: no source docs changed; this artifact records the strengthened invariant.

--- a/.output/nkda-tddsn/agent_lease_coordination/05-implementation-summary.md
+++ b/.output/nkda-tddsn/agent_lease_coordination/05-implementation-summary.md
@@ -1,0 +1,39 @@
+# Implementation Summary: agent_lease_coordination
+
+## 1. Changed Files Summary
+
+- Added `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/AgentWorkerBaseLeaseCoordinationTests.cs`.
+- Updated `src/DevOpsMigrationPlatform.Infrastructure.Agent/AgentWorkerBase.cs`.
+
+## 2. Tests Added
+
+- `AgentWorkerBaseLeaseCoordinationTests.ExecuteAsync_WhenJobDispatchThrows_ClearsActiveLeaseAndPackageState`
+  - Starts a concrete `AgentWorkerBase` test double.
+  - Serves one in-memory lease response.
+  - Forces deterministic dispatch failure.
+  - Asserts active lease id, active job, and cached run id are cleared after the worker stops.
+
+## 3. Tests Rewritten
+
+- None.
+
+## 4. Tests Deleted
+
+- None.
+
+## 5. Production Changes Made
+
+- `AgentWorkerBase.PollAndExecuteAsync` now wraps `OnJobAsync` in `try/finally` so active lease state is cleared and post-job cleanup executes even if concrete job dispatch throws.
+- Package cleanup is nested in a `finally` after post-job flushing so package state is cleared even if flushing fails.
+
+## 6. Unresolved Issues
+
+- The environment does not have the `dotnet` CLI on `PATH`, so MSTest execution could not be completed in this container.
+- `JobAgentWorkerDispatchTests.cs` remains excluded from compilation by the project file; restoring that broader suite is a documented follow-up outside this pass.
+
+## 7. Test Commands Run
+
+- `dotnet test tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests.csproj --filter FullyQualifiedName~AgentWorkerBaseLeaseCoordinationTests --no-restore`
+  - Result: not executed; PowerShell reported `dotnet` is not recognized.
+- `git diff --check`
+  - Result: exit code 0.

--- a/.output/nkda-tddsn/agent_lease_coordination/06-verification.md
+++ b/.output/nkda-tddsn/agent_lease_coordination/06-verification.md
@@ -1,0 +1,48 @@
+# Verification Review: agent_lease_coordination
+
+## 1. Verification Inputs
+
+- Assessment: `.output/nkda-tddsn/agent_lease_coordination/01-assessment.md`
+- Target suite: `.output/nkda-tddsn/agent_lease_coordination/02-target-test-suite.md`
+- Architecture update: `.output/nkda-tddsn/agent_lease_coordination/03-architecture-update.md`
+- Rebuild plan: `.output/nkda-tddsn/agent_lease_coordination/04-rebuild-plan.md`
+- Implementation summary: `.output/nkda-tddsn/agent_lease_coordination/05-implementation-summary.md`
+
+## 2. Test Command Used
+
+`dotnet test tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests.csproj --filter FullyQualifiedName~AgentWorkerBaseLeaseCoordinationTests --no-restore`
+
+Result: not executed in this container because `dotnet` is not installed or not on `PATH` for PowerShell. Output: `dotnet: The term 'dotnet' is not recognized as a name of a cmdlet, function, script file, or executable program.`
+
+## 3. Additional Checks
+
+`git diff --check`
+
+Result: exit code 0.
+
+## 4. Changed Files Summary
+
+- `src/DevOpsMigrationPlatform.Infrastructure.Agent/AgentWorkerBase.cs`: lease and package cleanup now run from `finally` blocks around job dispatch and post-job flush.
+- `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/AgentWorkerBaseLeaseCoordinationTests.cs`: added focused behavioural test for dispatch-failure cleanup.
+
+## 5. Target Suite Coverage Status
+
+| Target Test | Status | Evidence |
+|-------------|--------|----------|
+| `ExecuteAsync_WhenJobDispatchThrows_ClearsActiveLeaseAndPackageState` | Implemented; not executable in this container | Test file added; `dotnet` unavailable |
+| Existing inventory tests | Unchanged; not executable in this container | No changes made to inventory tests; `dotnet` unavailable |
+| Existing TFS worker tests | Unchanged; not executable in this container | No changes made to TFS tests; `dotnet` unavailable |
+
+## 6. Remaining Drift Risks
+
+- Test execution remains unverified until run in an environment with the .NET SDK.
+- `JobAgentWorkerDispatchTests.cs` is still compile-excluded, so concrete .NET agent dispatch coverage remains a separate follow-up risk.
+- Terminal signal retry base-level tests remain a future medium-priority addition.
+
+## 7. Guardrail Review
+
+- Testing rules: added a unit/design MSTest with deterministic in-memory fakes and no sleeps.
+- Coding standards: production change preserves async/await and cancellation propagation; no public API changes.
+- Architecture boundaries: change stays inside infrastructure worker lifecycle.
+- Observability: no metrics/log schema changes.
+- Definition of done: automated test execution is blocked by missing `dotnet`, so this verification is partial.

--- a/src/DevOpsMigrationPlatform.Infrastructure.Agent/AgentWorkerBase.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure.Agent/AgentWorkerBase.cs
@@ -151,13 +151,23 @@ public abstract class AgentWorkerBase : BackgroundService
         _leaseState.CurrentLeaseId = lease.LeaseId;
         _packageState.CurrentJob = lease.Job;
 
-        await OnJobAsync(lease.Job, controlPlane, lease.LeaseId, ct).ConfigureAwait(false);
+        try
+        {
+            await OnJobAsync(lease.Job, controlPlane, lease.LeaseId, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _leaseState.CurrentLeaseId = null;
 
-        _leaseState.CurrentLeaseId = null;
-
-        await OnPostJobFlushAsync().ConfigureAwait(false);
-
-        _packageState.Clear();
+            try
+            {
+                await OnPostJobFlushAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _packageState.Clear();
+            }
+        }
     }
 
     /// <summary>

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/AgentWorkerBaseLeaseCoordinationTests.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/AgentWorkerBaseLeaseCoordinationTests.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) Naked Agility Limited
+
+using System.Net;
+using System.Net.Http.Json;
+using DevOpsMigrationPlatform.Abstractions.Agent.Lease;
+using DevOpsMigrationPlatform.Abstractions.Jobs;
+using DevOpsMigrationPlatform.Infrastructure.Agent;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace DevOpsMigrationPlatform.Infrastructure.Agent.Tests.Context;
+
+[TestClass]
+public sealed class AgentWorkerBaseLeaseCoordinationTests
+{
+    [TestMethod]
+    public async Task ExecuteAsync_WhenJobDispatchThrows_ClearsActiveLeaseAndPackageState()
+    {
+        var leaseState = new ActiveLeaseState();
+        var packageState = new ActivePackageState();
+        var job = new Job
+        {
+            JobId = "job-dispatch-failure",
+            Kind = JobKind.Export,
+            Package = new JobPackage { PackageUri = "file:///tmp/package" }
+        };
+
+        using var client = new HttpClient(new SingleLeaseResponseHandler("lease-dispatch-failure", job))
+        {
+            BaseAddress = new Uri("http://localhost:5100")
+        };
+        var worker = new ThrowingAgentWorker(
+            leaseState,
+            packageState,
+            new TestHttpClientFactory(client));
+
+        using var runCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await worker.StartAsync(runCts.Token);
+
+        var observedDispatch = await Task.WhenAny(
+            worker.DispatchObserved.Task,
+            Task.Delay(TimeSpan.FromSeconds(2), runCts.Token));
+
+        Assert.AreSame(worker.DispatchObserved.Task, observedDispatch, "The leased job should be dispatched before assertions run.");
+        Assert.AreEqual("lease-dispatch-failure", await worker.DispatchObserved.Task);
+        Assert.AreEqual(1, worker.DispatchCount);
+
+        await runCts.CancelAsync();
+        await worker.StopAsync(CancellationToken.None);
+
+        Assert.IsNull(leaseState.CurrentLeaseId, "The active lease must be cleared even when job dispatch throws.");
+        Assert.IsNull(packageState.CurrentJob, "The active job must be cleared even when job dispatch throws.");
+        Assert.IsNull(packageState.CurrentRunId, "The cached run id must be cleared with the active package state.");
+    }
+
+    private sealed class ThrowingAgentWorker(
+        ActiveLeaseState leaseState,
+        ActivePackageState packageState,
+        IHttpClientFactory httpClientFactory)
+        : AgentWorkerBase(
+            leaseState,
+            packageState,
+            httpClientFactory,
+            NullLogger<ThrowingAgentWorker>.Instance)
+    {
+        private readonly ActivePackageState _packageState = packageState;
+        private readonly TaskCompletionSource<string> _dispatchObserved = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<string> DispatchObserved => _dispatchObserved;
+        public int DispatchCount { get; private set; }
+
+        protected override ConnectorType[] Capabilities => [ConnectorType.Simulated];
+
+        protected override Task OnJobAsync(Job job, HttpClient controlPlane, string leaseId, CancellationToken ct)
+        {
+            DispatchCount++;
+            _ = _packageState.CurrentRunId;
+            _dispatchObserved.TrySetResult(leaseId);
+            throw new InvalidOperationException("Deterministic dispatch failure for lease cleanup test.");
+        }
+    }
+
+    private sealed class SingleLeaseResponseHandler(string leaseId, Job job) : HttpMessageHandler
+    {
+        private bool _leaseReturned;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (!_leaseReturned && request.Method == HttpMethod.Get && request.RequestUri?.AbsolutePath == "/agents/lease")
+            {
+                _leaseReturned = true;
+                return Task.FromResult(HttpResponseMessageJson(new LeaseEnvelope(leaseId, job)));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+        }
+
+        private static HttpResponseMessage HttpResponseMessageJson(LeaseEnvelope lease)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK);
+            response.Content = JsonContent.Create(lease);
+            return response;
+        }
+    }
+
+    private sealed record LeaseEnvelope(string LeaseId, Job Job);
+
+    private sealed class TestHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent stale `ActiveLeaseState`/`ActivePackageState` when a job dispatch throws so telemetry/progress and package writes cannot be attributed to an expired lease. 
- Close a high-priority drift risk in the agent lease/worker lifecycle where cleanup was only executed on the normal return path. 
- Introduce a focused behavioural test and NKDA TDD artefacts to make the invariant explicit and reproducible.

### Description

- Wrap `OnJobAsync(…)` in a `try/finally` in `AgentWorkerBase.PollAndExecuteAsync` and clear `_leaseState.CurrentLeaseId` in the `finally` so the lease is always released after dispatch attempts. 
- Run `OnPostJobFlushAsync()` in a nested `try/finally` and call `_packageState.Clear()` in the inner `finally` so package state is cleared even if flushing fails. 
- Add a focused MSTest `AgentWorkerBaseLeaseCoordinationTests` that uses a `ThrowingAgentWorker`, a `SingleLeaseResponseHandler`, and a test `IHttpClientFactory` to exercise a deterministic dispatch failure and assert that `ActiveLeaseState` and `ActivePackageState` are cleared. 
- Produce NKDA TDD safety-net artefacts under `.output/nkda-tddsn/agent_lease_coordination/` (`01-assessment.md`, `02-target-test-suite.md`, `03-architecture-update.md`, `04-rebuild-plan.md`, `05-implementation-summary.md`, `06-verification.md`).

### Testing

- Ran `git diff --check`, which passed with no whitespace or diff-check errors. 
- Added the focused test file `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/AgentWorkerBaseLeaseCoordinationTests.cs`, but executing `dotnet test ...` could not be performed here because the `dotnet` CLI is not available on this host (attempted `dotnet test tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests.csproj --filter FullyQualifiedName~AgentWorkerBaseLeaseCoordinationTests --no-restore`). 
- Verification is therefore partial: the behavioral test and the production change are present and ready to run in an environment with the .NET SDK; the NKDA artifacts document the assessment, target suite, plan, implementation summary, and verification steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde3406ff883269ca2e0df877d571f)