### PR TITLE
Allow nkda-testdsl-autonomous to process feature folders

### DIFF
--- a/.agents/skill-sets/nkda-testdsl/workflow.md
+++ b/.agents/skill-sets/nkda-testdsl/workflow.md
@@ -29,7 +29,7 @@
 
 ## Autonomous Workflow
 
-Autonomous execution runs the seven phases in order for exactly one feature family:
+Autonomous execution runs the seven phases in order for each selected feature family:
 
 1. assessment
 2. dsl design
@@ -37,7 +37,7 @@ Autonomous execution runs the seven phases in order for exactly one feature fami
 4. conversion
 5. refactor
 6. verification
-7. next-feature recommendation
+7. next-feature recommendation (after the final selected family)
 
 ## Entry Point
 
@@ -55,6 +55,13 @@ Invoke it as:
 - named feature family
 
 If `{feature}` is omitted, `nkda-testdsl-autonomous` must run `nkda-testdsl-next-feature-selection` first and then continue the full loop.
+
+If `{feature}` is a folder, `nkda-testdsl-autonomous` must:
+
+1. resolve all `.feature` files under that folder
+2. map them to feature families
+3. process each unique family in deterministic path order
+4. run the full six conversion phases per family, then run next-feature-selection after the final family
 
 ## Phase Gates
 
@@ -93,7 +100,7 @@ A family is complete only when:
 
 ### Stop Gate
 
-Autonomous execution stops after one family or sooner if:
+Autonomous execution stops after all selected families are complete, or sooner if:
 
 - behaviour parity cannot be established
 - conversion requires unplanned production behaviour changes

--- a/.agents/skills/nkda-testdsl-autonomous/SKILL.md
+++ b/.agents/skills/nkda-testdsl-autonomous/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nkda-testdsl-autonomous
-description: Use when the user wants a single autonomous entrypoint that migrates one Reqnroll feature family to internal DSL without manually running each phase.
+description: Use when the user wants a single autonomous entrypoint that migrates one or more Reqnroll feature families to internal DSL without manually running each phase.
 ---
 
 # Skill: NKDA Test DSL Autonomous
@@ -20,7 +20,7 @@ Where `{feature}` is one of:
 
 ## Required Behavior
 
-Run this sequence for exactly one feature family:
+Run this sequence for each selected feature family:
 
 1. `nkda-testdsl-feature-assessment`
 2. `nkda-testdsl-dsl-design`
@@ -28,16 +28,23 @@ Run this sequence for exactly one feature family:
 4. `nkda-testdsl-feature-conversion`
 5. `nkda-testdsl-refactor`
 6. `nkda-testdsl-verification`
-7. `nkda-testdsl-next-feature-selection`
+7. `nkda-testdsl-next-feature-selection` (after the final selected family is completed)
 
 ## Input Handling
 
-- If `{feature}` is provided, use it directly.
-- If `{feature}` is missing, run `nkda-testdsl-next-feature-selection` to select one, then continue.
+- If `{feature}` is a feature family name, feature file path, or step file path, resolve it to one feature family and run the sequence once.
+- If `{feature}` is a folder, resolve every `.feature` file under that folder, map each file to its feature family, then run the sequence once per family until the folder scope is exhausted.
+- If `{feature}` is missing, run `nkda-testdsl-next-feature-selection` to select one family, then continue.
 
 ## Stopping Rules
 
-Stop after one feature family.
+Stop after all selected families complete.
+
+For folder input:
+
+- process families in deterministic path order
+- skip duplicate family resolutions
+- stop when every resolved family has completed or when an early-stop condition is met
 
 Stop early if:
 
@@ -45,4 +52,3 @@ Stop early if:
 - behaviour parity cannot be established
 - conversion requires unplanned production behaviour changes
 - failures cannot be resolved in feature-family scope
-


### PR DESCRIPTION
## Why
`nkda-testdsl-autonomous` already accepted folder input, but its workflow contract still described single-family execution. That mismatch made folder usage ambiguous.

## What changed
Updated the autonomous skill and workflow docs so folder input is explicitly supported as a multi-family run:

- Folder input now resolves all `.feature` files under the folder.
- Resolved feature families are deduplicated and processed in deterministic path order.
- The 6 conversion phases run once per resolved family.
- `nkda-testdsl-next-feature-selection` now runs after the final selected family.
- Stop behavior now reflects folder scope completion, while preserving the existing early-stop conditions.

## Notes for reviewers
This is a contract/documentation alignment change in the Test DSL skill surface only; no runtime migration code paths were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded autonomous execution to support migrating multiple feature families from a folder rather than single-family operation. Clarified input handling for various feature references and folder processing with deterministic ordering. Full assessment-through-verification phases execute for each unique family, followed by next-feature selection after final family completion. Stopping rules now account for all selected families.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nkdAgility/azure-devops-migration-platform/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->