### PR TITLE
Ensure accurate final summary for fast jobs by draining updates

### DIFF
--- a/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
@@ -778,6 +778,14 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                     }
                     if (update is JobTerminated jt)
                     {
+                        // On fast jobs the SSE stream ends before the bootstrap HTTP call
+                        // completes — drain pending updates so the final summary is accurate.
+                        try { await bootstrapTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false); }
+                        catch (OperationCanceledException) { }
+                        catch (Exception) { /* best-effort */ }
+                        while (updates.Reader.TryRead(out var pending))
+                            state = Apply(state, pending);
+
                         if (jt.Failed)
                         {
                             jobFailed = true;
@@ -823,6 +831,18 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                                 ctx.UpdateTarget(BuildProgressDisplay(state));
                             if (update is JobTerminated jt)
                             {
+                                // On fast jobs the SSE stream ends before the bootstrap HTTP
+                                // call completes. Await bootstrap then drain pending updates
+                                // so the final render shows completed tasks, not the spinner.
+                                try { await bootstrapTask.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false); }
+                                catch (OperationCanceledException) { }
+                                catch (Exception) { /* best-effort */ }
+                                while (updates.Reader.TryRead(out var pending))
+                                    state = Apply(state, pending);
+
+                                if (state.Tasks is not null)
+                                    ctx.UpdateTarget(BuildProgressDisplay(state));
+
                                 if (jt.Failed)
                                 {
                                     jobFailed = true;


### PR DESCRIPTION
This pull request improves the accuracy and completeness of the progress display and summary in the `QueueCommand` by ensuring that all pending updates are processed before the final output, particularly for fast jobs where the SSE stream can end before the bootstrap HTTP call completes.

**Progress and summary accuracy improvements:**

* In `QueueCommand.cs`, after receiving a `JobTerminated` update, the code now waits (up to 5 seconds) for the bootstrap task to complete and drains any remaining updates from the queue to ensure the final state and summary are accurate.
* Similarly, in the live progress display logic, the code waits for the bootstrap task and processes any pending updates before the final render, ensuring that completed tasks are shown instead of a spinner. The UI is updated one last time if there are tasks present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced end-of-job rendering accuracy for fast migration jobs where the progress stream completes before system initialisation finishes.
  * Resolved an issue where pending job updates were not properly processed before final display, preventing the UI from correctly transitioning from loading state upon job completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nkdAgility/azure-devops-migration-platform/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->