### PR TITLE
fix: correct path for release packages in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,8 @@ jobs:
         if: github.event_name != 'pull_request'
         with:
           name: release-packages
-          path: output/MigrationTools-*.zip
+          path: '.output/MigrationTools-*.zip'
+          if-no-files-found: error
 
   # ── Preview release: auto-create on main push ──────────────────────────────
   preview-release:


### PR DESCRIPTION
This pull request makes a minor update to the workflow configuration for releasing packages. The change ensures that the release step fails if the expected output files are not found, and also corrects the path to the output files.

* Workflow configuration improvements:
  * [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L101-R102): Updated the `path` for release artifacts to `.output/MigrationTools-*.zip` and added `if-no-files-found: error` to ensure the workflow fails if no files are found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for release package artifact handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nkdAgility/azure-devops-migration-platform/pull/106)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->