### PR TITLE
Fix diagnostics path resolution using AppContext.BaseDirectory

### DIFF
--- a/src/DevOpsMigrationPlatform.CLI.Migration/Commands/Agent/AgentStartCommand.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Commands/Agent/AgentStartCommand.cs
@@ -77,7 +77,7 @@ public sealed class AgentStartCommand : AsyncCommand<AgentStartCommand.Settings>
         var diagnosticsPath = Environment.GetEnvironmentVariable("Telemetry__DiagnosticsPath");
         if (string.IsNullOrWhiteSpace(diagnosticsPath))
         {
-            diagnosticsPath = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), ".otel-diagnostics"));
+            diagnosticsPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, ".otel-diagnostics"));
             Environment.SetEnvironmentVariable("Telemetry__DiagnosticsPath", diagnosticsPath);
         }
         psi.Environment["Telemetry__DiagnosticsPath"] = diagnosticsPath;

--- a/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
+++ b/src/DevOpsMigrationPlatform.CLI.Migration/Commands/QueueCommand.cs
@@ -175,13 +175,6 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
             return;
 
         Environment.SetEnvironmentVariable("Telemetry__DetailedDiagnostics", "true");
-
-        var diagnosticsPath = Environment.GetEnvironmentVariable("Telemetry__DiagnosticsPath");
-        if (string.IsNullOrWhiteSpace(diagnosticsPath))
-        {
-            diagnosticsPath = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), ".otel-diagnostics"));
-            Environment.SetEnvironmentVariable("Telemetry__DiagnosticsPath", diagnosticsPath);
-        }
     }
 
     private string? ResolveDiagnosticsPath()
@@ -2007,6 +2000,7 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         TaskCompletionSource<long> bootstrapTrigger,
         CancellationToken ct)
     {
+        string? lastFailureReason = null;
         try
         {
             await foreach (var evt in client.FollowLogsAsync(jobId, ct, null).ConfigureAwait(false))
@@ -2015,6 +2009,10 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
                 if (evt.Module == "Job" && evt.Stage == "Job.Ready")
                     bootstrapTrigger.TrySetResult(evt.EventSequence);
 
+                // Capture the last Job.Failed message so it can be surfaced as the failure reason.
+                if (evt.Stage == "Job.Failed" && !string.IsNullOrWhiteSpace(evt.Message))
+                    lastFailureReason = evt.Message;
+
                 await updates.WriteAsync(new StageAdvanced(evt), ct).ConfigureAwait(false);
             }
 
@@ -2022,7 +2020,7 @@ public sealed class QueueCommand : ControlPlaneCommandBase<QueueCommandSettings>
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("Job failed"))
         {
-            await updates.WriteAsync(new JobTerminated(true, ex.Message), ct).ConfigureAwait(false);
+            await updates.WriteAsync(new JobTerminated(true, lastFailureReason ?? ex.Message), ct).ConfigureAwait(false);
         }
         catch (OperationCanceledException) { }
     }

--- a/src/DevOpsMigrationPlatform.MigrationAgent/JobAgentWorker.cs
+++ b/src/DevOpsMigrationPlatform.MigrationAgent/JobAgentWorker.cs
@@ -118,7 +118,26 @@ public sealed class JobAgentWorker : ModulePipelineWorkerBase
         await InitializeJobPackageAsync(job, ct).ConfigureAwait(false);
 
         // Write config payload from the Job into the package before any config reads.
-        await WriteConfigPayloadAsync(_package, job, ct).ConfigureAwait(false);
+        // An InvalidOperationException here means the source/target identity changed vs the
+        // existing package (resume-source mismatch). Signal the job as failed immediately so
+        // the CLI surfaces the error instead of retrying indefinitely.
+        try
+        {
+            await WriteConfigPayloadAsync(_package, job, ct).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "Cannot process job {JobId}: {Message}", job.JobId, ex.Message);
+            ProgressSink.Emit(new ProgressEvent
+            {
+                Module = "Job",
+                Stage = "Job.Failed",
+                Message = ex.Message,
+                Timestamp = DateTimeOffset.UtcNow
+            });
+            await SignalTerminalAsync(controlPlane, leaseId, "fail", ct).ConfigureAwait(false);
+            return;
+        }
 
         // Load migration-config.json so singleton services (ActiveJobSourceEndpointInfo,
         // IOptions<T> bound from PackageConfig, etc.) resolve per-job values.

--- a/src/DevOpsMigrationPlatform.ServiceDefaults/Diagnostics/FileDiagnosticsExtensions.cs
+++ b/src/DevOpsMigrationPlatform.ServiceDefaults/Diagnostics/FileDiagnosticsExtensions.cs
@@ -90,7 +90,7 @@ public static class FileDiagnosticsExtensions
     {
         var path = configuration["Telemetry:DiagnosticsPath"];
         if (string.IsNullOrWhiteSpace(path))
-            return null;
+            path = Path.Combine(AppContext.BaseDirectory, ".otel-diagnostics");
 
         path = Environment.ExpandEnvironmentVariables(path);
         var basePath = Path.IsPathRooted(path) ? path : Path.GetFullPath(path);


### PR DESCRIPTION
This pull request focuses on improving diagnostics handling and error reporting in the migration platform CLI and agent. The changes ensure more consistent diagnostics path resolution, enhance error propagation for job failures, and improve logging for configuration mismatches.

**Diagnostics Path Handling:**
* Changed the default diagnostics path resolution from using `Directory.GetCurrentDirectory()` to `AppContext.BaseDirectory` in both the CLI and service defaults, ensuring the diagnostics directory is consistently placed relative to the application's base directory. [[1]](diffhunk://#diff-d8f0a9ff5f6aedb3a92ac881e66dbf17ae047a94d30d4ce01b68339077b701b7L80-R80) [[2]](diffhunk://#diff-b7e03fe5716453bee1b01ddabfe57c17a5f745b54bb454ced90e785a8d9c708cL93-R93)
* Removed redundant diagnostics path setup in `QueueCommand.cs` since this logic is now handled elsewhere, reducing duplication.

**Error Reporting and Propagation:**
* In the agent worker, added logic to immediately fail and log an error if a configuration payload write fails due to an identity mismatch, emitting a `Job.Failed` event so the CLI can surface the error instead of retrying indefinitely.
* In the CLI's job progress following logic, now captures and surfaces the last failure reason from a `Job.Failed` event, providing clearer feedback on job failure causes. [[1]](diffhunk://#diff-03d9a8be2ad2a37da3074c48ce74b9deb4c70da92676f6093383b03fee5f9d41R2003) [[2]](diffhunk://#diff-03d9a8be2ad2a37da3074c48ce74b9deb4c70da92676f6093383b03fee5f9d41R2012-R2023)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostics now use a stable default location when no path is configured, reducing dependence on the current working directory.
  * Job failures during config writing are now handled more gracefully, with clearer failure reporting and earlier exit.
  * Progress updates now surface the most relevant failure message from the live stream when a job stops unexpectedly.

* **Improvements**
  * Diagnostics settings are simplified, with clearer handling of detailed diagnostics and output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->