### PR TITLE
Preserve run-scoped package log folder for delayed telemetry flushes

### DIFF
--- a/.output/nkda-tddsn/agent_package_persistence/01-assessment.md
+++ b/.output/nkda-tddsn/agent_package_persistence/01-assessment.md
@@ -1,0 +1,75 @@
+# TDD Safety Net Assessment: agent_package_persistence
+
+## 1. Behaviour Model
+
+### Subsystem purpose
+`agent_package_persistence` owns durable package writes performed by the migration agent through `IArtefactStore` and `IStateStore`. It protects the package as the source of truth for artefacts, migration configuration, execution plans, cursor/state files, and run-scoped operational logs.
+
+### Primary behaviours
+- Resolve a package store for the active job and expose it through `ActivePackageState`.
+- Persist artefacts and state through abstractions only; module code must not bypass `IArtefactStore`/`IStateStore`.
+- Persist diagnostic and progress logs into the package using append-only NDJSON files.
+- Keep fast-job and shutdown log drains from losing buffered package telemetry.
+- Place active-job logs under the run-scoped folder returned by `ActivePackageState.CurrentLogFolder`.
+
+### State transitions
+- No active job: `ActivePackageState.CurrentStore` and `CurrentJob` are null; fallback logs use `.migration/Logs`.
+- Lease acquired: worker sets `CurrentJob`, then job-specific code sets/uses `CurrentStore`; run-scoped log folder becomes `.migration/runs/<runId>/logs`.
+- Event/log emitted: sinks capture the current store so buffered records can be flushed later.
+- Job completion/shutdown: buffered records are drained before or after state clear; records emitted during the job must still land in the job's original run folder.
+- State clear: current job/store are removed and future records without an active store are dropped or use fallback behaviour.
+
+### External contracts
+- `IArtefactStore.AppendAsync(path, content, ct)` is the persistence contract for package logs.
+- Progress logs use `<run-log-folder>/progress.jsonl`.
+- Diagnostic logs use `<run-log-folder>/agent.jsonl` with rotation suffixes when enabled.
+- Package paths use forward slashes and `.migration` system folders.
+
+### Failure and rejection behaviours
+- If no store has ever been observed, buffered records are counted as dropped and are not written.
+- Append failures are best-effort failures: records are counted as dropped and the sink does not fail the migration.
+- Cancellation during flushing must not silently cancel append writes for already-buffered records.
+
+### Boundary conditions
+- Fast jobs may emit records and complete before the background drain loop wakes.
+- Host shutdown may stop hosted sink services after the active package state has already been cleared.
+- Records emitted while a job was active must not drift from run-scoped logs to fallback `.migration/Logs` during delayed flush.
+- Rotation decisions must keep diagnostic log records in the same captured run folder.
+
+### Drift risks
+- DR-1: Buffered records flushed after `ActivePackageState.Clear()` can be written to `.migration/Logs` instead of the job run folder.
+- DR-2: Tests cover logger rotation but not package progress run-folder preservation.
+- DR-3: The fallback-store design can preserve the store while losing associated path context.
+- DR-4: Existing tests favour structural package operations and under-protect fast-job/shutdown telemetry persistence.
+
+## 2. Current Test Inventory
+
+| Test/File | Type | Protected Behaviour | Assessment |
+| --- | --- | --- | --- |
+| `FileSystemArtefactStoreTests` | unit/design | Basic read/write/exists and lexicographic enumeration | Valuable for store behaviour, not run-scoped telemetry. |
+| `FileSystemStateStoreTests` | unit/design | State-store persistence and cursor backing behaviour | Valuable for state durability, not log flush path drift. |
+| `PackageConfigStoreTests` | unit/design | Config persistence and observability around config reads/writes | Valuable for config contracts, not active-job log folder preservation. |
+| `PackageLoggerProviderRotationTests` | unit/design | Log path rotation under fallback `.migration/Logs` | Useful but misses active-job clear-after-write case. |
+| `JobAgentWorkerDispatchTests` | unit/integration | Worker dispatch and flush registration in some paths | Test file is excluded from project compilation; does not protect runtime behaviour. |
+
+## 3. Scored Tests
+
+| Test Area | Behaviour Focus | Small/Focused | Readable Example | Fails Right Reason | Deterministic | Fast | Independent | Clear Name | Meaningful Example | Minimises Mocking | Design Pressure | Outcome/Contract Assertions | Classification |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| FileSystem artefact store | 3 | 3 | 3 | 2 | 3 | 3 | 3 | 3 | 2 | 3 | 2 | 3 | GOOD TDD |
+| State store/checkpointing | 3 | 2 | 2 | 2 | 3 | 2 | 2 | 2 | 2 | 2 | 2 | 3 | GOOD TDD |
+| Package config store | 3 | 2 | 2 | 2 | 3 | 2 | 2 | 2 | 2 | 2 | 2 | 3 | GOOD TDD |
+| Package logger rotation | 2 | 2 | 2 | 2 | 2 | 2 | 2 | 2 | 2 | 2 | 2 | 2 | MIXED |
+| Package progress run flush | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | MISSING |
+
+## 4. Suite-Level Gaps
+
+- No behavioural test proves that `PackageProgressSink` preserves the active run log folder when flushing after state clear.
+- No behavioural test proves that `PackageLoggerProvider` preserves the active run log folder when flushing after state clear.
+- No test couples the fallback store reference with the associated path context, leaving a realistic fast-job/shutdown regression unprotected.
+
+## 5. Recommendations
+
+- Add focused unit/design tests for progress and diagnostic log sinks that emit while a job is active, clear package state, then flush.
+- Keep existing store/config tests.
+- Do not broaden into full worker integration unless a later regression shows worker sequencing is unclear; the current drift risk is isolated to sink path selection.

--- a/.output/nkda-tddsn/agent_package_persistence/02-target-test-suite.md
+++ b/.output/nkda-tddsn/agent_package_persistence/02-target-test-suite.md
@@ -1,0 +1,55 @@
+# Target Test Suite: agent_package_persistence
+
+## 1. Design Intent
+
+Protect the package persistence boundary where buffered package telemetry survives fast-job completion and shutdown. The target suite focuses on observable package paths passed to `IArtefactStore.AppendAsync`, not private sink internals.
+
+## 2. Proposed Test Classes
+
+- class name: `PackagePersistenceRunLogFlushTests`
+- purpose: Verify buffered package progress and diagnostic logs remain in the run-scoped folder captured while the job was active, even if flushed after `ActivePackageState.Clear()`.
+- test type emphasis: unit/design contract tests
+- related production area: `PackageProgressSink`, `PackageLoggerProvider`, `ActivePackageState`, `PackagePaths`
+
+## 3. Proposed Tests
+
+- test method name: `PackageProgressSink_FlushAfterPackageStateClear_WritesToOriginalRunLogFolder`
+- type: unit/design
+- status: add
+- protects: Progress log records emitted during an active job are appended to the original run-scoped `progress.jsonl`.
+- drift risk: DR-1, DR-2, DR-3
+- scenario:
+  - Given: an active package state with a current job and artefact store
+  - When: a progress event is emitted, the active package state is cleared, and the sink is flushed
+  - Then: the append path is `<captured-run-log-folder>/progress.jsonl`
+- assertions: exactly one append occurs; appended path equals the run folder captured before clear plus `progress.jsonl`; no fallback `.migration/Logs` path is used.
+- notes: Uses a mock `IArtefactStore`; no private methods are tested.
+
+- test method name: `PackageLoggerProvider_FlushAfterPackageStateClear_WritesToOriginalRunLogFolder`
+- type: unit/design
+- status: add
+- protects: Diagnostic log records emitted during an active job are appended to the original run-scoped `agent.jsonl`.
+- drift risk: DR-1, DR-3, DR-4
+- scenario:
+  - Given: an active package state with a current job and artefact store
+  - When: a diagnostic log is written, the active package state is cleared, and the provider is flushed
+  - Then: the append path is `<captured-run-log-folder>/agent.jsonl`
+- assertions: exactly one append occurs; appended path equals the run folder captured before clear plus `agent.jsonl`; no fallback `.migration/Logs` path is used.
+- notes: Complements existing rotation tests rather than replacing them.
+
+## 4. Required Test Support
+
+- fakes: none
+- builders: none
+- test context helpers: none
+- data builders: inline `Job` instances with stable job IDs
+- deterministic clocks: not required; tests capture the run folder before clearing state rather than asserting a fixed timestamp
+- ID providers: not required
+- storage fakes: mock `IArtefactStore` capturing `AppendAsync` paths
+- schedulers: not required because tests call explicit `FlushAsync`
+
+## 5. Explicit Non-Goals
+
+- Do not test hosted-service timing or background loop scheduling; explicit flush is the contract under test.
+- Do not test Azure Blob persistence separately; the behavioural contract is the `IArtefactStore.AppendAsync` path/content boundary.
+- Do not test logger rotation here; existing rotation tests cover segment naming.

--- a/.output/nkda-tddsn/agent_package_persistence/03-architecture-update.md
+++ b/.output/nkda-tddsn/agent_package_persistence/03-architecture-update.md
@@ -1,0 +1,38 @@
+# Architecture Update Proposal: agent_package_persistence
+
+## 1. Established Architecture
+
+`ActivePackageState` carries the current package store and job for services that cannot receive `IArtefactStore` through construction because the package is resolved only after lease acquisition. Package diagnostic and progress sinks buffer records and append NDJSON lines through `IArtefactStore`. `PackagePaths` defines fallback `.migration/Logs` and run-scoped `.migration/runs/<runId>/logs` paths.
+
+## 2. Proposed Clarifications
+
+Document that any package sink that caches a store reference for delayed shutdown flushing must cache the matching log folder at the same time. A cached store without cached path context is insufficient because `ActivePackageState.Clear()` resets the run identity.
+
+## 3. Behavioural Contracts
+
+- Records emitted while a job is active belong to that job's run log folder.
+- Delayed flush after state clear must use the run log folder captured at emit/drain time.
+- Records emitted without any observed package store may be dropped according to best-effort logging semantics.
+
+## 4. State Transitions
+
+- Active job observed: sink captures both `CurrentStore` and `CurrentLogFolder`.
+- Flush with active state: sink uses live `CurrentLogFolder`.
+- Flush after state clear: sink uses cached log folder paired with the cached store.
+- No cached store: sink drops records rather than inventing package state.
+
+## 5. Failure and Rejection Behaviour
+
+Append failure remains best-effort: the sinks count dropped records and do not fail the migration. The change does not alter append failure handling.
+
+## 6. Observability Behaviour
+
+Progress logs remain at `<run-log-folder>/progress.jsonl`; diagnostic logs remain at `<run-log-folder>/agent.jsonl` with existing rotation semantics. This supports run-scoped auditability after process shutdown.
+
+## 7. Testability Seams
+
+The existing `IArtefactStore.AppendAsync` boundary is sufficient. Tests can capture append paths through a mock store and drive delayed flush with `IFlushable.FlushAsync`.
+
+## 8. Open Questions
+
+- Whether `ActivePackageState` should expose a single immutable active package snapshot in the future to prevent store/path divergence more broadly. This was not required for the minimal fix.

--- a/.output/nkda-tddsn/agent_package_persistence/04-rebuild-plan.md
+++ b/.output/nkda-tddsn/agent_package_persistence/04-rebuild-plan.md
@@ -1,0 +1,34 @@
+# TDD Safety Net Rebuild Plan: agent_package_persistence
+
+## Priority 1: Stop Critical Drift
+
+- Add `PackageProgressSink_FlushAfterPackageStateClear_WritesToOriginalRunLogFolder` to expose progress records drifting to fallback logs after state clear.
+- Add `PackageLoggerProvider_FlushAfterPackageStateClear_WritesToOriginalRunLogFolder` to expose diagnostic records drifting to fallback logs after state clear.
+
+## Priority 2: Replace Weak Verification Tests
+
+- Keep existing `PackageLoggerProviderRotationTests`; add focused run-folder flush tests instead of rewriting rotation tests.
+
+## Priority 3: Add Boundary Protection
+
+- Assert only the observable `IArtefactStore.AppendAsync` path contract.
+- Avoid background timing dependencies by using explicit `FlushAsync`.
+
+## Priority 4: Improve Design Pressure
+
+- Capture the active log folder whenever a sink captures an active store.
+- Select the cached log folder when flushing through the cached store after state clear.
+
+## Priority 5: Consolidate and Clean Up
+
+- Place progress and logger run-folder tests in one telemetry-focused test class.
+- Leave broader architecture unchanged.
+
+## Safe Stopping Points
+
+- After adding failing tests, no production behaviour should be changed until the run-folder drift is confirmed.
+- After caching log folders in both sinks, run the focused telemetry tests.
+
+## Production Code Seams Required
+
+- Add a private cached log-folder field to each package sink. No public API changes are required.

--- a/.output/nkda-tddsn/agent_package_persistence/05-implementation-summary.md
+++ b/.output/nkda-tddsn/agent_package_persistence/05-implementation-summary.md
@@ -1,0 +1,47 @@
+# Implementation Summary: agent_package_persistence
+
+## Changed Files Summary
+
+- Added `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Telemetry/PackagePersistenceRunLogFlushTests.cs` with focused behavioural tests for delayed flush after `ActivePackageState.Clear()`.
+- Updated `src/DevOpsMigrationPlatform.Infrastructure.Agent/Telemetry/PackageProgressSink.cs` to cache the active log folder when it caches the active store and to use that cached folder during fallback flush.
+- Updated `src/DevOpsMigrationPlatform.Infrastructure.Agent/Telemetry/PackageLoggerProvider.cs` to cache the active log folder when it caches the active store and to use that cached folder when computing the current log path after state clear.
+
+## Tests Added
+
+- `PackageProgressSink_FlushAfterPackageStateClear_WritesToOriginalRunLogFolder`
+- `PackageLoggerProvider_FlushAfterPackageStateClear_WritesToOriginalRunLogFolder`
+
+## Tests Rewritten
+
+- None.
+
+## Tests Deleted
+
+- None.
+
+## Production Changes Made
+
+- Added `_lastKnownLogFolder` to `PackageProgressSink` and `PackageLoggerProvider`.
+- Captured `_lastKnownLogFolder` on emit/write and background-drain store observation.
+- Used the cached log folder when the live store is absent and a fallback store is used for flush.
+
+## Minimal Change Gate
+
+- failing or missing target test requiring change: the two added run-folder flush tests.
+- behaviour corrected or enabled: package progress and diagnostic records emitted during an active job remain under that job's run-scoped log folder even if flushed after package state is cleared.
+- why minimal: the change only stores the already-derived log folder alongside the existing cached store; no public API, worker flow, serialization, or store implementation changed.
+- architecture documentation impact: `03-architecture-update.md` records the clarified store/path snapshot contract; canonical docs were not edited because this is an internal invariant clarification.
+
+## Unresolved Issues
+
+- Focused tests could not be executed in this container because `dotnet` is not installed.
+
+## Test Command Run
+
+```powershell
+dotnet test tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests.csproj --filter "FullyQualifiedName~PackagePersistenceRunLogFlushTests" --no-restore
+```
+
+## Test Result
+
+Environment warning: PowerShell reported `dotnet: The term 'dotnet' is not recognized as a name of a cmdlet, function, script file, or executable program.`

--- a/.output/nkda-tddsn/agent_package_persistence/06-verification.md
+++ b/.output/nkda-tddsn/agent_package_persistence/06-verification.md
@@ -1,0 +1,47 @@
+# Verification Report: agent_package_persistence
+
+## Test Command
+
+```powershell
+dotnet test tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests.csproj --filter "FullyQualifiedName~PackagePersistenceRunLogFlushTests" --no-restore
+```
+
+## Test Result
+
+Partial: the relevant test command was invoked through PowerShell, but the container does not have the .NET SDK/CLI installed. PowerShell returned: `dotnet: The term 'dotnet' is not recognized as a name of a cmdlet, function, script file, or executable program.`
+
+Additional static check:
+
+```powershell
+git diff --check
+```
+
+Result: passed with no whitespace errors.
+
+## Target Suite Coverage
+
+| Target Test | Status | Evidence |
+| ----------- | ------ | -------- |
+| `PackageProgressSink_FlushAfterPackageStateClear_WritesToOriginalRunLogFolder` | Implemented | Added in `PackagePersistenceRunLogFlushTests`; asserts append path remains `<captured-run-log-folder>/progress.jsonl` after `ActivePackageState.Clear()`. |
+| `PackageLoggerProvider_FlushAfterPackageStateClear_WritesToOriginalRunLogFolder` | Implemented | Added in `PackagePersistenceRunLogFlushTests`; asserts append path remains `<captured-run-log-folder>/agent.jsonl` after `ActivePackageState.Clear()`. |
+
+## Guardrail Review
+
+* testing rules: Tests are MSTest methods, behaviour-oriented, deterministic, and assert observable package append paths rather than private methods.
+* coding standards: Production change is minimal and keeps dependencies explicit; no try/catch blocks around imports were introduced.
+* architecture boundaries: Package writes remain through `IArtefactStore`; no raw filesystem access or module-boundary bypass was added.
+* observability requirements: Change preserves package progress and diagnostic log persistence under run-scoped logs.
+* definition of done: Partial due missing .NET CLI in the execution environment; focused test command could not produce runtime pass/fail evidence.
+
+## Remaining Drift Risks
+
+* Runtime verification still needs to be performed in an environment with the .NET SDK installed.
+* A future immutable `ActivePackageSnapshot` could reduce broader risk of store/path divergence, but was outside this minimal change.
+
+## Final Classification
+
+Partial: target tests and minimal code changes are implemented; runtime test execution is blocked by the container environment.
+
+## Required Follow-Up
+
+* Run the focused `dotnet test` command in a .NET-enabled environment before merging.

--- a/src/DevOpsMigrationPlatform.Infrastructure.Agent/Telemetry/PackageLoggerProvider.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure.Agent/Telemetry/PackageLoggerProvider.cs
@@ -40,6 +40,7 @@ public sealed class PackageLoggerProvider : BackgroundService, ILoggerProvider, 
     private readonly long _maxSegmentBytes;
     private long _droppedCount;
     private volatile IArtefactStore? _lastKnownStore;
+    private volatile string? _lastKnownLogFolder;
 
     // Rotation state — only accessed from the drain loop (single-threaded).
     private int _segmentIndex;
@@ -70,7 +71,9 @@ public sealed class PackageLoggerProvider : BackgroundService, ILoggerProvider, 
     {
         get
         {
-            var logDir = _packageState.CurrentLogFolder;
+            var logDir = _packageState.CurrentStore is not null
+                ? _packageState.CurrentLogFolder
+                : _lastKnownLogFolder ?? _packageState.CurrentLogFolder;
             return _segmentIndex == 0
                 ? $"{logDir}/{LogBaseName}{LogExtension}"
                 : $"{logDir}/{LogBaseName}-{_segmentIndex:D3}{LogExtension}";
@@ -89,7 +92,10 @@ public sealed class PackageLoggerProvider : BackgroundService, ILoggerProvider, 
         // can flush even if the job completes before the next poll interval.
         var store = _packageState.CurrentStore;
         if (store is not null)
+        {
             _lastKnownStore = store;
+            _lastKnownLogFolder = _packageState.CurrentLogFolder;
+        }
 
         _channel.Writer.TryWrite(record);
     }
@@ -126,6 +132,7 @@ public sealed class PackageLoggerProvider : BackgroundService, ILoggerProvider, 
                     continue;
                 }
                 _lastKnownStore = currentStore;
+                _lastKnownLogFolder = _packageState.CurrentLogFolder;
 
                 batch.Clear();
 

--- a/src/DevOpsMigrationPlatform.Infrastructure.Agent/Telemetry/PackageProgressSink.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure.Agent/Telemetry/PackageProgressSink.cs
@@ -36,6 +36,7 @@ public sealed class PackageProgressSink : BackgroundService, IProgressSink, IFlu
     private readonly ILogger<PackageProgressSink> _logger;
     private long _droppedCount;
     private volatile IArtefactStore? _lastKnownStore;
+    private volatile string? _lastKnownLogFolder;
 
     public PackageProgressSink(
         ActivePackageState packageState,
@@ -51,7 +52,10 @@ public sealed class PackageProgressSink : BackgroundService, IProgressSink, IFlu
         // can flush even if the job completes before the next poll interval.
         var store = _packageState.CurrentStore;
         if (store is not null)
+        {
             _lastKnownStore = store;
+            _lastKnownLogFolder = _packageState.CurrentLogFolder;
+        }
 
         _channel.Writer.TryWrite(evt);
     }
@@ -88,6 +92,7 @@ public sealed class PackageProgressSink : BackgroundService, IProgressSink, IFlu
                     continue;
                 }
                 _lastKnownStore = currentStore;
+                _lastKnownLogFolder = _packageState.CurrentLogFolder;
 
                 batch.Clear();
 
@@ -161,7 +166,10 @@ public sealed class PackageProgressSink : BackgroundService, IProgressSink, IFlu
             {
                 sb.AppendLine(JsonSerializer.Serialize(evt));
             }
-            var logPath = $"{_packageState.CurrentLogFolder}/{LogFileName}";
+            var logFolder = _packageState.CurrentStore is not null
+                ? _packageState.CurrentLogFolder
+                : _lastKnownLogFolder ?? _packageState.CurrentLogFolder;
+            var logPath = $"{logFolder}/{LogFileName}";
             await store.AppendAsync(logPath, sb.ToString(), cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Telemetry/PackagePersistenceRunLogFlushTests.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Telemetry/PackagePersistenceRunLogFlushTests.cs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) Naked Agility Limited
+
+#if !NETFRAMEWORK
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DevOpsMigrationPlatform.Abstractions;
+using DevOpsMigrationPlatform.Abstractions.Jobs;
+using DevOpsMigrationPlatform.Infrastructure.Agent.Telemetry;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace DevOpsMigrationPlatform.Infrastructure.Tests.Telemetry;
+
+[TestClass]
+public class PackagePersistenceRunLogFlushTests
+{
+    [TestMethod]
+    public async Task PackageProgressSink_FlushAfterPackageStateClear_WritesToOriginalRunLogFolder()
+    {
+        var appendedPaths = new List<string>();
+        var mockStore = new Mock<IArtefactStore>(MockBehavior.Loose);
+        mockStore.Setup(s => s.AppendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, CancellationToken>((path, _, _) => appendedPaths.Add(path))
+            .Returns(Task.CompletedTask);
+
+        var state = new ActivePackageState
+        {
+            CurrentStore = mockStore.Object,
+            CurrentJob = new Job { JobId = "job-progress", Kind = JobKind.Export }
+        };
+        var expectedLogFolder = state.CurrentLogFolder;
+        var sink = new PackageProgressSink(state, NullLogger<PackageProgressSink>.Instance);
+
+        sink.Emit(new ProgressEvent { Module = "WorkItems", Stage = "Export", Message = "exported" });
+        state.Clear();
+
+        await sink.FlushAsync();
+
+        CollectionAssert.AreEqual(
+            new[] { $"{expectedLogFolder}/progress.jsonl" },
+            appendedPaths,
+            "Buffered progress events must stay in the run-scoped log folder captured while the job was active.");
+    }
+
+    [TestMethod]
+    public async Task PackageLoggerProvider_FlushAfterPackageStateClear_WritesToOriginalRunLogFolder()
+    {
+        var appendedPaths = new List<string>();
+        var mockStore = new Mock<IArtefactStore>(MockBehavior.Loose);
+        mockStore.Setup(s => s.AppendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, CancellationToken>((path, _, _) => appendedPaths.Add(path))
+            .Returns(Task.CompletedTask);
+
+        var state = new ActivePackageState
+        {
+            CurrentStore = mockStore.Object,
+            CurrentJob = new Job { JobId = "job-logger", Kind = JobKind.Import }
+        };
+        var expectedLogFolder = state.CurrentLogFolder;
+        using var provider = new PackageLoggerProvider(
+            state,
+            Options.Create(new DiagnosticLogOptions { MaxLogFileSizeMB = 50 }));
+        var logger = provider.CreateLogger("Test");
+
+        logger.LogInformation("imported");
+        state.Clear();
+
+        await provider.FlushAsync();
+
+        CollectionAssert.AreEqual(
+            new[] { $"{expectedLogFolder}/agent.jsonl" },
+            appendedPaths,
+            "Buffered diagnostic logs must stay in the run-scoped log folder captured while the job was active.");
+    }
+}
+#endif


### PR DESCRIPTION
### Motivation

- Fast jobs and abrupt shutdowns caused buffered progress/diagnostic records to be flushed to the fallback `.migration/Logs` instead of the original run-scoped folder, breaking package-level auditability.
- The sinks cached the `IArtefactStore` but not the run-folder path, creating a window where `ActivePackageState.Clear()` removed the run identity before buffered records were persisted.

### Description

- Cache the active run log folder alongside the cached artefact store in `PackageProgressSink` by adding a private `_lastKnownLogFolder` and populating it when the sink captures the active store, then use it when flushing after state clear; see `src/DevOpsMigrationPlatform.Infrastructure.Agent/Telemetry/PackageProgressSink.cs`.
- Apply the same run-folder caching to `PackageLoggerProvider` and prefer the cached folder when computing `CurrentLogPath` while the live package state is gone; see `src/DevOpsMigrationPlatform.Infrastructure.Agent/Telemetry/PackageLoggerProvider.cs`.
- Add focused behavioural unit tests that assert buffered progress and diagnostic writes still append to the captured run folder after `ActivePackageState.Clear()` in `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Telemetry/PackagePersistenceRunLogFlushTests.cs`.
- Include NKDA TDD safety-net artefacts for `agent_package_persistence`: assessment, target suite, architecture update, rebuild plan, implementation summary, and verification under `.output/nkda-tddsn/agent_package_persistence/`.

### Testing

- Static checks passed: `git diff --check` produced no whitespace errors.
- New unit tests were added for `PackageProgressSink` and `PackageLoggerProvider` to assert append paths (they rely on mocking `IArtefactStore`), but runtime test execution could not be completed in this environment because `dotnet` is not installed; the attempted command was `dotnet test ... --filter "FullyQualifiedName~PackagePersistenceRunLogFlushTests"` and failed with the CLI not found.
- Manual verification steps recorded: run the above `dotnet test` command in a .NET-enabled environment to confirm the new tests pass before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde33c5bfc832683e5fbd8ffaa8749)