### PR TITLE
fix(inventory): address review feedback on area path counts

### DIFF
--- a/src/DevOpsMigrationPlatform.Abstractions.Agent/Discovery/ProjectDiscoverySummary.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions.Agent/Discovery/ProjectDiscoverySummary.cs
@@ -35,5 +35,5 @@ public class ProjectDiscoverySummary
     /// Work item count keyed by System.AreaPath. Populated on the final event only.
     /// Empty when the discovery path does not support field-level area path collection.
     /// </summary>
-    public Dictionary<string, int> AreaPathCounts { get; } = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, int> AreaPathCounts { get; } = new();
 }

--- a/src/DevOpsMigrationPlatform.Abstractions/ControlPlaneApi/InventoryReport.cs
+++ b/src/DevOpsMigrationPlatform.Abstractions/ControlPlaneApi/InventoryReport.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace DevOpsMigrationPlatform.Abstractions.ControlPlaneApi;
 

--- a/src/DevOpsMigrationPlatform.Infrastructure.Agent/Discovery/InventoryOrchestrator.cs
+++ b/src/DevOpsMigrationPlatform.Infrastructure.Agent/Discovery/InventoryOrchestrator.cs
@@ -154,6 +154,19 @@ internal sealed class InventoryOrchestrator : IInventoryOrchestrator
                     orgProjectData.Values.Sum(l => l.Count));
             }
 
+            // Reload previously-written area-path CSV rows so a resumed run doesn't overwrite them.
+            var existingAreaPathCsv = await ReadInventoryCsvAsync(package, OrgAreaPathCsvIndexFor(orgSlug), ct).ConfigureAwait(false);
+            if (existingAreaPathCsv is not null)
+            {
+                var apLines = existingAreaPathCsv.Split('\n');
+                for (int i = 1; i < apLines.Length; i++) // skip header
+                {
+                    var trimmed = apLines[i].TrimEnd('\r');
+                    if (!string.IsNullOrWhiteSpace(trimmed))
+                        areaPathCsvBuilder.AppendLine(trimmed);
+                }
+            }
+
             sink.Emit(new ProgressEvent
             {
                 Module = moduleName,


### PR DESCRIPTION
## Summary

Follow-up to #123 addressing CodeRabbit and Codex review feedback.

- **Case-sensitive comparer**: `AreaPathCounts` now uses the default case-sensitive comparer — Azure DevOps area paths are case-sensitive and `OrdinalIgnoreCase` would silently merge distinct paths
- **Resume fix**: `inventory-areapath.csv` is now reloaded on resume so previously-collected rows are not overwritten when an interrupted inventory run is retried
- **Unused import**: Removed `using System.Collections.ObjectModel` from `InventoryReport.cs`

Note: the `GetValueOrDefault` nitpick was not applied — the TFS Object Model project targets `net481` where that method is unavailable; `TryGetValue` is kept there.

## Test plan

- [x] All 1022 tests passing (`dotnet test`)
- [x] Full solution builds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)