### PR TITLE
feat(inventory): add work item counts per area path

### DIFF
--- a/.agents/skills/source-command-nkda-core-implementation-architecture-compliance/SKILL.md
+++ b/.agents/skills/source-command-nkda-core-implementation-architecture-compliance/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: "source-command-nkda-core-implementation-architecture-compliance"
+description: "Implementation-time architecture compliance review for changed code."
+---
+
+# source-command-nkda-core-implementation-architecture-compliance
+
+Use this skill when the user asks to run the migrated source command `nkda-core-implementation-architecture-compliance`.
+
+## Command Template
+
+# NKDA Core Implementation Architecture Compliance
+
+Repository-local command surface for the mandatory `after_implement` architecture gate.
+
+## Scope
+
+Validate changed implementation against:
+- architecture boundaries and capability seams,
+- all five architecture perspectives + architecture deepening,
+- guardrail-driven reject conditions for shortcuts/stubs/partial states.
+
+## Required Outcome
+
+- **PASS** only when all perspectives are explicitly evidenced and no guardrail violation remains.
+- **FAIL** on any missing perspective evidence, seam bypass, stub placeholder, or deferral pattern.
+
+If `FAIL`, completion must be blocked.

--- a/.agents/skills/source-command-nkda-core-tasks-architecture-compliance/SKILL.md
+++ b/.agents/skills/source-command-nkda-core-tasks-architecture-compliance/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: "source-command-nkda-core-tasks-architecture-compliance"
+description: "Design-time architecture compliance review for tasks.md against spec.md and plan.md."
+---
+
+# source-command-nkda-core-tasks-architecture-compliance
+
+Use this skill when the user asks to run the migrated source command `nkda-core-tasks-architecture-compliance`.
+
+## Command Template
+
+# NKDA Core Tasks Architecture Compliance
+
+Repository-local command surface for the mandatory `after_tasks` architecture gate.
+
+## Scope
+
+Validate `tasks.md` design coverage against:
+- `spec.md`
+- `plan.md`
+- active architecture guardrails
+- five architecture perspectives + architecture deepening
+
+## Required Outcome
+
+- **PASS** only when every requirement has concrete implementation tasks and no perspective fails.
+- **FAIL** when any requirement is missing, partially specified, or any perspective is non-compliant.
+
+If `FAIL`, implementation must not begin.

--- a/.agents/skills/source-command-nkda-tddsn-autonomous/SKILL.md
+++ b/.agents/skills/source-command-nkda-tddsn-autonomous/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: "source-command-nkda-tddsn-autonomous"
+description: "Run the NKDA TDD Safety Net autonomous pipeline for the active subsystem."
+---
+
+# source-command-nkda-tddsn-autonomous
+
+Use this skill when the user asks to run the migrated source command `nkda-tddsn-autonomous`.
+
+## Command Template
+
+# NKDA TDDSN Autonomous Command
+
+This command is the command-surface artifact required by the repository workflow guardrails.
+
+## Invocation
+
+```text
+/nkda-tddsn-autonomous <subsystem-scope>
+```
+
+## Required Behavior
+
+Execute the autonomous six-phase pipeline for the named subsystem:
+1. Assessment
+2. Target suite design
+3. Architecture refresh
+4. Rebuild planning
+5. Test + minimal code implementation
+6. Verification review
+
+## Required Outputs
+
+Produce these artifacts under `.output/nkda-tddsn/<subsystem>/`:
+- `01-assessment.md`
+- `02-target-test-suite.md`
+- `03-architecture-update.md`
+- `04-rebuild-plan.md`
+- `05-implementation-summary.md`
+- `06-verification.md`
+
+Any missing artifact is a fail condition.

--- a/.agents/skills/source-command-speckit-agent-context-update/SKILL.md
+++ b/.agents/skills/source-command-speckit-agent-context-update/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: "source-command-speckit-agent-context-update"
+description: "Refresh the managed Spec Kit section in the coding agent context file"
+---
+
+# source-command-speckit-agent-context-update
+
+Use this skill when the user asks to run the migrated source command `speckit.agent-context.update`.
+
+## Command Template
+
+<!-- Extension: agent-context -->
+<!-- Config: .specify/extensions/agent-context/ -->
+# Update Coding Agent Context
+
+Refresh the managed Spec Kit section inside the active coding agent's context/instruction file (e.g. `AGENTS.md`, `.github/copilot-instructions.md`, `AGENTS.md`).
+
+## Behavior
+
+The script reads the agent-context extension config at
+`.specify/extensions/agent-context/agent-context-config.yml` to discover:
+
+- `context_file` — the path of the coding agent context file to manage.
+- `context_markers.start` / `.end` — the delimiters surrounding the managed section. Defaults to `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` when the field is missing.
+
+It then creates, replaces, or appends the managed block so that the section points at the most recent plan path when one can be discovered (`specs/<feature>/plan.md`).
+
+If `context_file` is empty or the file cannot be located, the command reports nothing to do and exits successfully.
+
+## Execution
+
+- **Bash**: `.specify/extensions/agent-context/scripts/bash/update-agent-context.sh [plan_path]`
+- **PowerShell**: `.specify/extensions/agent-context/scripts/powershell/update-agent-context.ps1 [plan_path]`
+
+When `plan_path` is omitted, the script auto-detects the most recently modified `specs/*/plan.md`.

--- a/.agents/skills/source-command-speckit-git-commit/SKILL.md
+++ b/.agents/skills/source-command-speckit-git-commit/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: "source-command-speckit-git-commit"
+description: "Auto-commit changes after a Spec Kit command completes"
+---
+
+# source-command-speckit-git-commit
+
+Use this skill when the user asks to run the migrated source command `speckit.git.commit`.
+
+## Command Template
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Auto-Commit Changes
+
+Automatically stage and commit all changes after a Spec Kit command completes.
+
+## Behavior
+
+This command is invoked as a hook after (or before) core commands. It:
+
+1. Determines the event name from the hook context (e.g., if invoked as an `after_specify` hook, the event is `after_specify`; if `before_plan`, the event is `before_plan`)
+2. Checks `.specify/extensions/git/git-config.yml` for the `auto_commit` section
+3. Looks up the specific event key to see if auto-commit is enabled
+4. Falls back to `auto_commit.default` if no event-specific key exists
+5. Uses the per-command `message` if configured, otherwise a default message
+6. If enabled and there are uncommitted changes, runs `git add .` + `git commit`
+
+## Execution
+
+Determine the event name from the hook that triggered this command, then run the script:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/auto-commit.sh <event_name>`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/auto-commit.ps1 <event_name>`
+
+Replace `<event_name>` with the actual hook event (e.g., `after_specify`, `before_plan`, `after_implement`).
+
+## Configuration
+
+In `.specify/extensions/git/git-config.yml`:
+
+```yaml
+auto_commit:
+  default: false          # Global toggle — set true to enable for all commands
+  after_specify:
+    enabled: true          # Override per-command
+    message: "[Spec Kit] Add specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+```
+
+## Graceful Degradation
+
+- If Git is not available or the current directory is not a repository: skips with a warning
+- If no config file exists: skips (disabled by default)
+- If no changes to commit: skips with a message

--- a/.agents/skills/source-command-speckit-git-initialize/SKILL.md
+++ b/.agents/skills/source-command-speckit-git-initialize/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: "source-command-speckit-git-initialize"
+description: "Initialize a Git repository with an initial commit"
+---
+
+# source-command-speckit-git-initialize
+
+Use this skill when the user asks to run the migrated source command `speckit.git.initialize`.
+
+## Command Template
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Initialize Git Repository
+
+Initialize a Git repository in the current project directory if one does not already exist.
+
+## Execution
+
+Run the appropriate script from the project root:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/initialize-repo.sh`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/initialize-repo.ps1`
+
+If the extension scripts are not found, fall back to:
+- **Bash**: `git init && git add . && git commit -m "Initial commit from Specify template"`
+- **PowerShell**: `git init; git add .; git commit -m "Initial commit from Specify template"`
+
+The script handles all checks internally:
+- Skips if Git is not available
+- Skips if already inside a Git repository
+- Runs `git init`, `git add .`, and `git commit` with an initial commit message
+
+## Customization
+
+Replace the script to add project-specific Git initialization steps:
+- Custom `.gitignore` templates
+- Default branch naming (`git config init.defaultBranch`)
+- Git LFS setup
+- Git hooks installation
+- Commit signing configuration
+- Git Flow initialization
+
+## Output
+
+On success:
+- `✓ Git repository initialized`
+
+## Graceful Degradation
+
+If Git is not installed:
+- Warn the user
+- Skip repository initialization
+- The project continues to function without Git (specs can still be created under `specs/`)
+
+If Git is installed but `git init`, `git add .`, or `git commit` fails:
+- Surface the error to the user
+- Stop this command rather than continuing with a partially initialized repository

--- a/.agents/skills/source-command-speckit-git-remote/SKILL.md
+++ b/.agents/skills/source-command-speckit-git-remote/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: "source-command-speckit-git-remote"
+description: "Detect Git remote URL for GitHub integration"
+---
+
+# source-command-speckit-git-remote
+
+Use this skill when the user asks to run the migrated source command `speckit.git.remote`.
+
+## Command Template
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Detect Git Remote URL
+
+Detect the Git remote URL for integration with GitHub services (e.g., issue creation).
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and return empty:
+  ```
+  [specify] Warning: Git repository not detected; cannot determine remote URL
+  ```
+
+## Execution
+
+Run the following command to get the remote URL:
+
+```bash
+git config --get remote.origin.url
+```
+
+## Output
+
+Parse the remote URL and determine:
+
+1. **Repository owner**: Extract from the URL (e.g., `github` from `https://github.com/github/spec-kit.git`)
+2. **Repository name**: Extract from the URL (e.g., `spec-kit` from `https://github.com/github/spec-kit.git`)
+3. **Is GitHub**: Whether the remote points to a GitHub repository
+
+Supported URL formats:
+- HTTPS: `https://github.com/<owner>/<repo>.git`
+- SSH: `git@github.com:<owner>/<repo>.git`
+
+> [!CAUTION]
+> ONLY report a GitHub repository if the remote URL actually points to github.com.
+> Do NOT assume the remote is GitHub if the URL format doesn't match.
+
+## Graceful Degradation
+
+If Git is not installed, the directory is not a Git repository, or no remote is configured:
+- Return an empty result
+- Do NOT error — other workflows should continue without Git remote information

--- a/.agents/skills/source-command-speckit-git-validate/SKILL.md
+++ b/.agents/skills/source-command-speckit-git-validate/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: "source-command-speckit-git-validate"
+description: "Validate current branch follows feature branch naming conventions"
+---
+
+# source-command-speckit-git-validate
+
+Use this skill when the user asks to run the migrated source command `speckit.git.validate`.
+
+## Command Template
+
+<!-- Extension: git -->
+<!-- Config: .specify/extensions/git/ -->
+# Validate Feature Branch
+
+Validate that the current Git branch follows the expected feature branch naming conventions.
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and skip validation:
+  ```
+  [specify] Warning: Git repository not detected; skipped branch validation
+  ```
+
+## Validation Rules
+
+Get the current branch name:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+The branch name must match one of these patterns:
+
+1. **Sequential**: `^[0-9]{3,}-` (e.g., `001-feature-name`, `042-fix-bug`, `1000-big-feature`)
+2. **Timestamp**: `^[0-9]{8}-[0-9]{6}-` (e.g., `20260319-143022-feature-name`)
+
+## Execution
+
+If on a feature branch (matches either pattern):
+- Output: `✓ On feature branch: <branch-name>`
+- Check if the corresponding spec directory exists under `specs/`:
+  - For sequential branches, look for `specs/<prefix>-*` where prefix matches the numeric portion
+  - For timestamp branches, look for `specs/<prefix>-*` where prefix matches the `YYYYMMDD-HHMMSS` portion
+- If spec directory exists: `✓ Spec directory found: <path>`
+- If spec directory missing: `⚠ No spec directory found for prefix <prefix>`
+
+If NOT on a feature branch:
+- Output: `✗ Not on a feature branch. Current branch: <branch-name>`
+- Output: `Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name`
+
+## Graceful Degradation
+
+If Git is not installed or the directory is not a Git repository:
+- Check the `SPECIFY_FEATURE` environment variable as a fallback
+- If set, validate that value against the naming patterns
+- If not set, skip validation with a warning

--- a/.agents/skills/source-command-strict-implement/SKILL.md
+++ b/.agents/skills/source-command-strict-implement/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: "source-command-strict-implement"
+description: "Fail-closed implementation orchestration that blocks shortcuts, stubs, and partial states without editing Speckit core."
+---
+
+# source-command-strict-implement
+
+Use this skill when the user asks to run the migrated source command `strict-implement`.
+
+## Command Template
+
+# Strict Implement (Fail-Closed Wrapper)
+
+Use this command instead of `/speckit.implement` for delivery work in this repository.
+
+It is a repository-local orchestration wrapper and is intentionally strict:
+- no silent hook bypass,
+- no checklist bypass,
+- no requirement-to-task coverage gaps,
+- no missing mandatory orchestrator artifacts.
+
+## Mandatory Sequence
+
+1. Run repository orchestrator preflight (hard fail on any issue):
+   ```powershell
+   pwsh ./scripts/guardrails/validate-orchestrator.ps1
+   ```
+
+2. Resolve the active feature context:
+   ```powershell
+   .specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks
+   ```
+   Use `FEATURE_DIR` from the script output.
+
+3. Enforce checklist completeness (hard fail on any incomplete checklist item):
+   ```powershell
+   pwsh ./scripts/guardrails/enforce-checklists.ps1 -FeatureDir "<FEATURE_DIR>"
+   ```
+
+4. Enforce requirements-to-tasks mapping (hard fail on any unmapped requirement ID):
+   ```powershell
+   pwsh ./scripts/guardrails/enforce-task-coverage.ps1 -FeatureDir "<FEATURE_DIR>"
+   ```
+
+5. Run mandatory pre-implementation architecture/task gates:
+   ```text
+   /nkda-core-tasks-architecture-compliance
+   /speckit.superb.review
+   /speckit.superb.tdd
+   ```
+
+6. Execute implementation:
+   ```text
+   /speckit.implement
+   ```
+
+7. Run mandatory post-implementation gates:
+   ```text
+   /nkda-core-implementation-architecture-compliance
+   /nkda-core-definition-of-done
+   /speckit.superb.verify
+   ```
+
+## Fail-Closed Rules
+
+- Any preflight parser failure is blocking.
+- Any missing mandatory hook command/skill artifact is blocking.
+- Any incomplete checklist is blocking.
+- Any requirement coverage gap is blocking.
+- Any non-pass verdict from mandatory gates is blocking.
+
+Do not downgrade this command to advisory behavior.

--- a/src/DevOpsMigrationPlatform.Abstractions.Agent/Discovery/InventoryProgressEvent.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions.Agent/Discovery/InventoryProgressEvent.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Naked Agility Limited
 
 using System;
+using System.Collections.Generic;
 
 namespace DevOpsMigrationPlatform.Abstractions.Agent.Discovery;
 
@@ -27,4 +28,6 @@ public sealed class InventoryProgressEvent
     /// <summary>Non-null on error events.</summary>
     public string? Error { get; set; }
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+    /// <summary>Work item count by System.AreaPath. Populated on the final (IsComplete) event only.</summary>
+    public Dictionary<string, int>? AreaPathCounts { get; set; }
 }

--- a/src/DevOpsMigrationPlatform.Abstractions.Agent/Discovery/ProjectDiscoverySummary.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions.Agent/Discovery/ProjectDiscoverySummary.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Naked Agility Limited
 
 using System;
+using System.Collections.Generic;
 
 namespace DevOpsMigrationPlatform.Abstractions.Agent.Discovery;
 
@@ -29,4 +30,10 @@ public class ProjectDiscoverySummary
     public string? Error { get; set; }
 
     public DateTime LastUpdatedUtc { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Work item count keyed by System.AreaPath. Populated on the final event only.
+    /// Empty when the discovery path does not support field-level area path collection.
+    /// </summary>
+    public Dictionary<string, int> AreaPathCounts { get; } = new(StringComparer.OrdinalIgnoreCase);
 }

--- a/src/DevOpsMigrationPlatform.Abstractions/ControlPlaneApi/InventoryReport.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions/ControlPlaneApi/InventoryReport.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace DevOpsMigrationPlatform.Abstractions.ControlPlaneApi;
 
@@ -57,4 +58,6 @@ public sealed record ProjectInventory
     public int Teams { get; init; }
     public bool IsComplete { get; init; }
     public string? Error { get; init; }
+    /// <summary>Work item count by System.AreaPath. Null when not collected.</summary>
+    public IReadOnlyDictionary<string, int>? AreaPathCounts { get; init; }
 }

--- a/src/DevOpsMigrationPlatform.Infrastructure.Agent/Discovery/InventoryOrchestrator.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure.Agent/Discovery/InventoryOrchestrator.cs
@@ -42,6 +42,9 @@ internal sealed class InventoryOrchestrator : IInventoryOrchestrator
     private static PackageIndexContext OrgCsvIndexFor(string orgSlug)
         => new("inventory.csv", Organisation: orgSlug);
 
+    private static PackageIndexContext OrgAreaPathCsvIndexFor(string orgSlug)
+        => new("inventory-areapath.csv", Organisation: orgSlug);
+
     // Aggregate index (all orgs combined).
     private static PackageIndexContext RootCsvIndex => new("inventory.csv");
 
@@ -106,6 +109,9 @@ internal sealed class InventoryOrchestrator : IInventoryOrchestrator
 
         var csvBuilder = new StringBuilder();
         csvBuilder.AppendLine("Url,ProjectName,WorkItemsCount,RevisionsCount,ReposCount,IsComplete,Error");
+
+        var areaPathCsvBuilder = new StringBuilder();
+        areaPathCsvBuilder.AppendLine("Url,ProjectName,AreaPath,WorkItemsCount");
 
         var orgProjectData = new Dictionary<string, List<(string Project, long WorkItems, long Revisions, int Repos, bool IsComplete, string? Error)>>(StringComparer.OrdinalIgnoreCase);
 
@@ -216,6 +222,7 @@ internal sealed class InventoryOrchestrator : IInventoryOrchestrator
                 if (DateTime.UtcNow - lastCheckpoint >= checkpointInterval)
                 {
                     await WriteInventoryCsvAsync(package, csvOutputContext, csvBuilder.ToString(), ct).ConfigureAwait(false);
+                    await WriteInventoryCsvAsync(package, OrgAreaPathCsvIndexFor(orgSlug), areaPathCsvBuilder.ToString(), ct).ConfigureAwait(false);
                     await WriteInventoryJsonAsync(package, orgSlug, orgProjectData, ct).ConfigureAwait(false);
                     lastCheckpoint = DateTime.UtcNow;
                     _logger.LogDebug("Inventory mid-project flush at checkpoint interval.");
@@ -256,6 +263,12 @@ internal sealed class InventoryOrchestrator : IInventoryOrchestrator
             csvBuilder.AppendLine(
                 $"{EscapeCsv(evt.Url)},{EscapeCsv(evt.ProjectName)},{evt.WorkItemsCount},{evt.RevisionsCount},{evt.ReposCount},{evt.IsComplete},{EscapeCsv(evt.Error ?? "")}");
 
+            if (evt.AreaPathCounts is { Count: > 0 })
+            {
+                foreach (var kvp in evt.AreaPathCounts)
+                    areaPathCsvBuilder.AppendLine($"{EscapeCsv(evt.Url)},{EscapeCsv(evt.ProjectName)},{EscapeCsv(kvp.Key)},{kvp.Value}");
+            }
+
             if (!orgProjectData.TryGetValue(evt.Url, out var orgList))
             {
                 orgList = new List<(string, long, long, int, bool, string?)>();
@@ -273,6 +286,7 @@ internal sealed class InventoryOrchestrator : IInventoryOrchestrator
                 repos: evt.ReposCount,
                 isComplete: evt.Error is null,
                 error: evt.Error,
+                areaPaths: evt.AreaPathCounts,
                 ct: ct).ConfigureAwait(false);
 
             projectSw.Stop();
@@ -322,6 +336,7 @@ internal sealed class InventoryOrchestrator : IInventoryOrchestrator
 
             // Flush CSV and JSON after every completed project.
             await WriteInventoryCsvAsync(package, csvOutputContext, csvBuilder.ToString(), ct).ConfigureAwait(false);
+            await WriteInventoryCsvAsync(package, OrgAreaPathCsvIndexFor(orgSlug), areaPathCsvBuilder.ToString(), ct).ConfigureAwait(false);
             await WriteInventoryJsonAsync(package, orgSlug, orgProjectData, ct).ConfigureAwait(false);
             lastCompletedProjectKey = projectKey;
             lastCompletedProjectUrl = evt.Url;
@@ -369,6 +384,7 @@ internal sealed class InventoryOrchestrator : IInventoryOrchestrator
 
         // Final write — per-org CSV/JSON and rolling aggregate.
         await WriteInventoryCsvAsync(package, csvOutputContext, csvBuilder.ToString(), ct).ConfigureAwait(false);
+        await WriteInventoryCsvAsync(package, OrgAreaPathCsvIndexFor(orgSlug), areaPathCsvBuilder.ToString(), ct).ConfigureAwait(false);
         await WriteInventoryJsonAsync(package, orgSlug, orgProjectData, ct).ConfigureAwait(false);
         await MergeAndWriteAggregateAsync(package, orgProjectData, ct).ConfigureAwait(false);
 

--- a/src/DevOpsMigrationPlatform.Infrastructure.Agent/Discovery/InventoryService.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure.Agent/Discovery/InventoryService.cs
@@ -97,7 +97,8 @@ public sealed class InventoryService : IInventoryService
                             RevisionsCount = summary.RevisionsCount,
                             IsComplete = true,
                             Error = summary.Error,
-                            Timestamp = summary.LastUpdatedUtc
+                            Timestamp = summary.LastUpdatedUtc,
+                            AreaPathCounts = summary.AreaPathCounts.Count > 0 ? summary.AreaPathCounts : null
                         };
                     }
                 }
@@ -178,7 +179,8 @@ public sealed class InventoryService : IInventoryService
                         RevisionsCount = summary.RevisionsCount,
                         IsComplete = true,
                         Error = summary.Error,
-                        Timestamp = summary.LastUpdatedUtc
+                        Timestamp = summary.LastUpdatedUtc,
+                        AreaPathCounts = summary.AreaPathCounts.Count > 0 ? summary.AreaPathCounts : null
                     };
                 }
             }

--- a/src/DevOpsMigrationPlatform.Infrastructure.Agent/Discovery/ProjectInventoryFile.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure.Agent/Discovery/ProjectInventoryFile.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Naked Agility Limited
 
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,6 +28,8 @@ internal sealed record ProjectInventoryData
     public int Teams { get; init; }
     public bool IsComplete { get; init; }
     public string? Error { get; init; }
+    /// <summary>Work item count by System.AreaPath. Null when not collected.</summary>
+    public Dictionary<string, int>? AreaPathCounts { get; init; }
 }
 
 /// <summary>
@@ -59,9 +62,12 @@ internal static class ProjectInventoryFile
         int? teams = null,
         bool? isComplete = null,
         string? error = null,
+        Dictionary<string, int>? areaPaths = null,
         CancellationToken ct = default)
     {
         var existing = await ReadAsync(package, orgSlug, projectName, ct).ConfigureAwait(false);
+
+        var mergedAreaPaths = areaPaths ?? existing.AreaPathCounts;
 
         var updated = existing with
         {
@@ -76,6 +82,7 @@ internal static class ProjectInventoryFile
             Teams = teams ?? existing.Teams,
             IsComplete = isComplete ?? existing.IsComplete,
             Error = error ?? existing.Error,
+            AreaPathCounts = mergedAreaPaths,
         };
 
         using var stream = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(JsonSerializer.Serialize(updated, s_writeOpts)), writable: false);

--- a/src/DevOpsMigrationPlatform.Infrastructure.AzureDevOps/WorkItems/WorkItemResolution/AzureDevOpsWorkItemDiscoveryService.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure.AzureDevOps/WorkItems/WorkItemResolution/AzureDevOpsWorkItemDiscoveryService.cs
@@ -39,10 +39,11 @@ internal sealed class AzureDevOpsWorkItemDiscoveryService : IWorkItemDiscoverySe
     {
         var summary = new ProjectDiscoverySummary { ProjectName = project };
 
-        // Union caller-supplied fields with System.Rev (always required for revision counting).
+        // Union caller-supplied fields with System.Rev (always required for revision counting)
+        // and System.AreaPath (required for per-area-path work item counts).
         var mergedFields = scope?.Fields is { Count: > 0 }
-            ? new[] { "System.Rev" }.Union(scope.Fields).ToArray()
-            : new[] { "System.Rev" };
+            ? new[] { "System.Rev", "System.AreaPath" }.Union(scope.Fields).ToArray()
+            : new[] { "System.Rev", "System.AreaPath" };
 
         // Thread the caller's progress callback into the fetch scope so per-batch
         // ProgressEvents are fired automatically without a manual counting loop here.
@@ -62,6 +63,8 @@ internal sealed class AzureDevOpsWorkItemDiscoveryService : IWorkItemDiscoverySe
             summary.WorkItemsCount++;
             if (item.Fields.TryGetValue("System.Rev", out var revObj) && revObj is IConvertible c)
                 summary.RevisionsCount += c.ToInt32(null);
+            if (item.Fields.TryGetValue("System.AreaPath", out var areaPathObj) && areaPathObj is string areaPath && !string.IsNullOrEmpty(areaPath))
+                summary.AreaPathCounts[areaPath] = summary.AreaPathCounts.TryGetValue(areaPath, out var n) ? n + 1 : 1;
 
             itemsSinceLastYield++;
             if (itemsSinceLastYield >= ProgressInterval)

--- a/src/DevOpsMigrationPlatform.Infrastructure.TfsObjectModel/WorkItems/WorkItemResolution/TfsObjectModelWorkItemDiscoveryService.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure.TfsObjectModel/WorkItems/WorkItemResolution/TfsObjectModelWorkItemDiscoveryService.cs
@@ -54,6 +54,9 @@ public sealed class TfsObjectModelWorkItemDiscoveryService : IWorkItemDiscoveryS
                 var wi = _workItemStore.GetWorkItem(id);
                 summary.WorkItemsCount++;
                 summary.RevisionsCount += wi.Revisions.Count;
+                var areaPath = wi.AreaPath;
+                if (!string.IsNullOrEmpty(areaPath))
+                    summary.AreaPathCounts[areaPath] = summary.AreaPathCounts.TryGetValue(areaPath, out var n) ? n + 1 : 1;
             }
 
             summary.LastUpdatedUtc = DateTime.UtcNow;

--- a/tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Inventory/InventoryServiceTests.cs
+++ b/tests/DevOpsMigrationPlatform.Infrastructure.Agent.Tests/Inventory/InventoryServiceTests.cs
@@ -584,7 +584,7 @@ public class InventoryServiceTests
     }
 
     [TestMethod]
-    public async Task DiscoverWorkItemsAsync_WithNoScope_UsesOnlySystemRevField()
+    public async Task DiscoverWorkItemsAsync_WithNoScope_UsesSystemRevAndAreaPathFields()
     {
         // Arrange: capture the WorkItemFetchScope passed to FetchAsync
         WorkItemFetchScope? capturedScope = null;
@@ -606,10 +606,10 @@ public class InventoryServiceTests
         // Act: no scope passed
         await foreach (var _ in sut.DiscoverWorkItemsAsync(TestOrgEndpoint, "Proj")) { }
 
-        // Assert: only System.Rev is requested
+        // Assert: System.Rev and System.AreaPath are always requested for revision counting and area path breakdown
         Assert.IsNotNull(capturedScope);
-        Assert.AreEqual(1, capturedScope!.Fields.Count, "Only System.Rev should be requested when no scope is given.");
-        Assert.AreEqual("System.Rev", capturedScope.Fields[0]);
+        CollectionAssert.Contains(capturedScope!.Fields.ToList(), "System.Rev");
+        CollectionAssert.Contains(capturedScope.Fields.ToList(), "System.AreaPath");
     }
 
     // ── Resume: completed project keys are skipped ────────────────────────────


### PR DESCRIPTION
## Summary

- Collects `System.AreaPath` during work item discovery for both the Azure DevOps REST and TFS Object Model paths
- Writes per-area-path work item counts to two new outputs per org:
  - `{orgSlug}/{project}/inventory.json` — `areaPathCounts` map added to the per-project file
  - `{orgSlug}/inventory-areapath.csv` — flat CSV with columns `Url,ProjectName,AreaPath,WorkItemsCount`
- `InventoryProgressEvent`, `ProjectDiscoverySummary`, `ProjectInventoryData`, and `ProjectInventory` all carry the new breakdown; serialisation is automatic via existing JSON/CSV infrastructure

## What changed

| Layer | Change |
|-------|--------|
| `ProjectDiscoverySummary` | Added `Dictionary<string, int> AreaPathCounts` populated per work item |
| `AzureDevOpsWorkItemDiscoveryService` | Requests `System.AreaPath` alongside `System.Rev`; increments count per item |
| `TfsObjectModelWorkItemDiscoveryService` | Reads `wi.AreaPath`; increments count per item |
| `InventoryProgressEvent` | Added `AreaPathCounts?` — set on the final (IsComplete) event only |
| `InventoryService` | Forwards `AreaPathCounts` from final `ProjectDiscoverySummary` onto the final event |
| `ProjectInventoryFile` / `ProjectInventoryData` | Accept and persist `AreaPathCounts` via `MergeAsync` |
| `InventoryReport.ProjectInventory` | `IReadOnlyDictionary<string, int>? AreaPathCounts` added |
| `InventoryOrchestrator` | Writes `inventory-areapath.csv`; passes area paths into `ProjectInventoryFile.MergeAsync`; flushes at the same cadence as the main CSV |

## Test plan

- [x] Updated `DiscoverWorkItemsAsync_WithNoScope_UsesSystemRevAndAreaPathFields` to assert both `System.Rev` and `System.AreaPath` are always requested
- [x] All 1022 tests passing (`dotnet test`)
- [x] Full solution builds with 0 errors

## Reviewer notes

Area path data is only populated for the Azure DevOps REST and TFS Object Model discovery paths. The simulated infrastructure yields an empty map, which is intentional. The aggregate org/root `inventory.json` does not include the per-area-path breakdown (those are summary files); detail lives in the per-project file and the new CSV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added area path tracking to inventory reports, providing a breakdown of work item counts by area path across projects.
  * Added multiple new agent skill definitions for architecture compliance validation, autonomous pipeline execution, and Git operations management.

* **Documentation**
  * Documented new agent skills for source commands and orchestration workflows.

* **Tests**
  * Updated inventory discovery tests to reflect enhanced field collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->