### PR TITLE
Stabilize agent task dependency resume

### DIFF
--- a/.agents/context/architecture/agent-task-execution.md
+++ b/.agents/context/architecture/agent-task-execution.md
@@ -34,3 +34,10 @@ sequenceDiagram
   end
   TE-->>JW: bool success
 ```
+## Dependency and Resume Semantics
+
+- Tasks execute only after their declared `DependsOn` task IDs are satisfied.
+- `Completed` dependencies are satisfied, including when a persisted plan is resumed with downstream tasks still `Pending`.
+- `Skipped` and `Failed` dependencies are blockers. The executor cascades `Skipped` to pending downstream tasks before tier extraction and persists the updated plan.
+- Skip propagation applies to generic task execution, export/prerequisite execution, and import execution so control-plane progress and package state remain consistent across phases.
+- `Running` tasks are transient; crash recovery resets them to `Pending` before execution resumes.

--- a/.output/nkda-tddsn/agent_task_execution/01-assessment.md
+++ b/.output/nkda-tddsn/agent_task_execution/01-assessment.md
@@ -1,0 +1,91 @@
+# 01 — Assessment: agent_task_execution
+
+## Scope
+
+Subsystem: `agent_task_execution`.
+
+Primary context:
+
+- `.agents/context/architecture/agent-task-execution.md`
+- `src/DevOpsMigrationPlatform.Infrastructure.Agent/Context/JobPlanExecutor.cs`
+- `src/DevOpsMigrationPlatform.Infrastructure.Agent/Context/JobExecutionPlanBuilder.cs`
+- `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/JobPlanExecutorTests.cs`
+- `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/JobExecutionPlanBuilderTests.cs`
+- `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/JobExecutionPlanBuilderDependsOnTests.cs`
+
+## Behaviour Model Gate
+
+### Subsystem purpose
+
+`agent_task_execution` executes a persisted `JobTaskList` for migration agents. It must preserve deterministic phase ordering, enforce `DependsOn`, transition task state through the task lifecycle, persist every status transition, and emit task-level progress events for control-plane and UI consumers.
+
+### Primary behaviours
+
+1. Build or consume a `JobTaskList` with stable task IDs, task kind, phase, order, and dependency metadata.
+2. Extract runnable task tiers from dependency edges.
+3. Execute independent tasks in the same tier concurrently.
+4. Prevent dependent tasks from running when an upstream dependency is skipped or failed.
+5. Treat completed dependencies as satisfied when resuming a partially completed plan.
+6. Persist transitions to `PackagePaths.PlanFile` after running/completed/failed/skipped updates.
+7. Emit task lifecycle progress events with task ID, status, and progress counts when available.
+8. Reset `Running` tasks to `Pending` when loading a persisted plan after a crash.
+
+### State transitions
+
+- `Pending` → `Running` → `Completed`
+- `Pending` → `Running` → `Failed`
+- `Pending` → `Skipped` when a dependency is skipped/failed or prerequisite state makes the task unnecessary
+- `Running` → `Pending` during crash recovery via `LoadOrResetAsync`
+
+### External contracts
+
+- `JobTaskList`/`JobTask` are the control-plane-visible task contract.
+- `IStateStore` persists package job plan state.
+- `IProgressSink` emits lifecycle updates.
+- `IModule`, `ICapture`, and `IAnalyser` handlers are dispatched by task kind.
+
+### Failure and rejection behaviours
+
+- Missing handler registration fails the task and returns a failed execution result without cancelling sibling tasks in the same tier.
+- Failed upstream dependency skips downstream tasks.
+- Corrupt persisted plan returns `null` from `LoadOrResetAsync` so the caller can rebuild.
+- Unknown capture organisation URL fails the capture task without invoking the handler.
+
+### Boundary conditions
+
+- Completed or skipped tasks are not re-executed on resume.
+- Completed dependency tasks must not block their dependents.
+- Skipped/failed dependency tasks must cascade to direct and transitive dependents.
+- Capture tasks may be organisation/project-scoped.
+- Progress totals may be absent and must remain nullable.
+
+## Current Test Inventory
+
+| Test class | Current protection |
+| --- | --- |
+| `JobExecutionPlanBuilderTests` | Plan shape, ordering, disabled modules, persisted plan reuse, mode mismatch reset |
+| `JobExecutionPlanBuilderDependsOnTests` | Dependency graph generation, circular dependency rejection, disabled/missing dependency handling, inventory/dependency capture plans |
+| `JobPlanExecutorTests` | Concurrency, prerequisites, dependency wait/skip, failed sibling isolation, resume, capture routing, progress snapshots |
+| `JobAgentWorkerDispatchTests` | Agent dispatch into unified task execution and marker handling |
+| `JobAgentWorkerInventoryTests` | Inventory dispatch for multiple source endpoints |
+
+## TDD Quality Assessment
+
+| Area | Score | Notes |
+| --- | ---: | --- |
+| Behaviour focus | 4/5 | Tests generally assert observable task execution, persistence, and progress behaviour. |
+| Drift prevention | 3/5 | Good graph/build coverage, but resume dependency semantics had a gap. |
+| Refactor safety | 4/5 | Most tests use public executor/builder contracts rather than private methods. |
+| Boundary coverage | 3/5 | Existing coverage included failed dependencies but not completed-dependency resume and pre-skipped generic dependencies. |
+| Over-mocking risk | 3/5 | Module mocks are necessary but some tests assert call counts rather than persisted plan state. |
+
+## Drift Risks Identified
+
+1. A completed dependency on a resumed import plan could be treated as a blocker rather than a satisfied dependency.
+2. A pre-skipped dependency in generic task execution could be omitted from runnable tier extraction and accidentally treated as satisfied.
+3. Failed persisted tasks could be selected for rerun unless terminal states are consistently filtered.
+4. Architecture documentation did not explicitly state resume semantics for completed versus skipped/failed dependencies.
+
+## Assessment Conclusion
+
+The safety net was broadly useful but incomplete for dependency resume semantics. The target rebuild should add behavioural regression tests for completed-dependency resume and pre-skipped dependency cascade, then minimally adjust executor filtering and skip propagation.

--- a/.output/nkda-tddsn/agent_task_execution/02-target-test-suite.md
+++ b/.output/nkda-tddsn/agent_task_execution/02-target-test-suite.md
@@ -1,0 +1,41 @@
+# 02 — Target Test Suite: agent_task_execution
+
+## Target Suite Gate
+
+| Decision | Test class | Test method | Type | Protected behaviour | Expected assertions |
+| --- | --- | --- | --- | --- | --- |
+| Keep | `JobExecutionPlanBuilderTests` | Existing plan shape and persisted-plan tests | Unit/behaviour | Builder emits deterministic task plans and reuses terminal persisted plans | Task counts/order/statuses match contract |
+| Keep | `JobExecutionPlanBuilderDependsOnTests` | Existing dependency graph tests | Unit/behaviour | Builder creates valid dependency edges and rejects cycles | `DependsOn` arrays and exceptions match expected graph |
+| Keep | `JobPlanExecutorTests` | `ExecuteImportPhaseAsync_WorkItemsDependsOnIdentities_WaitsForIdentities` | Unit/behaviour | Dependent import task waits for upstream completion | Execution order has identities before workitems |
+| Keep | `JobPlanExecutorTests` | `ExecuteImportPhaseAsync_IdentitiesFails_WorkItemsSkipped` | Unit/behaviour | Failed upstream dependency skips dependent import task | Result fails and dependent handler is not invoked |
+| Add | `JobPlanExecutorTests` | `ExecuteImportPhaseAsync_PartialResume_CompletedDependencyAllowsDependentTaskToRun` | Unit/behaviour | Completed dependency satisfies a pending dependent during resume | Result succeeds and pending dependent handler runs |
+| Add | `JobPlanExecutorTests` | `ExecuteTasksAsync_SkippedDependency_SkipsDependentTaskWithoutInvokingHandler` | Unit/behaviour | Generic execution cascades a pre-skipped dependency to dependent tasks | Result succeeds as no runnable task fails, dependent handler is not invoked, skipped state persists |
+| Keep | `JobPlanExecutorTests` | `LoadOrResetAsync_RunningTasksAreResetToPending` | Unit/behaviour | Crash recovery clears transient running state | Running tasks become pending |
+| Keep | `JobAgentWorkerDispatchTests` | Existing dispatch tests | Unit/behaviour | Worker dispatches job kinds into task execution and marker writing | Executor receives expected route and markers are written only on success |
+
+## Proposed Minimal Skeletons
+
+```csharp
+[TestMethod]
+public async Task ExecuteImportPhaseAsync_PartialResume_CompletedDependencyAllowsDependentTaskToRun()
+{
+    // Arrange plan: import.identities completed, import.workitems pending depends on identities.
+    // Act import execution.
+    // Assert workitems executes and result succeeds.
+}
+
+[TestMethod]
+public async Task ExecuteTasksAsync_SkippedDependency_SkipsDependentTaskWithoutInvokingHandler()
+{
+    // Arrange plan: capture.identities skipped, capture.workitems pending depends on identities.
+    // Act generic task execution.
+    // Assert workitems handler is not invoked and skipped state is persisted.
+}
+```
+
+## Test Decisions for Relevant Existing Tests
+
+- Keep dependency wait, failure, and sibling isolation tests because they encode essential execution semantics.
+- Keep partial export resume test because it protects non-reexecution of completed tasks.
+- Add import partial resume with dependency because the existing import all-completed test does not cover a pending dependent with completed dependency.
+- Add generic skipped dependency cascade because unified inventory/dependency execution uses `ExecuteTasksAsync`, not the import-specific path.

--- a/.output/nkda-tddsn/agent_task_execution/03-architecture-update.md
+++ b/.output/nkda-tddsn/agent_task_execution/03-architecture-update.md
@@ -1,0 +1,21 @@
+# 03 — Architecture Update: agent_task_execution
+
+## Architecture Refresh
+
+The architecture narrative for `agent_task_execution` now needs to distinguish dependency satisfaction from dependency blocking during resume:
+
+- `Completed` dependencies are satisfied and must allow pending dependents to execute.
+- `Skipped` and `Failed` dependencies are blockers and must cascade `Skipped` to pending dependents before tier extraction.
+- The skip cascade must apply consistently across generic task execution, export/prerequisite execution, and import execution.
+- Persisted skipped dependent state is part of the package/control-plane contract so UI bootstrap and resumed agents see the same task state.
+
+## Documentation Change Applied
+
+Updated `.agents/context/architecture/agent-task-execution.md` with explicit dependency and resume semantics.
+
+## Guardrail Alignment
+
+- Preserves package state as the durable source of truth.
+- Preserves control-plane-visible task state through `JobTaskList`.
+- Does not introduce UI coupling or direct filesystem access.
+- Does not change connector behaviour.

--- a/.output/nkda-tddsn/agent_task_execution/04-rebuild-plan.md
+++ b/.output/nkda-tddsn/agent_task_execution/04-rebuild-plan.md
@@ -1,0 +1,31 @@
+# 04 — Rebuild Plan: agent_task_execution
+
+## Rebuild Plan
+
+1. Add a failing regression test for import partial resume where a completed dependency must satisfy a pending dependent.
+2. Add a failing regression test for generic execution where a pre-skipped dependency must skip the pending dependent without invoking the handler.
+3. Implement shared blocked-dependency skip propagation in `JobPlanExecutor`.
+4. Apply shared propagation to generic task execution, export/prerequisite execution, and import execution.
+5. Ensure runnable task filters exclude terminal failed/skipped/completed states.
+6. Update architecture context to record resume dependency semantics.
+7. Run the focused infrastructure agent test project using PowerShell.
+8. Produce implementation and verification artefacts.
+
+## Minimal Production Change Gate
+
+### Required production change
+
+`JobPlanExecutor` needs shared blocked-dependency propagation before tier extraction.
+
+### Behaviour being corrected
+
+- A pending dependent should run when the dependency is already `Completed`.
+- A pending dependent should skip when the dependency is already `Skipped` or `Failed`.
+
+### Why this is minimal
+
+The change is limited to executor state filtering and skip propagation. It does not alter plan building, task contracts, module APIs, control-plane APIs, connector code, or job dispatch.
+
+### Architecture documentation impact
+
+The subsystem architecture context required a concise update to document the explicit resume semantics.

--- a/.output/nkda-tddsn/agent_task_execution/05-implementation-summary.md
+++ b/.output/nkda-tddsn/agent_task_execution/05-implementation-summary.md
@@ -1,0 +1,24 @@
+# 05 — Implementation Summary: agent_task_execution
+
+## Implemented Changes
+
+- Added shared `MarkBlockedDependenciesSkippedAsync` handling in `JobPlanExecutor` so skipped/failed dependencies are cascaded to pending dependents before tier extraction.
+- Applied blocked-dependency handling to generic task execution, export/prerequisite execution, and import execution.
+- Updated runnable task filtering so terminal `Failed` tasks are not selected for rerun with pending tasks.
+- Corrected import resume semantics so `Completed` dependencies are treated as satisfied instead of blockers.
+- Added regression coverage for completed-dependency import resume.
+- Added regression coverage for pre-skipped dependency cascade in generic execution.
+- Updated `agent_task_execution` architecture context with dependency and resume semantics.
+
+## Minimal Change Gate Result
+
+The production change is limited to task executor state handling and does not change public task contracts, module interfaces, connector implementations, or control-plane APIs.
+
+## Tests Added
+
+- `ExecuteImportPhaseAsync_PartialResume_CompletedDependencyAllowsDependentTaskToRun`
+- `ExecuteTasksAsync_SkippedDependency_SkipsDependentTaskWithoutInvokingHandler`
+
+## Verification Limitation
+
+The focused test command was attempted with PowerShell, but the environment does not have the .NET SDK on `PATH` (`dotnet` command not found). The exact command and result are recorded in `06-verification.md`.

--- a/.output/nkda-tddsn/agent_task_execution/06-verification.md
+++ b/.output/nkda-tddsn/agent_task_execution/06-verification.md
@@ -1,0 +1,54 @@
+# 06 — Verification: agent_task_execution
+
+## Verification Gate
+
+### Test command used
+
+```powershell
+dotnet test tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests.csproj --filter FullyQualifiedName~JobPlanExecutorTests --no-restore
+```
+
+### Test result
+
+Environment-limited. PowerShell reported:
+
+```text
+dotnet: The term 'dotnet' is not recognized as a name of a cmdlet, function, script file, or executable program.
+```
+
+No passing test claim is made because the .NET SDK is unavailable in this container.
+
+### Additional checks
+
+```powershell
+git diff --check
+```
+
+Result: exit code 0 after trimming the architecture context file ending.
+
+## Changed Files Summary
+
+| File | Change |
+| --- | --- |
+| `src/DevOpsMigrationPlatform.Infrastructure.Agent/Context/JobPlanExecutor.cs` | Added shared blocked-dependency skip propagation and terminal task filtering. |
+| `tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/JobPlanExecutorTests.cs` | Added two behavioural regression tests for dependency resume/skip semantics. |
+| `.agents/context/architecture/agent-task-execution.md` | Documented completed/skipped/failed dependency resume semantics. |
+| `.output/nkda-tddsn/agent_task_execution/*.md` | Produced all six TDDSN workflow artefacts. |
+
+## Target Suite Coverage Status
+
+| Target behaviour | Status |
+| --- | --- |
+| Completed dependency satisfies pending import dependent on resume | Implemented in test and production code; not executable in this environment due missing SDK. |
+| Skipped dependency blocks generic dependent before handler invocation | Implemented in test and production code; not executable in this environment due missing SDK. |
+| Existing dependency wait/failure/sibling isolation tests retained | Existing tests unchanged. |
+| Architecture semantics documented | Updated in subsystem context. |
+
+## Remaining Drift Risks
+
+- Test execution must be run in an environment with .NET SDK 10.0.201 or compatible `latestPatch` roll-forward.
+- The export prerequisite inventory-marker branch has complex skip behaviour that should remain covered by existing tests and may benefit from a future dedicated resume matrix.
+
+## Guardrail Violations
+
+None identified in the modified scope. The changes preserve package-backed durable task state, do not add direct filesystem access in module code, do not change connector behaviour, and do not introduce UI coupling.

--- a/src/DevOpsMigrationPlatform.Infrastructure.Agent/Context/JobPlanExecutor.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure.Agent/Context/JobPlanExecutor.cs
@@ -79,6 +79,7 @@ public sealed class JobPlanExecutor : IJobPlanExecutor
             stateStore,
             ct).ConfigureAwait(false);
 
+        var hasCanonicalFailures = HasFailedTasks(plan, _ => true);
         var tasks = plan.Tasks
             .Where(t => t.Status != JobTaskStatus.Skipped
                 && t.Status != JobTaskStatus.Completed
@@ -87,8 +88,10 @@ public sealed class JobPlanExecutor : IJobPlanExecutor
 
         if (tasks.Count == 0)
         {
-            _logger.LogInformation("ExecuteTasksAsync: no tasks to execute (all skipped or completed).");
-            return true;
+            _logger.LogInformation(
+                "ExecuteTasksAsync: no tasks to execute (all skipped, completed, or failed). Failed task(s) present: {HasFailedTasks}.",
+                hasCanonicalFailures);
+            return !hasCanonicalFailures;
         }
 
         var tiers = ExtractTiers(tasks);
@@ -170,14 +173,20 @@ public sealed class JobPlanExecutor : IJobPlanExecutor
                 tierIndex, tier.Count - result.FailedTaskIds.Count, result.FailedTaskIds.Count);
         }
 
-        if (anyFailed)
+        if (anyFailed || hasCanonicalFailures)
         {
-            _logger.LogWarning("ExecuteTasksAsync completed with {FailedCount} failed task(s).", failedTasks.Count);
+            _logger.LogWarning(
+                "ExecuteTasksAsync completed with {FailedCount} newly failed task(s). Persisted failed task(s) present: {HasFailedTasks}.",
+                failedTasks.Count,
+                hasCanonicalFailures);
             return false;
         }
 
         return true;
     }
+
+    private static bool HasFailedTasks(JobTaskList plan, Func<JobTask, bool> isInScope)
+        => plan.Tasks.Any(t => isInScope(t) && t.Status == JobTaskStatus.Failed);
 
     private async Task<JobTaskList> MarkBlockedDependenciesSkippedAsync(
         JobTaskList plan,
@@ -265,6 +274,7 @@ public sealed class JobPlanExecutor : IJobPlanExecutor
             stateStore,
             ct).ConfigureAwait(false);
 
+        var hasCanonicalFailures = HasFailedTasks(plan, t => t.Phase == "Export" || t.TaskKind is TaskKind.Capture or TaskKind.Analyse);
         var tasks = plan.Tasks
             .Where(t => (t.Phase == "Export" || t.TaskKind is TaskKind.Capture or TaskKind.Analyse)
                 && t.Status != JobTaskStatus.Skipped
@@ -326,8 +336,10 @@ public sealed class JobPlanExecutor : IJobPlanExecutor
 
         if (tasks.Count == 0)
         {
-            _logger.LogInformation("Export phase: no tasks to execute (all skipped or completed).");
-            return true;
+            _logger.LogInformation(
+                "Export phase: no tasks to execute (all skipped, completed, or failed). Failed task(s) present: {HasFailedTasks}.",
+                hasCanonicalFailures);
+            return !hasCanonicalFailures;
         }
 
         // Use the same tier-based execution as Import so that tasks with DependsOn
@@ -420,9 +432,12 @@ public sealed class JobPlanExecutor : IJobPlanExecutor
                 tierIndex, tier.Count - result.FailedTaskIds.Count, result.FailedTaskIds.Count);
         }
 
-        if (anyFailed)
+        if (anyFailed || hasCanonicalFailures)
         {
-            _logger.LogWarning("Export phase completed with {FailedCount} failed task(s).", failedTasks.Count);
+            _logger.LogWarning(
+                "Export phase completed with {FailedCount} newly failed task(s). Persisted failed task(s) present: {HasFailedTasks}.",
+                failedTasks.Count,
+                hasCanonicalFailures);
             return false;
         }
 
@@ -537,6 +552,7 @@ public sealed class JobPlanExecutor : IJobPlanExecutor
             stateStore,
             ct).ConfigureAwait(false);
 
+        var hasCanonicalFailures = HasFailedTasks(plan, t => t.Phase == "Import");
         var tasksToExecute = plan.Tasks
             .Where(t => t.Phase == "Import"
                 && t.Status != JobTaskStatus.Skipped
@@ -546,8 +562,10 @@ public sealed class JobPlanExecutor : IJobPlanExecutor
 
         if (tasksToExecute.Count == 0)
         {
-            _logger.LogInformation("Import phase: no tasks to execute (all skipped or completed).");
-            return true;
+            _logger.LogInformation(
+                "Import phase: no tasks to execute (all skipped, completed, or failed). Failed task(s) present: {HasFailedTasks}.",
+                hasCanonicalFailures);
+            return !hasCanonicalFailures;
         }
 
         var tiers = ExtractTiers(tasksToExecute);
@@ -634,9 +652,12 @@ public sealed class JobPlanExecutor : IJobPlanExecutor
                 0); // Skipped count is zero at tier-exec time; skips happen after failures.
         }
 
-        if (anyFailed)
+        if (anyFailed || hasCanonicalFailures)
         {
-            _logger.LogWarning("Import phase completed with {FailedCount} failed task(s).", failedTasks.Count);
+            _logger.LogWarning(
+                "Import phase completed with {FailedCount} newly failed task(s). Persisted failed task(s) present: {HasFailedTasks}.",
+                failedTasks.Count,
+                hasCanonicalFailures);
             return false;
         }
 

--- a/src/DevOpsMigrationPlatform.Infrastructure.Agent/Context/JobPlanExecutor.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure.Agent/Context/JobPlanExecutor.cs
@@ -71,8 +71,18 @@ public sealed class JobPlanExecutor : IJobPlanExecutor
         IStateStore stateStore,
         CancellationToken ct)
     {
+        plan = await MarkBlockedDependenciesSkippedAsync(
+            plan,
+            _ => true,
+            "Task.Skipped",
+            captureHandlersByName.Keys.Concat(analysersByName.Keys),
+            stateStore,
+            ct).ConfigureAwait(false);
+
         var tasks = plan.Tasks
-            .Where(t => t.Status != JobTaskStatus.Skipped && t.Status != JobTaskStatus.Completed)
+            .Where(t => t.Status != JobTaskStatus.Skipped
+                && t.Status != JobTaskStatus.Completed
+                && t.Status != JobTaskStatus.Failed)
             .ToList();
 
         if (tasks.Count == 0)
@@ -169,6 +179,74 @@ public sealed class JobPlanExecutor : IJobPlanExecutor
         return true;
     }
 
+    private async Task<JobTaskList> MarkBlockedDependenciesSkippedAsync(
+        JobTaskList plan,
+        Func<JobTask, bool> isInScope,
+        string stage,
+        IEnumerable<string> registeredNames,
+        IStateStore stateStore,
+        CancellationToken ct)
+    {
+        var scopedTasks = plan.Tasks.Where(isInScope).ToList();
+        var blockedTaskIds = scopedTasks
+            .Where(t => t.Status is JobTaskStatus.Skipped or JobTaskStatus.Failed)
+            .Select(t => t.Id)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (blockedTaskIds.Count == 0)
+            return plan;
+
+        bool changed;
+        do
+        {
+            changed = false;
+            foreach (var task in plan.Tasks.Where(isInScope))
+            {
+                if (task.Status is JobTaskStatus.Completed or JobTaskStatus.Skipped or JobTaskStatus.Failed)
+                    continue;
+
+                if (task.DependsOn is null || !task.DependsOn.Any(dep => blockedTaskIds.Contains(dep)))
+                    continue;
+
+                var matchedDep = task.DependsOn.First(dep => blockedTaskIds.Contains(dep));
+                var updated = task with
+                {
+                    Status = JobTaskStatus.Skipped,
+                    SkipReason = $"Dependency '{matchedDep}' failed or was skipped."
+                };
+
+                var taskList = plan.Tasks.ToList();
+                var idx = taskList.FindIndex(t => t.Id == task.Id);
+                if (idx < 0)
+                    continue;
+
+                taskList[idx] = updated;
+                plan = plan with { Tasks = taskList.AsReadOnly() };
+                await PersistPlanAsync(plan, stateStore, ct).ConfigureAwait(false);
+
+                _progressSink?.Emit(new ProgressEvent
+                {
+                    Module = GetModuleName(task.Id, registeredNames),
+                    Stage = stage,
+                    Message = $"Skipped due to failed dependency: {matchedDep}",
+                    Timestamp = DateTimeOffset.UtcNow,
+                    TaskId = task.Id,
+                    TaskStatus = JobTaskStatus.Skipped
+                });
+
+                _logger.LogWarning(
+                    "Task {TaskId} skipped — dependency {Dependency} failed or was skipped.",
+                    task.Id, matchedDep);
+
+                blockedTaskIds.Add(task.Id);
+                changed = true;
+            }
+        }
+        while (changed);
+
+        return plan;
+    }
+
     public async Task<bool> ExecuteExportPhaseAsync(
         JobTaskList plan,
         IReadOnlyDictionary<string, IModule> modulesByName,
@@ -179,10 +257,19 @@ public sealed class JobPlanExecutor : IJobPlanExecutor
         IStateStore stateStore,
         CancellationToken ct)
     {
+        plan = await MarkBlockedDependenciesSkippedAsync(
+            plan,
+            t => t.Phase == "Export" || t.TaskKind is TaskKind.Capture or TaskKind.Analyse,
+            "Export.Skipped",
+            modulesByName.Keys.Concat(analysersByName.Keys),
+            stateStore,
+            ct).ConfigureAwait(false);
+
         var tasks = plan.Tasks
             .Where(t => (t.Phase == "Export" || t.TaskKind is TaskKind.Capture or TaskKind.Analyse)
                 && t.Status != JobTaskStatus.Skipped
-                && t.Status != JobTaskStatus.Completed)
+                && t.Status != JobTaskStatus.Completed
+                && t.Status != JobTaskStatus.Failed)
             .ToList();
 
         if (await HasInventoryCompletionMarkerAsync(stateStore, ct).ConfigureAwait(false))
@@ -442,56 +529,20 @@ public sealed class JobPlanExecutor : IJobPlanExecutor
         IStateStore stateStore,
         CancellationToken ct)
     {
-        // Filter out already-completed or skipped tasks, and mark tasks with skipped dependencies as skipped.
-        var skippedOrCompletedIds = plan.Tasks
-            .Where(t => t.Phase == "Import" && (t.Status == JobTaskStatus.Skipped || t.Status == JobTaskStatus.Completed || t.Status == JobTaskStatus.Failed))
-            .Select(t => t.Id)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        plan = await MarkBlockedDependenciesSkippedAsync(
+            plan,
+            t => t.Phase == "Import",
+            "Import.Skipped",
+            modulesByName.Keys,
+            stateStore,
+            ct).ConfigureAwait(false);
 
-        // Mark tasks depending on skipped/failed tasks as skipped before tier extraction.
-        var tasksToExecute = new List<JobTask>();
-        foreach (var task in plan.Tasks.Where(t => t.Phase == "Import"))
-        {
-            if (skippedOrCompletedIds.Contains(task.Id))
-                continue; // Already skipped/completed/failed
-
-            // Check if any dependency is skipped or failed
-            if (task.DependsOn is not null && task.DependsOn.Any(dep => skippedOrCompletedIds.Contains(dep)))
-            {
-                var matchedDep = task.DependsOn.First(dep => skippedOrCompletedIds.Contains(dep));
-                var updated = task with
-                {
-                    Status = JobTaskStatus.Skipped,
-                    SkipReason = $"Dependency '{matchedDep}' was skipped or failed."
-                };
-
-                // Update in plan and persist
-                var taskList = plan.Tasks.ToList();
-                var idx = taskList.FindIndex(t => t.Id == task.Id);
-                if (idx >= 0)
-                {
-                    taskList[idx] = updated;
-                    plan = plan with { Tasks = taskList.AsReadOnly() };
-                    await PersistPlanAsync(plan, stateStore, ct).ConfigureAwait(false);
-
-                    _progressSink?.Emit(new ProgressEvent
-                    {
-                        Module = GetModuleName(task.Id, modulesByName.Keys),
-                        Stage = "Import.Skipped",
-                        Message = $"Skipped due to dependency: {matchedDep}",
-                        Timestamp = DateTimeOffset.UtcNow,
-                        TaskId = task.Id,
-                        TaskStatus = JobTaskStatus.Skipped
-                    });
-                }
-
-                skippedOrCompletedIds.Add(task.Id); // Add to skipped set for cascading dependencies
-            }
-            else
-            {
-                tasksToExecute.Add(task);
-            }
-        }
+        var tasksToExecute = plan.Tasks
+            .Where(t => t.Phase == "Import"
+                && t.Status != JobTaskStatus.Skipped
+                && t.Status != JobTaskStatus.Completed
+                && t.Status != JobTaskStatus.Failed)
+            .ToList();
 
         if (tasksToExecute.Count == 0)
         {

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/JobPlanExecutorTests.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/JobPlanExecutorTests.cs
@@ -778,6 +778,52 @@ public sealed class JobPlanExecutorTests
     }
 
     [TestMethod]
+    public async Task ExecuteTasksAsync_FailedDependencyOnResume_ReturnsFalseAndSkipsDependentTask()
+    {
+        var invoked = false;
+        var captureHandler = new Mock<ICapture>(MockBehavior.Strict);
+        captureHandler.SetupGet(c => c.Name).Returns("workitems");
+        captureHandler.Setup(c => c.CaptureAsync(It.IsAny<InventoryContext>(), It.IsAny<CancellationToken>()))
+            .Callback(() => invoked = true)
+            .Returns(Task.CompletedTask);
+
+        var handlers = new Dictionary<string, ICapture>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["workitems"] = captureHandler.Object
+        };
+
+        var stateStore = new InMemoryStateStore();
+        var plan = CreatePlan(new[]
+        {
+            CreateTask("capture.identities.org.project", "Identities Capture", "Capture", status: JobTaskStatus.Failed),
+            CreateTask(
+                "capture.workitems.org.project",
+                "WorkItems Capture",
+                "Capture",
+                dependsOn: new[] { "capture.identities.org.project" })
+        });
+
+        var result = await CreateExecutor().ExecuteTasksAsync(
+            plan,
+            handlers,
+            new Dictionary<string, IAnalyser>(StringComparer.OrdinalIgnoreCase),
+            CreateMinimalInventoryContext(stateStore),
+            null,
+            null,
+            new Dictionary<string, OrganisationEndpoint>(StringComparer.OrdinalIgnoreCase),
+            stateStore,
+            CancellationToken.None);
+
+        Assert.IsFalse(result, "A resumed canonical plan containing a failed task must keep the job failed.");
+        Assert.IsFalse(invoked, "Dependent capture handlers must not run when their dependency already failed.");
+
+        var persisted = await stateStore.ReadAsync(PackagePaths.PlanFile, CancellationToken.None);
+        Assert.IsNotNull(persisted, "The skipped dependent state should be persisted for resume and UI bootstrap.");
+        StringAssert.Contains(persisted, "capture.workitems.org.project");
+        StringAssert.Contains(persisted, "failed or was skipped");
+    }
+
+    [TestMethod]
     public async Task ExecuteTasksAsync_SkippedDependency_SkipsDependentTaskWithoutInvokingHandler()
     {
         var invoked = false;
@@ -820,6 +866,44 @@ public sealed class JobPlanExecutorTests
         var persisted = await stateStore.ReadAsync(PackagePaths.PlanFile, CancellationToken.None);
         Assert.IsNotNull(persisted, "The skipped dependent state should be persisted for resume and UI bootstrap.");
         StringAssert.Contains(persisted, "capture.workitems.org.project");
+        StringAssert.Contains(persisted, "failed or was skipped");
+    }
+
+    [TestMethod]
+    public async Task ExecuteImportPhaseAsync_FailedDependencyOnResume_ReturnsFalseAndSkipsDependentTask()
+    {
+        var invoked = false;
+        var workItemsModule = new Mock<IModule>(MockBehavior.Strict);
+        workItemsModule.SetupGet(m => m.Name).Returns("WorkItems");
+        workItemsModule.Setup(m => m.ImportAsync(It.IsAny<ImportContext>(), It.IsAny<CancellationToken>()))
+            .Callback(() => invoked = true)
+            .Returns(Task.CompletedTask);
+
+        var modules = new Dictionary<string, IModule>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["WorkItems"] = workItemsModule.Object
+        };
+
+        var stateStore = new InMemoryStateStore();
+        var plan = CreatePlan(new[]
+        {
+            CreateTask("import.identities", "Identities Import", "Import", status: JobTaskStatus.Failed),
+            CreateTask("import.workitems", "WorkItems Import", "Import", dependsOn: new[] { "import.identities" })
+        });
+
+        var result = await CreateExecutor().ExecuteImportPhaseAsync(
+            plan,
+            modules,
+            new ImportContext(),
+            stateStore,
+            CancellationToken.None);
+
+        Assert.IsFalse(result, "A resumed import plan containing a failed task must keep the phase failed.");
+        Assert.IsFalse(invoked, "Dependent import modules must not run when their dependency already failed.");
+
+        var persisted = await stateStore.ReadAsync(PackagePaths.PlanFile, CancellationToken.None);
+        Assert.IsNotNull(persisted, "The skipped dependent state should be persisted for resume and UI bootstrap.");
+        StringAssert.Contains(persisted, "import.workitems");
         StringAssert.Contains(persisted, "failed or was skipped");
     }
 

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/JobPlanExecutorTests.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Context/JobPlanExecutorTests.cs
@@ -741,6 +741,88 @@ public sealed class JobPlanExecutorTests
         Assert.IsTrue(result, "Import phase should return true when all tasks are already completed");
     }
 
+    [TestMethod]
+    public async Task ExecuteImportPhaseAsync_PartialResume_CompletedDependencyAllowsDependentTaskToRun()
+    {
+        var identitiesModule = new Mock<IModule>(MockBehavior.Strict);
+        identitiesModule.SetupGet(m => m.Name).Returns("Identities");
+
+        var invoked = false;
+        var workItemsModule = new Mock<IModule>(MockBehavior.Strict);
+        workItemsModule.SetupGet(m => m.Name).Returns("WorkItems");
+        workItemsModule.Setup(m => m.ImportAsync(It.IsAny<ImportContext>(), It.IsAny<CancellationToken>()))
+            .Callback(() => invoked = true)
+            .Returns(Task.CompletedTask);
+
+        var modules = new Dictionary<string, IModule>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Identities"] = identitiesModule.Object,
+            ["WorkItems"] = workItemsModule.Object
+        };
+
+        var plan = CreatePlan(new[]
+        {
+            CreateTask("import.identities", "Identities Import", "Import", status: JobTaskStatus.Completed),
+            CreateTask("import.workitems", "WorkItems Import", "Import", dependsOn: new[] { "import.identities" })
+        });
+
+        var result = await CreateExecutor().ExecuteImportPhaseAsync(
+            plan,
+            modules,
+            new ImportContext(),
+            new InMemoryStateStore(),
+            CancellationToken.None);
+
+        Assert.IsTrue(result, "A completed dependency should satisfy the dependent import task on resume.");
+        Assert.IsTrue(invoked, "The dependent pending task should execute after its dependency has already completed.");
+    }
+
+    [TestMethod]
+    public async Task ExecuteTasksAsync_SkippedDependency_SkipsDependentTaskWithoutInvokingHandler()
+    {
+        var invoked = false;
+        var captureHandler = new Mock<ICapture>(MockBehavior.Strict);
+        captureHandler.SetupGet(c => c.Name).Returns("workitems");
+        captureHandler.Setup(c => c.CaptureAsync(It.IsAny<InventoryContext>(), It.IsAny<CancellationToken>()))
+            .Callback(() => invoked = true)
+            .Returns(Task.CompletedTask);
+
+        var handlers = new Dictionary<string, ICapture>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["workitems"] = captureHandler.Object
+        };
+
+        var stateStore = new InMemoryStateStore();
+        var plan = CreatePlan(new[]
+        {
+            CreateTask("capture.identities.org.project", "Identities Capture", "Capture", status: JobTaskStatus.Skipped),
+            CreateTask(
+                "capture.workitems.org.project",
+                "WorkItems Capture",
+                "Capture",
+                dependsOn: new[] { "capture.identities.org.project" })
+        });
+
+        var result = await CreateExecutor().ExecuteTasksAsync(
+            plan,
+            handlers,
+            new Dictionary<string, IAnalyser>(StringComparer.OrdinalIgnoreCase),
+            CreateMinimalInventoryContext(stateStore),
+            null,
+            null,
+            new Dictionary<string, OrganisationEndpoint>(StringComparer.OrdinalIgnoreCase),
+            stateStore,
+            CancellationToken.None);
+
+        Assert.IsTrue(result, "Skipping a blocked dependent task is a successful no-op when no runnable tasks fail.");
+        Assert.IsFalse(invoked, "Dependent capture handlers must not run when their dependency was skipped.");
+
+        var persisted = await stateStore.ReadAsync(PackagePaths.PlanFile, CancellationToken.None);
+        Assert.IsNotNull(persisted, "The skipped dependent state should be persisted for resume and UI bootstrap.");
+        StringAssert.Contains(persisted, "capture.workitems.org.project");
+        StringAssert.Contains(persisted, "failed or was skipped");
+    }
+
     /// <summary>
     /// Regression guard: mixed plan where some tasks are Completed and one is still Pending.
     /// Only the Pending task's module should execute; the completed ones must not.


### PR DESCRIPTION
### Motivation

- Fix incorrect resume behaviour where a `Completed` dependency could block a pending dependent and where pre-skipped/failed dependencies were not consistently propagated to downstream tasks.  
- Ensure the task executor consistently persists and emits the canonical `JobTaskList` state so UI/control-plane and resumed agents observe identical task status.  

### Description

- Add a shared helper `MarkBlockedDependenciesSkippedAsync` in `JobPlanExecutor` and invoke it before tier extraction in `ExecuteTasksAsync`, `ExecuteExportPhaseAsync`, and `ExecuteImportPhaseAsync`, so `Skipped`/`Failed` dependencies cascade to pending dependents and are persisted.  
- Change runnable task filtering to exclude terminal `Failed` tasks so pending tasks are not selected for rerun incorrectly.  
- Add two behavioural regression tests to `tests/.../JobPlanExecutorTests.cs`: `ExecuteImportPhaseAsync_PartialResume_CompletedDependencyAllowsDependentTaskToRun` and `ExecuteTasksAsync_SkippedDependency_SkipsDependentTaskWithoutInvokingHandler`.  
- Update subsystem documentation `.agents/context/architecture/agent-task-execution.md` with explicit dependency/resume semantics and produce the NKDA TDDSN artefacts under `.output/nkda-tddsn/agent_task_execution/`.

### Testing

- Ran `git diff --cached --check` and staged + committed the changes; pre-commit checks passed.  
- Attempted to run the focused unit tests with `dotnet test` and to run `dotnet format`, but the container environment does not have the .NET SDK available so the test/format steps could not be executed (recorded in `.output/nkda-tddsn/agent_task_execution/06-verification.md`).  
- New tests added: `ExecuteImportPhaseAsync_PartialResume_CompletedDependencyAllowsDependentTaskToRun` and `ExecuteTasksAsync_SkippedDependency_SkipsDependentTaskWithoutInvokingHandler` (not executed here due to SDK absence).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde33666fc8326b2af3f6f70b2c6fb)